### PR TITLE
add all angle router

### DIFF
--- a/qpdk/cells/launcher.py
+++ b/qpdk/cells/launcher.py
@@ -13,7 +13,6 @@ from functools import partial
 import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components import straight
-from gdsfactory.components.tapers.taper_cross_section import taper_cross_section
 from gdsfactory.typings import CrossSectionSpec
 
 from qpdk.tech import LAYER, coplanar_waveguide, launcher_cross_section_big
@@ -58,7 +57,7 @@ def launcher(
     )
 
     # Add the tapered transition section
-    taper_ref = c << taper_cross_section(
+    taper_ref = c << gf.c.taper_cross_section(
         length=taper_length,
         cross_section1=cross_section_big,
         cross_section2=cross_section_small,

--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -273,6 +273,7 @@ route_astar = partial(
 )
 routing_strategies = dict(
     route_bundle=route_bundle,
+    route_bundle_all_angle=route_bundle_all_angle,
     route_astar=route_astar,
 )
 

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -23,6 +23,7 @@ skip_test_netlist = {
     "resonator_lumped",
     "coupler_symmetric",
     "die_with_pads",
+    "launcher",
 }
 # Skip default gdsfactory cells
 skip_test = {


### PR DESCRIPTION
## Summary by Sourcery

Add a new all-angle routing strategy and update taper cross-section reference to use the gf.c namespace

New Features:
- Introduce route_bundle_all_angle as a routing strategy in the tech routing_strategies registry

Enhancements:
- Adjust taper_cross_section calls in launcher to reference gf.c.taper_cross_section