### PR TITLE
Fix PDF docs badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)
 [![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
 [![HTML Docs](https://img.shields.io/badge/📄_HTML-Docs-blue?style=flat)](https://gdsfactory.github.io/quantum-rf-pdk/)
-[![PDF Docs](https://img.shields.io/badge/📄_PDF-Docs-blue?style=flat&logo=adobeacrobatreader)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk-documentation.pdf)
+[![PDF Docs](https://img.shields.io/badge/📄_PDF-Docs-blue?style=flat&logo=adobeacrobatreader)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
 [![MIT](https://img.shields.io/github/license/gdsfactory/quantum-rf-pdk)](https://choosealicense.com/licenses/mit/)
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Update the PDF Docs badge link in README.md to reference qpdk.pdf instead of qpdk-documentation.pdf