### PR TITLE
Fix notebooks in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help: ##@ (Default) Print listing of key targets with their descriptions
 install: ##@ Install the package and all development dependencies
 	uv sync --all-extras
 
-CLEAN_DIRS := dist build *.egg-info docs/_build
+CLEAN_DIRS := dist build *.egg-info docs/_build docs/notebooks
 clean: ##@ Clean up all build, test, coverage and Python artifacts
 	@# Use rip if available, otherwise fall back to rm -rf
 	rm -rf $(CLEAN_DIRS)
@@ -58,8 +58,8 @@ write-cells: ##@ Write cell outputs into documentation notebooks (used when buil
 	uv run .github/write_cells.py
 
 copy-sample-notebooks: ##@ Copy all sample scripts to use as notebooks docs
-	mkdir -p docs/_build/notebooks
-	cp qpdk/samples/resonator_frequency_model.py docs/_build/notebooks/resonator_frequency_model.py
+	mkdir -p docs/notebooks
+	cp qpdk/samples/resonator_frequency_model.py docs/notebooks/resonator_frequency_model.py
 
 docs: write-cells copy-sample-notebooks ##@ Build the HTML documentation
 	uv run jb build docs

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -11,4 +11,4 @@ parts:
       - file: changelog
   - caption: Notebooks
     chapters:
-      - file: _build/notebooks/resonator_frequency_model
+      - file: notebooks/resonator_frequency_model


### PR DESCRIPTION
Fix notebooks not appearing docs due to using `_build/`

## Summary by Sourcery

Fix documentation build to properly include sample notebooks by copying them to the docs/notebooks directory, updating the TOC, and cleaning up that directory.

Build:
- Include docs/notebooks in CLEAN_DIRS for the clean target
- Update copy-sample-notebooks Makefile target to copy sample scripts into docs/notebooks instead of docs/_build/notebooks

Documentation:
- Update docs/_toc.yml to reference notebooks/resonator_frequency_model instead of the old _build path