### PR TITLE
Add Binder support with Dockerfile for interactive notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,7 @@ repos:
     hooks:
       - id: bibtex-tidy
         args: ['--align=1', '--curly', '--months', '--sort', '--duplicates', '--strip-enclosing-braces']
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.13.1
+    hooks:
+      - id: hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,43 @@
+# Note, to download from ghcr.io you may need to authenticate with docker login, e.g.
+#     echo $(gh auth token) | docker login ghcr.io -u "$(gh api user | jq -r .login)" --password-stdin
 FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 
 # Create user for binder
 ARG NB_USER=notebook-user
-ARG NB_UID=1000
-ENV USER=${NB_USER}
-ENV HOME=/home/${NB_USER}
+ARG NB_UID=1001
+ENV USER=${NB_USER} \
+    HOME=/home/${NB_USER} \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_TOOL_BIN_DIR=/usr/local/bin
+ENV UV_CACHE_DIR=${HOME}/.cache/uv
 
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
-    ${NB_USER}
+    ${NB_USER} && \
+    mkdir -p ${HOME} && \
+    chown -R ${USER}:${USER} ${HOME} && \
+    chown -R ${USER}:${USER} /usr/local/
+
 WORKDIR ${HOME}
 USER ${USER}
 
-# Install deps. with uv
-ENV UV_COMPILE_BYTECODE=1
-ENV UV_LINK_MODE=copy
-ENV UV_TOOL_BIN_DIR=/usr/local/bin
-
-RUN --mount=type=cache,target=/root/.cache/uv \
+# Install dependencies with cache mount
+RUN --mount=type=cache,uid=${NB_UID},gid=${NB_UID},target=${HOME}/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --extra dev --extra docs && \
-    uv pip install jupyterlab
+    uv sync --no-install-project --all-extras && \
+    uv tool install jupyterlab
 
-# Install rest of project separately allowing optimal layer caching
-COPY . ${HOME}
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --extra dev --extra docs && \
-    uv pip install jupyterlab
+# Copy source code and install project
+COPY --chown=${USER}:${USER} . ${HOME}
+RUN --mount=type=cache,uid=${NB_UID},gid=${NB_UID},target=${HOME}/.cache/uv \
+    uv sync --all-extras
 
-ENV PATH="/${HOME}/.venv/bin:$PATH"
+# Set PATH to include virtual environment
+ENV PATH="${HOME}/.venv/bin:$PATH"
 
-# Reset the entrypoint
-ENTRYPOINT []
+# Expose Jupyter Lab port
+EXPOSE 8888
+
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--ServerApp.token=''", "--ServerApp.password=''"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,19 +20,19 @@ RUN adduser --disabled-password \
     chown -R ${USER}:${USER} ${HOME} && \
     chown -R ${USER}:${USER} /usr/local/
 
-# For klayout
+# Apt dependencies for gdsfactory & KLayout
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends libexpat1 libexpat1-dev && \
+    apt-get install -y --no-install-recommends git libexpat1 libexpat1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR ${HOME}
 USER ${USER}
 
-# Install dependencies with cache mount
+# First install only dependencies with cache mount
 RUN --mount=type=cache,uid=${NB_UID},gid=${NB_UID},target=${HOME}/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --no-install-project --all-extras && \
-    uv tool install jupyterlab
+    uv pip install jupyterlab
 
 # Copy source code and install project
 COPY --chown=${USER}:${USER} . ${HOME}
@@ -45,4 +45,5 @@ ENV PATH="${HOME}/.venv/bin:$PATH"
 # Expose Jupyter Lab port
 EXPOSE 8888
 
-CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--ServerApp.token=''", "--ServerApp.password=''"]
+SHELL ["/bin/bash", "-c"]
+CMD ["/usr/local/bin/uv", "run", "--with", "jupyter", "jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--ServerApp.token=''", "--ServerApp.password=''"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,13 @@ USER ${USER}
 RUN --mount=type=cache,uid=${NB_UID},gid=${NB_UID},target=${HOME}/.cache/uv \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --no-install-project --all-extras && \
-    uv pip install jupyterlab
+    uv pip install jupyterlab jupytext
 
-# Copy source code and install project
+# Copy source code, install project and convert jupytext scripts to notebooks
 COPY --chown=${USER}:${USER} . ${HOME}
 RUN --mount=type=cache,uid=${NB_UID},gid=${NB_UID},target=${HOME}/.cache/uv \
-    uv sync --all-extras
+    uv sync --all-extras && \
+    uv run jupytext --to ipynb qpdk/samples/**/*.py
 
 # Set PATH to include virtual environment
 ENV PATH="${HOME}/.venv/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ghcr.io/astral-sh/uv:python3.13-slim
+
+# Create user for binder
+ARG NB_USER=notebook-user
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+WORKDIR ${HOME}
+USER ${USER}
+
+# Install deps. with uv
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_TOOL_BIN_DIR=/usr/local/bin
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --extra dev --extra docs && \
+    uv pip install jupyterlab
+
+# Install rest of project separately allowing optimal layer caching
+COPY . ${HOME}
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked --extra dev --extra docs && \
+    uv pip install jupyterlab
+
+ENV PATH="/${HOME}/.venv/bin:$PATH"
+
+# Reset the entrypoint
+ENTRYPOINT []

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 # Create user for binder
 ARG NB_USER=notebook-user
 ARG NB_UID=1000
-ENV USER ${NB_USER}
-ENV HOME /home/${NB_USER}
+ENV USER=${NB_USER}
+ENV HOME=/home/${NB_USER}
 
 RUN adduser --disabled-password \
     --gecos "Default user" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ ENV UV_LINK_MODE=copy
 ENV UV_TOOL_BIN_DIR=/usr/local/bin
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --locked --no-install-project --extra dev --extra docs && \
     uv pip install jupyterlab

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.13-slim
+FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 
 # Create user for binder
 ARG NB_USER=notebook-user

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 ARG NB_USER=notebook-user
 ARG NB_UID=1001
 ENV USER=${NB_USER} \
-    HOME=/home/${NB_USER} \
-    UV_COMPILE_BYTECODE=1 \
+    HOME=/home/${NB_USER}
+ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
-    UV_TOOL_BIN_DIR=/usr/local/bin
-ENV UV_CACHE_DIR=${HOME}/.cache/uv
+    UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_CACHE_DIR=${HOME}/.cache/uv
 
 RUN adduser --disabled-password \
     --gecos "Default user" \
@@ -19,6 +19,11 @@ RUN adduser --disabled-password \
     mkdir -p ${HOME} && \
     chown -R ${USER}:${USER} ${HOME} && \
     chown -R ${USER}:${USER} /usr/local/
+
+# For klayout
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libexpat1 libexpat1-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR ${HOME}
 USER ${USER}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
-[![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test_code.yml)
+[![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
 [![MIT](https://img.shields.io/github/license/gdsfactory/quantum-rf-pdk)](https://choosealicense.com/licenses/mit/)
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sample Generic Quantum RF PDK 0.0.2
 
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
 [![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test_code.yml)
 [![MIT](https://img.shields.io/github/license/gdsfactory/quantum-rf-pdk)](https://choosealicense.com/licenses/mit/)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Sample Generic Quantum RF PDK 0.0.2
 
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
 [![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
 [![MIT](https://img.shields.io/github/license/gdsfactory/quantum-rf-pdk)](https://choosealicense.com/licenses/mit/)
 
 


### PR DESCRIPTION
## Summary

Adds Binder support to enable interactive Jupyter notebooks in the browser.

## Changes

- **Dockerfile**: New containerized environment for notebooks with Python 3.13
- **README.md**: Added Binder launch badge
- **qpdk/cells/helpers.py**: Enhanced notebook conversion utilities
- **Makefile**: Added Docker build targets
- **.pre-commit-config.yaml**: Added hadolint for Dockerfile linting

## Features

- Interactive notebook environment via Binder
- Automatic conversion of samples to `.ipynb` format
- Optimized Docker image with necessary dependencies