### PR TITLE
Update README with `make help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ cd quantum-rf-pdk
 uv sync --all-extras
 ```
 
+Check out the commands for testing and building documentation with:
+
+```bash
+make help
+```
+
 ## Documentation
 
 - [Quantum RF PDK documentation](https://gdsfactory.github.io/quantum-rf-pdk/)


### PR DESCRIPTION
Mention commands for testing and building documentation.

## Summary by Sourcery

Documentation:
- Add instructions in README to use `make help` to display available test and documentation build commands