### PR TITLE
Resonator simulation example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Pipfile
 
 docs/cells.rst
 docs/samples.rst
+docs/notebooxs/*.py
 
 # C extensions
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,3 +73,13 @@ repos:
     hooks:
       - id: checkmake
         args: ['--config=.github/.checkmake.ini']
+  - repo: https://github.com/LilSpazJoekp/docstrfmt
+    rev: v1.11.1
+    hooks:
+      - id: docstrfmt
+        language_version: python3
+        types: [rst]
+  - repo: https://github.com/sphinx-contrib/sphinx-lint
+    rev: v1.0.0
+    hooks:
+      - id: sphinx-lint

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ write-cells: ##@ Write cell outputs into documentation notebooks (used when buil
 	uv run .github/write_cells.py
 
 copy-sample-notebooks: ##@ Copy all sample scripts to use as notebooks docs
-	mkdir -p docs/notebooks
-	cp qpdk/samples/resonator_frequency_model.py docs/notebooks/resonator_frequency_model.py
+	mkdir -p docs/_build/notebooks
+	cp qpdk/samples/resonator_frequency_model.py docs/_build/notebooks/resonator_frequency_model.py
 
 docs: write-cells copy-sample-notebooks ##@ Build the HTML documentation
 	uv run jb build docs

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help: ##@ (Default) Print listing of key targets with their descriptions
 
 
 install: ##@ Install the package and all development dependencies
-	uv sync --extra docs --extra dev
+	uv sync --all-extras
 
 CLEAN_DIRS := dist build *.egg-info docs/_build
 clean: ##@ Clean up all build, test, coverage and Python artifacts

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,14 @@ build: ##@ Build the Python package (install build tool and create dist)
 write-cells: ##@ Write cell outputs into documentation notebooks (used when building docs)
 	uv run .github/write_cells.py
 
-docs: write-cells ##@ Build the HTML documentation
+copy-sample-notebooks: ##@ Copy all sample scripts to use as notebooks docs
+	mkdir -p docs/_build/notebooks
+	cp qpdk/samples/resonator_frequency_model.py docs/_build/notebooks/resonator_frequency_model.py
+
+docs: write-cells copy-sample-notebooks ##@ Build the HTML documentation
 	uv run jb build docs
 
-docs-latex: write-cells ##@ Setup LaTeX for PDF documentation
+docs-latex: write-cells copy-sample-notebooks ##@ Setup LaTeX for PDF documentation
 	uv run jb build docs --builder latex
 
 docs-pdf: docs-latex ##@ Build PDF documentation (requires a TeXLive installation)

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ install: ##@ Install the package and all development dependencies
 CLEAN_DIRS := dist build *.egg-info docs/_build
 clean: ##@ Clean up all build, test, coverage and Python artifacts
 	@# Use rip if available, otherwise fall back to rm -rf
-	@command -v rip >/dev/null 2>&1 && { echo "Using rip to remove artifacts"; rip -f $(CLEAN_DIRS) || true; } || { echo "rip not found, falling back to rm -rf"; rm -rf $(CLEAN_DIRS); }
+	rm -rf $(CLEAN_DIRS)
 
 
 ###########

--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ write-cells: ##@ Write cell outputs into documentation notebooks (used when buil
 	uv run .github/write_cells.py
 
 copy-sample-notebooks: ##@ Copy all sample scripts to use as notebooks docs
-	mkdir -p docs/_build/notebooks
-	cp qpdk/samples/resonator_frequency_model.py docs/_build/notebooks/resonator_frequency_model.py
+	mkdir -p docs/notebooks
+	cp qpdk/samples/resonator_frequency_model.py docs/notebooks/resonator_frequency_model.py
 
 docs: write-cells copy-sample-notebooks ##@ Build the HTML documentation
 	uv run jb build docs

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,6 +35,7 @@ launch_buttons:
   notebook_interface: jupyterlab
   binderhub_url: "https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD"
   colab_url: "https://colab.research.google.com"
+  thebe: true
 sphinx:
   extra_extensions:
     - "sphinx.ext.autodoc"
@@ -56,6 +57,7 @@ sphinx:
       "CrossSection | str | dict[str, Any] | Callable[[...], CrossSection] | SymmetricalCrossSection | DCrossSection": "CrossSectionSpec"
     autodoc_typehints: "description"
     autodoc_typehints_format: "short"
+    html_show_copyright: false
     python_use_unqualified_type_names: True
     nb_execution_show_tb: True
     nb_execution_raise_on_error: true

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -11,4 +11,4 @@ parts:
       - file: changelog
   - caption: Notebooks
     chapters:
-      - file: notebooks/resonator_frequency_model.py
+      - file: _build/notebooks/resonator_frequency_model

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -12,4 +12,5 @@ parts:
     chapters:
       - file: cells
       - file: samples
+      - file: models
       - file: changelog

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -11,4 +11,4 @@ parts:
       - file: changelog
   - caption: Notebooks
     chapters:
-      - file: _build/notebooks/resonator_frequency_model.py
+      - file: notebooks/resonator_frequency_model.py

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -3,14 +3,12 @@
 format: jb-book
 root: index
 parts:
-  # - caption: Tutorial
-  #   chapters:
-  #     - file: tutorial
-  #       sections:
-  #         - file: notebooks/demo
   - caption: Reference
     chapters:
       - file: cells
       - file: samples
       - file: models
       - file: changelog
+  - caption: Notebooks
+    chapters:
+      - file: _build/notebooks/resonator_frequency_model.py

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -123,6 +123,18 @@
   urldate = {2025-09-05},
   langid = {english}
 }
+@book{simonsCoplanarWaveguideCircuits2001,
+  title = {Coplanar Waveguide Circuits, Components, and Systems},
+  author = {Simons, Rainee},
+  year = {2001},
+  series = {Wiley {{Series}} in {{Microwave}} and {{Optical Engineering}}},
+  number = {v. 165},
+  publisher = {Wiley Interscience},
+  address = {New York},
+  doi = {10.1002/0471224758},
+  isbn = {978-0-471-22475-4 978-0-471-46393-1},
+  langid = {english}
+}
 @article{tuokkolaMethodsAchieveNearmillisecond2025,
   title = {Methods to Achieve Near-Millisecond Energy Relaxation and Dephasing Times for a Superconducting Transmon Qubit},
   author = {Tuokkola, Mikko and Sunada, Yoshiki and Kivij{\"a}rvi, Heidi and Albanese, Jonatan and Gr{\"o}nberg, Leif and Kaikkonen, Jukka-Pekka and Vesterinen, Visa and Govenius, Joonas and M{\"o}tt{\"o}nen, Mikko},

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,7 +1,11 @@
 Models
-=============================
+======
 
 .. automodule:: qpdk.models
-   :members:
-   :undoc-members:
-   :show-inheritance:
+    :synopsis: Code for S-parameter and other modelling
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. bibliography::
+    :filter: docname in docnames

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,0 +1,7 @@
+Models
+=============================
+
+.. automodule:: qpdk.models
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
   "hypothesis"
 ]
 docs = ["jupytext", "matplotlib", "jupyter-book==1.0.4"]
+models = ["sax", "scikit-rf"]
 
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem, Commun, Ue"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
 docs = ["jupytext", "matplotlib", "jupyter-book==1.0.4"]
 
 [tool.codespell]
-ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem, Commun"
+ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem, Commun, Ue"
 skip = 'bibliography.bib'
 
 [tool.gdsfactoryplus.drc]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dev = [
   "hypothesis"
 ]
 docs = ["jupytext", "matplotlib", "jupyter-book==1.0.4"]
-models = ["sax", "scikit-rf"]
+models = ["sax", "scikit-rf", "ray[tune]", "optuna"]
 
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, schem, Commun, Ue"

--- a/qpdk/__init__.py
+++ b/qpdk/__init__.py
@@ -16,6 +16,8 @@ from qpdk.config import PATH
 # from qpdk.models import get_models
 from qpdk.tech import LAYER, LAYER_STACK, LAYER_VIEWS, routing_strategies
 
+from .models import models as _models
+
 # _models = get_models()
 _cells = get_cells(cells)
 _cross_sections = get_cross_sections(tech)
@@ -31,7 +33,7 @@ def get_pdk() -> Pdk:
         layers=LAYER,
         layer_stack=LAYER_STACK,
         layer_views=LAYER_VIEWS,
-        # models=_models,
+        models=_models,
         routing_strategies=routing_strategies,
     )
 

--- a/qpdk/cells/launcher.py
+++ b/qpdk/cells/launcher.py
@@ -15,6 +15,7 @@ from gdsfactory.component import Component
 from gdsfactory.components import straight
 from gdsfactory.typings import CrossSectionSpec
 
+from qpdk.cells.waveguides import taper_cross_section
 from qpdk.tech import LAYER, coplanar_waveguide, launcher_cross_section_big
 
 LAUNCHER_CROSS_SECTION_BIG = launcher_cross_section_big
@@ -57,7 +58,7 @@ def launcher(
     )
 
     # Add the tapered transition section
-    taper_ref = c << gf.c.taper_cross_section(
+    taper_ref = c << taper_cross_section(
         length=taper_length,
         cross_section1=cross_section_big,
         cross_section2=cross_section_small,
@@ -69,6 +70,13 @@ def launcher(
 
     # Add output port at the small end for circuit connection
     c.add_port(port=taper_ref.ports["o2"], name="o1", cross_section=cross_section_small)
+
+    # Add a port at the large end for reference and simulation purposes
+    c.add_port(
+        port=straight_ref.ports["o1"],
+        name="waveport",
+        cross_section=cross_section_big,
+    )
 
     return c
 

--- a/qpdk/config.py
+++ b/qpdk/config.py
@@ -13,8 +13,10 @@ repo = module.parent
 class Path:
     module = module
     repo = repo
+    build = repo / "build"
     gds = module / "gds"
     klayout = module / "klayout"
+    simulation = build / "simulation"
 
     lyp = klayout / "tech" / "layers.lyp"
     lyt = klayout / "tech" / "tech.lyt"

--- a/qpdk/models/__init__.py
+++ b/qpdk/models/__init__.py
@@ -1,11 +1,18 @@
-from typing import Any, Callable
+"""Model definitions for qpdk."""
 
 import sax
 
+from .resonator import quarter_wave_resonator_coupled_to_probeline, resonator_frequency
+
 sax.set_port_naming_strategy("optical")
 
-models: dict[str, Callable[..., Any]] = {}
 
-from .resonator import quarter_wave_resonator
+models = {
+    "quarter_wave_resonator": quarter_wave_resonator_coupled_to_probeline,
+}
 
-models["quarter_wave_resonator"] = quarter_wave_resonator
+__all__ = [
+    "models",
+    "resonator_frequency",
+    *models.keys(),
+]

--- a/qpdk/models/__init__.py
+++ b/qpdk/models/__init__.py
@@ -1,0 +1,11 @@
+from typing import Any, Callable
+
+import sax
+
+sax.set_port_naming_strategy("optical")
+
+models: dict[str, Callable[..., Any]] = {}
+
+from .resonator import quarter_wave_resonator
+
+models["quarter_wave_resonator"] = quarter_wave_resonator

--- a/qpdk/models/resonator.py
+++ b/qpdk/models/resonator.py
@@ -1,0 +1,135 @@
+from functools import partial
+from typing import Callable
+
+import jax.numpy as jnp
+import sax
+import skrf
+from matplotlib import pyplot as plt
+from skrf.media import CPW, Media
+from skrf.network import connect
+
+from qpdk import PDK
+from qpdk.tech import material_properties
+
+
+def cpw_media_skrf(width: float, gap: float) -> partial[CPW]:
+    """Create a partial coplanar waveguide (CPW) media object using scikit-rf.
+
+    Args:
+        width: Width of the center conductor in μm.
+        gap: Width of the gap between the center conductor and ground planes in μm.
+
+    Returns:
+        partial[skrf.media.CPW]: A CPW media object with specified dimensions.
+    """
+    # Convert μm to m for skrf
+    return partial(
+        CPW,
+        w=width * 1e-6,
+        s=gap * 1e-6,
+        h=PDK.layer_stack.layers["Substrate"].thickness * 1e-6,
+        t=PDK.layer_stack.layers["M1"].thickness * 1e-6,
+        ep_r=material_properties[PDK.layer_stack.layers["Substrate"].material][
+            "relative_permittivity"
+        ],
+    )
+
+
+def resonator_frequency(
+    length: float, media: Media, is_quarter_wave: bool = True
+) -> float:
+    """Calculate the resonance frequency of a quarter-wave resonator.
+
+    .. math::
+
+        f = \\frac{v_p}{4L}  \\text{ (quarter-wave resonator)}
+        f = \\frac{v_p}{2L}  \\text{ (half-wave resonator)}
+
+    See :cite:`m.pozarMicrowaveEngineering2012` for details.
+
+    Args:
+        length: Length of the resonator in μm.
+        media: skrf media object defining the CPW (or other) properties.
+        is_quarter_wave: If True, calculates for a quarter-wave resonator; if False, for a half-wave resonator.
+            default is True.
+
+    Returns:
+        float: Resonance frequency in Hz.
+    """
+    coefficient = 4 if is_quarter_wave else 2  # Quarter-wave resonator
+    return media.v_p / (coefficient * length * 1e-6)
+
+
+def quarter_wave_resonator(
+    media: Callable[[jnp.ndarray], Media],
+    f: jnp.ndarray = [1e9, 5e9],
+    length: float = 4000,
+) -> sax.SDict:
+    """Model for a quarter-wave coplanar waveguide resonator.
+
+    Args:
+        media: skrf media object defining the CPW (or other) properties.
+        f: Frequency in Hz at which to evaluate the S-parameters.
+        length: Length of the resonator in μm.
+
+    Returns:
+        sax.SDict: S-parameters dictionary
+    """
+    media = media(frequency=skrf.Frequency.from_f(f, unit="Hz"))
+    transmission_line = media.line(d=length * 1e-6, unit="um")
+    quarter_wave_resonator = transmission_line ** media.short()
+    quarter_wave_resonator.name = "quarter_wave_resonator"
+    probeline_in = media.line(d=5000/2, unit="um")
+    probeline_out = media.line(d=5000/2, unit="um")
+    coupling_capacitor = media.capacitor(60e-15, name="C_coupling")
+    all_network = skrf.parallelconnect(
+        [quarter_wave_resonator, coupling_capacitor], [0, 0], name="resonator_coupled"
+    )
+    all_network = skrf.parallelconnect([probeline_in, coupling_capacitor], [0, 0], name="probeline_with_coupled_resonator")
+    all_network = all_network ** probeline_out
+
+    sdict = {
+        ("o1", "o1"): jnp.array(all_network.s[:, 0, 0]),
+        ("o1", "o2"): jnp.array(all_network.s[:, 0, 1]),
+    }
+    return sax.reciprocal(sdict)
+
+
+if __name__ == "__main__":
+    cpw = cpw_media_skrf(width=10, gap=6)()
+    print(cpw.z0)
+    print(cpw.v_p)
+
+    res_freq = resonator_frequency(length=4000, media=cpw, is_quarter_wave=True)
+    print(res_freq)
+
+    circuit, info = sax.circuit(
+        netlist={
+            "instances": {
+                "R1": "quarter_wave_resonator",
+            },
+            "connections": {},
+            "ports": {
+                "in": "R1,o1",
+                "out": "R1,o2",
+            },
+        },
+        models={
+            "quarter_wave_resonator": partial(
+                quarter_wave_resonator,
+                media=cpw_media_skrf(width=10, gap=6),
+                length=4000,
+            )
+        },
+    )
+
+    frequencies = jnp.linspace(1e9, 10e9, 501)
+    S = circuit(f=frequencies)
+    print(S)
+    print(info)
+    plt.plot(frequencies / 1e9, abs(S["in", "out"]) ** 2)
+    # plt.ylim(-0.05, 1.05)
+    plt.xlabel("f [GHz]")
+    plt.ylabel("T")
+    # plt.ylim(-0.05, 1.05)
+    plt.show()

--- a/qpdk/models/resonator.py
+++ b/qpdk/models/resonator.py
@@ -45,11 +45,11 @@ def resonator_frequency(
 
     .. math::
 
-        f = \frac{v_p}{4L}  \text{ (quarter-wave resonator)}
-        f = \frac{v_p}{2L}  \text{ (half-wave resonator)}
+        f &= \frac{v_p}{4L}  \text{ (quarter-wave resonator)} \\
+        f &= \frac{v_p}{2L}  \text{ (half-wave resonator)}
 
     There is some variation according to the frequency range specified for ``media`` due to how
-    :math:`v_p` is calculated in skrf. The phase velocity is given by :math:`v_p = \ii \cdot \omega / \gamma`,
+    :math:`v_p` is calculated in skrf. The phase velocity is given by :math:`v_p = i \cdot \omega / \gamma`,
     where :math:`\gamma` is the complex propagation constant and :math:`\omega` is the angular frequency.
 
     See :cite:`simonsCoplanarWaveguideCircuits2001,m.pozarMicrowaveEngineering2012` for details.

--- a/qpdk/samples/resonator_frequency_model.py
+++ b/qpdk/samples/resonator_frequency_model.py
@@ -98,8 +98,10 @@ if __name__ == "__main__":
 #
 # Find the resonator length that gives a desired resonance frequency using an optimizer.
 
-
-# %%
+# %% [markdown]
+#
+# ```python
+#
 if __name__ == "__main__":
     import ray
     import ray.tune
@@ -137,7 +139,7 @@ if __name__ == "__main__":
         tune_config=ray.tune.TuneConfig(
             metric="mse",
             mode="min",
-            num_samples=50,
+            num_samples=10,
             max_concurrent_trials=math.ceil(os.cpu_count() / 4),
             reuse_actors=True,
             search_alg=ray.tune.search.optuna.OptunaSearch(),
@@ -162,3 +164,4 @@ if __name__ == "__main__":
     _mark_resonance_frequency(TARGET_FREQUENCY, "orange", "Target resonance Frequency")
     plt.legend()
     plt.show()
+# ```

--- a/qpdk/samples/resonator_frequency_model.py
+++ b/qpdk/samples/resonator_frequency_model.py
@@ -27,10 +27,12 @@ from qpdk.models.resonator import (
 )
 
 # %% [markdown]
-# ## Resonator Test Chip Function
+# ## Probelines weakly coupled to $\lambda/4$ resonator
 #
-# Creates a test chip with two probelines and multiple resonators for characterization.
+# Creates a probelines weakly coupled to a quarter-wave resonator.
+# The resonance frequency is first estimated using the `resonator_frequency` function and then compared to the frequency in the coupled case.
 
+# %%
 if __name__ == "__main__":
     import matplotlib.pyplot as plt
 
@@ -82,6 +84,7 @@ if __name__ == "__main__":
 
     _mark_resonance_frequency(res_freq, "red", "Predicted resonance Frequency")
     actual_freq = frequencies[jnp.argmin(abs(S["in", "out"]))]
+    print("Coupled resonance frequency:", actual_freq / 1e9, "GHz")
     _mark_resonance_frequency(actual_freq, "green", "Coupled resonance Frequency")
 
     plt.legend()

--- a/qpdk/samples/resonator_frequency_model.py
+++ b/qpdk/samples/resonator_frequency_model.py
@@ -1,0 +1,88 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.17.3
+# ---
+
+# %% [markdown]
+# # Resonator frequency estimation models
+#
+# This example demonstrates estimating resonance frequencies of superconducting microwave resonators using scikit-rf and Jax.
+
+# %%
+from functools import partial
+
+import jax.numpy as jnp
+import sax
+import skrf
+
+from qpdk.models.resonator import (
+    cpw_media_skrf,
+    quarter_wave_resonator_coupled_to_probeline,
+    resonator_frequency,
+)
+
+# %% [markdown]
+# ## Resonator Test Chip Function
+#
+# Creates a test chip with two probelines and multiple resonators for characterization.
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
+    cpw = cpw_media_skrf(width=10, gap=6)(
+        frequency=skrf.Frequency(2, 9, 101, unit="GHz")
+    )
+    print(f"{cpw=!r}")
+    print(f"{cpw.z0.mean().real=!r}")  # Characteristic impedance
+
+    res_freq = resonator_frequency(length=4000, media=cpw, is_quarter_wave=True)
+    print("Resonance frequency (quarter-wave):", res_freq / 1e9, "GHz")
+
+    circuit, info = sax.circuit(
+        netlist={
+            "instances": {
+                "R1": "quarter_wave_resonator",
+            },
+            "connections": {},
+            "ports": {
+                "in": "R1,o1",
+                "out": "R1,o2",
+            },
+        },
+        models={
+            "quarter_wave_resonator": partial(
+                quarter_wave_resonator_coupled_to_probeline,
+                media=cpw_media_skrf(width=10, gap=6),
+                length=4000,
+                coupling_capacitance=15e-15,
+            )
+        },
+    )
+
+    frequencies = jnp.linspace(1e9, 10e9, 5001)
+    S = circuit(f=frequencies)
+    print(info)
+    plt.plot(frequencies / 1e9, abs(S["in", "out"]) ** 2)
+    plt.xlabel("f [GHz]")
+    plt.ylabel("$S_{21}$")
+
+    def _mark_resonance_frequency(x_value: float, color: str, label: str):
+        """Draws a vertical dashed line on the current matplotlib plot to mark a resonance frequency."""
+        plt.axvline(
+            x_value / 1e9,  # Convert frequency from Hz to GHz for plotting
+            color=color,
+            linestyle="--",
+            label=label,
+        )
+
+    _mark_resonance_frequency(res_freq, "red", "Predicted resonance Frequency")
+    actual_freq = frequencies[jnp.argmin(abs(S["in", "out"]))]
+    _mark_resonance_frequency(actual_freq, "green", "Coupled resonance Frequency")
+
+    plt.legend()
+    plt.show()

--- a/qpdk/samples/resonator_frequency_model.py
+++ b/qpdk/samples/resonator_frequency_model.py
@@ -14,6 +14,8 @@
 # This example demonstrates estimating resonance frequencies of superconducting microwave resonators using scikit-rf and Jax.
 
 # %%
+import math
+import os
 from functools import partial
 
 import jax.numpy as jnp
@@ -87,5 +89,76 @@ if __name__ == "__main__":
     print("Coupled resonance frequency:", actual_freq / 1e9, "GHz")
     _mark_resonance_frequency(actual_freq, "green", "Coupled resonance Frequency")
 
+    plt.legend()
+    # plt.show()
+
+
+# %% [markdown]
+# ## Optimizer for given resonance frequency
+#
+# Find the resonator length that gives a desired resonance frequency using an optimizer.
+
+
+# %%
+if __name__ == "__main__":
+    import ray
+    import ray.tune
+    import ray.tune.search.optuna
+
+    frequencies = jnp.linspace(0.5e9, 10e9, 1001)
+    TARGET_FREQUENCY = 6e9  # Target resonance frequency in Hz
+
+    def loss_fn(config: dict[str, float]) -> float:
+        """Loss function to minimize the difference between the actual and target resonance frequencies.
+
+        Args:
+            config: Dictionary containing the resonator length in micrometers.
+        """
+        length = config["length"]
+        # Setup model
+        S = circuit(f=frequencies, length=length)
+        # Get frequency at minimum S21
+        coupled_freq = frequencies[jnp.argmin(abs(S["in", "out"]))]
+        return {
+            "l1_loss_ghz": abs(float(coupled_freq) - TARGET_FREQUENCY) / 1e9,
+            "mse": (float(coupled_freq) - TARGET_FREQUENCY) ** 2,
+        }
+
+    # Test loss function
+    print(f"{loss_fn(dict(length=4000.0))=}")
+    print(f"{loss_fn(dict(length=5900.0))=}")
+
+    # Optimize length using Ray Tune
+    tuner = ray.tune.Tuner(
+        loss_fn,
+        param_space={
+            "length": ray.tune.uniform(1000.0, 9000.0),
+        },
+        tune_config=ray.tune.TuneConfig(
+            metric="mse",
+            mode="min",
+            num_samples=50,
+            max_concurrent_trials=math.ceil(os.cpu_count() / 4),
+            reuse_actors=True,
+            search_alg=ray.tune.search.optuna.OptunaSearch(),
+        ),
+    )
+    results = tuner.fit()
+    best_trial = results.get_best_result()
+    length = best_trial.config["length"]
+    print(f"Best trial config: {best_trial.config}")
+
+    # Initialize optimizer
+    print(f"Optimized Length: {length:.2f} µm")
+    optimal_S = circuit(f=frequencies, length=length)
+    optimal_freq = frequencies[jnp.argmin(abs(optimal_S["in", "out"]))]
+    print(f"Achieved Resonance Frequency: {optimal_freq / 1e9:.2f} GHz")
+
+    # Plot
+    plt.plot(frequencies / 1e9, abs(optimal_S["in", "out"]) ** 2)
+    plt.xlabel("f [GHz]")
+    plt.ylabel("$S_{21}$")
+    _mark_resonance_frequency(optimal_freq, "blue", "Optimized resonance Frequency")
+    _mark_resonance_frequency(TARGET_FREQUENCY, "orange", "Target resonance Frequency")
     plt.legend()
     plt.show()

--- a/qpdk/samples/simulate_resonator.py
+++ b/qpdk/samples/simulate_resonator.py
@@ -1,0 +1,160 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.17.3
+# ---
+
+# %% [markdown]
+# # Export a resonator for simulation
+#
+
+# %%
+from pathlib import Path
+
+import gdsfactory as gf
+import numpy as np
+from IPython import display
+
+from qpdk.cells.airbridge import cpw_with_airbridges
+from qpdk.cells.launcher import launcher
+from qpdk.cells.resonator import resonator_coupled
+from qpdk.tech import LAYER, route_bundle_sbend_cpw
+
+# %% [markdown]
+# ## System geometry
+
+
+# %%
+@gf.cell
+def resonator_simulations() -> gf.Component:
+    """Creates a simulation layout with a resonator coupled to a probeline."""
+    c = gf.Component()
+
+    res_ref = c << resonator_coupled({"open_start": True}, coupling_straight_length=300)
+    res_ref.movex(-res_ref.size_info.width / 4)
+
+    launcher_left = c << launcher()
+    launcher_right = c << launcher()
+    launcher_right.mirror()
+
+    width_offset = res_ref.size_info.width + 700
+    launcher_left.move((-width_offset, 0))
+    launcher_right.move((width_offset, 0))
+
+    route_bundle_sbend_cpw(
+        c,
+        [launcher_left["o1"], launcher_right["o1"]],
+        [res_ref["coupling_o1"], res_ref["coupling_o2"]],
+        cross_section=cpw_with_airbridges(
+            airbridge_spacing=250.0, airbridge_padding=20.0
+        ),
+    )
+
+    c.kdb_cell.shapes(LAYER.SIM_AREA).insert(c.bbox().enlarged(0, 400))
+
+    c.add_ports(launcher_left.ports, prefix="left_")
+    c.add_ports(launcher_right.ports, prefix="right_")
+
+    return c
+
+
+if __name__ == "__main__":
+    from qpdk import PDK
+
+    PDK.activate()
+
+    # Create and display the filled version
+    c = gf.Component("capacitance")
+    res_ref = c << resonator_simulations()
+    c.add_ports(res_ref.ports)
+    # c.flatten()
+    c.show()
+    # to_stl(
+    #     c,
+    #     "resonator_simulations.stl",
+    #     layer_stack=PDK.layer_stack,
+    #     hull_invalid_polygons=True,
+    # )
+
+    from gplugins.palace import run_scattering_simulation_palace
+
+    material_spec = {
+        "Si": {"relative_permittivity": 11.45},
+        "Nb": {"relative_permittivity": np.inf},
+        "vacuum": {"relative_permittivity": 1},
+    }
+
+    results = run_scattering_simulation_palace(
+        c,
+        layer_stack=PDK.layer_stack,
+        material_spec=material_spec,
+        only_one_port=True,
+        driven_settings={
+            "MinFreq": 0.1,
+            "MaxFreq": 5,
+            "FreqStep": 5,
+        },
+        n_processes=1,
+        simulation_folder=Path().cwd() / "temporary",
+        mesh_parameters=dict(
+            background_tag="vacuum",
+            background_padding=(0,) * 5 + (700,),
+            port_names=[port.name for port in c.ports],
+            default_characteristic_length=200,
+            resolutions={
+                "M1": {
+                    "resolution": 15,
+                },
+                "Silicon": {
+                    "resolution": 40,
+                },
+                "vacuum": {
+                    "resolution": 40,
+                },
+                **{
+                    f"M1__{port}": {  # `__` is used as the layer to port delimiter for Elmer
+                        "resolution": 20,
+                        "DistMax": 30,
+                        "DistMin": 10,
+                        "SizeMax": 14,
+                        "SizeMin": 3,
+                    }
+                    for port in c.ports
+                },
+            },
+        ),
+    )
+    display(results)
+    import skrf
+    df = results.scattering_matrix
+    df.columns = df.columns.str.strip()
+    s_complex = 10 ** df["|S[2][1]| (dB)"].values * np.exp(
+        1j * skrf.degree_2_radian(df["arg(S[2][1]) (deg.)"].values)
+    )
+    ntw = skrf.Network(f=df["f (GHz)"].values, s=s_complex, z0=50)
+    cap = np.imag(ntw.y.flatten()) / (ntw.f * 2 * np.pi)
+    display(cap)
+
+    plt.plot(ntw.f, cap * 1e15)
+    plt.xlabel("Freq (GHz)")
+    plt.ylabel("C (fF)")
+
+    if results.field_file_locations:
+        pv.start_xvfb()
+        pv.set_jupyter_backend("trame")
+        field = pv.read(results.field_file_locations[0])
+        slice = field.slice_orthogonal(z=layer_stack.layers["bw"].zmin * 1e-6)
+
+        p = pv.Plotter()
+        p.add_mesh(slice, scalars="Ue", cmap="turbo")
+        p.show_grid()
+        p.camera_position = "xy"
+        p.enable_parallel_projection()
+        p.show()
+
+    # trimesh_scene = to_3d(c,layer_stack=PDK.layer_stack)
+    # trimesh_scene.export("resonator_simulations.stl")

--- a/qpdk/samples/simulate_resonator.py
+++ b/qpdk/samples/simulate_resonator.py
@@ -39,11 +39,13 @@ from qpdk.tech import LAYER, route_bundle_sbend_cpw
 
 # %%
 @gf.cell
-def resonator_simulations() -> gf.Component:
+def resonator_simulation(coupling_gap: float = 12.0) -> gf.Component:
     """Create a resonator simulation layout with launchers and CPW routes."""
     c = gf.Component()
 
-    res_ref = c << resonator_coupled({"open_start": True}, coupling_straight_length=300)
+    res_ref = c << resonator_coupled(
+        {"open_start": True}, coupling_straight_length=300, coupling_gap=coupling_gap
+    )
     res_ref.movex(-res_ref.size_info.width / 4)
 
     launcher_left = c << launcher()
@@ -78,7 +80,7 @@ if __name__ == "__main__":
 
     # Create and display the filled version
     c = gf.Component("resonator_simulation")
-    res_ref = c << resonator_simulations()
+    res_ref = c << resonator_simulation()
     c.add_ports(res_ref.ports)
     c.plot(
         pixel_buffer_options=dict(width=1300, height=1000, oversampling=2, linewidth=3)

--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -79,6 +79,12 @@ class LayerMapQPDK(LayerMap):
 
 L = LAYER = LayerMapQPDK
 
+material_properties = {
+    "vacuum": {"relative_permittivity": 1},
+    "Nb": {"relative_permittivity": float("inf")},
+    "Si": {"relative_permittivity": 11.45},
+}
+
 
 @cache
 def get_layer_stack() -> LayerStack:


### PR DESCRIPTION
- **Add a resonator simulation example**
- **Add WIP example resonator simulation**
- **Add a `waveport` location to launchers**

## Summary by Sourcery

Provide a resonator simulation example by adding a sample script for generating a coupled resonator layout and STL export, enhance the launcher with a new waveport for simulation, and extend configuration to support simulation output paths.

New Features:
- Add a `simulate_resonator.py` sample that builds a resonator+launcher layout and exports a 3D STL model.
- Add a `waveport` port at the launcher's large end for reference and simulation.

Enhancements:
- Switch launcher taper to use the internal `taper_cross_section`.
- Extend configuration paths to include `build` and `simulation` directories.

Chores:
- Update codespell ignore-words list to include "Ue".