### PR TITLE
Fix GitHub note in README

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,5 +96,7 @@ repos:
         args: [--wrap=120]
         additional_dependencies:
           - mdformat-gfm
+          - mdformat-gfm-alerts
+          - mdformat-tables
           - mdformat-frontmatter
           - mdformat-footnote

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Install the package with:
 uv pip install qpdk
 ```
 
-> [!NOTE] After installation, restart KLayout to ensure the new technology appears.
+> [!NOTE]
+> After installation, restart KLayout to ensure the new technology appears.
 
 Optional dependencies for the models and simulation tools can be installed with:
 

--- a/qpdk/notebooks/README.md
+++ b/qpdk/notebooks/README.md
@@ -7,4 +7,5 @@ or converted to Jupyter Notebooks with:
 uvx jupytext --to ipynb <script>.py
 ```
 
-> [!IMPORTANT] Keep the scripts here out of the import scope of the package.
+> [!IMPORTANT]
+> Keep the scripts here out of the import scope of the package.


### PR DESCRIPTION
mdformat did not have `gfm_alerts` enabled and re-formatted the alert to
break

## Summary by Sourcery

Enable support for GFM alerts and tables in mdformat and correct the README note formatting

Enhancements:
- Enable mdformat-gfm-alerts and mdformat-tables plugins in pre-commit config to support GitHub-style admonitions and tables
- Fix the README admonition formatting by splitting the alert marker and content into separate lines