### PR TITLE
Fix resonator sample not importable

### DIFF
--- a/qpdk/samples/__init__.py
+++ b/qpdk/samples/__init__.py
@@ -1,3 +1,0 @@
-"""This folder contains sample components demonstrating how to use the package."""
-
-from qpdk.samples.resonator_test_chip import *


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix resonator sample not importable by deleting the conflicting samples/__init__.py