### PR TITLE
add show component helper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
       - id: pyrefly-typecheck-specific-version
         name: Pyrefly
-        pass_filenames: false
+        pass_filenames: true
         additional_dependencies: ["pyrefly==0.33.0"]
         # Pre-commit may not have access to all deps.
         args: ["--ignore", "import-error"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.10"
+    rev: "v0.13.1"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
@@ -47,7 +47,7 @@ repos:
     hooks:
       - id: actionlint
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.8.13
+    rev: 0.8.19
     hooks:
       - id: uv-lock
   - repo: https://github.com/facebook/pyrefly-pre-commit
@@ -56,7 +56,7 @@ repos:
       - id: pyrefly-typecheck-specific-version
         name: Pyrefly
         pass_filenames: false
-        additional_dependencies: ["pyrefly==0.32.0"]
+        additional_dependencies: ["pyrefly==0.33.0"]
         # Pre-commit may not have access to all deps.
         args: ["--ignore", "import-error"]
   - repo: https://github.com/FlamingTempura/bibtex-tidy

--- a/install_tech.py
+++ b/install_tech.py
@@ -1,6 +1,5 @@
 """Symlink tech to klayout."""
 
-import os
 import shutil
 import sys
 from pathlib import Path
@@ -30,7 +29,7 @@ def make_link(src: str | Path, dest: str | Path, overwrite: bool = True) -> None
         print(f"removing {dest} already installed")
         remove_path_or_dir(dest)
     try:
-        os.symlink(src, dest, target_is_directory=True)
+        Path.symlink_to(src, dest, target_is_directory=True)
     except OSError:
         shutil.copytree(src, dest)
     print("link made:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ project-includes = ["**/*.py"]
 bad-argument-type = "ignore"
 # Configure specific error types - start permissive and tighten over time
 missing-argument = "ignore"
+missing-module-attribute = "ignore"
 # Not all gdsfactory overloads are seem to be properly typed
 no-matching-overload = "ignore"
 not-a-type = "warn"

--- a/qpdk/__init__.py
+++ b/qpdk/__init__.py
@@ -10,7 +10,7 @@ from gdsfactory.get_factories import get_cells
 from gdsfactory.pdk import Pdk
 
 import qpdk.samples
-from qpdk import cells, config, tech
+from qpdk import cells, config, helper, tech
 from qpdk.config import PATH
 
 # from qpdk.models import get_models
@@ -59,6 +59,7 @@ __all__ = [
     "PATH",
     "cells",
     "config",
+    "helper",
     "tech",
 ]
 __version__ = "0.0.2"

--- a/qpdk/cells/capacitor.py
+++ b/qpdk/cells/capacitor.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+from functools import partial
 from itertools import chain
 from math import ceil, floor
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
-import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
+import gdsfactory as gf
 from qpdk.cells.waveguides import straight
+from qpdk.helper import show_components
 from qpdk.tech import LAYER
 
 
@@ -465,19 +467,12 @@ def coupler_tunable(
 
 
 if __name__ == "__main__":
-    from qpdk import PDK
 
-    PDK.activate()
-    c = gf.Component()
-    for i, component in enumerate(
-        (
-            plate_capacitor_single(),
-            plate_capacitor(),
-            coupler_tunable(),
-            interdigital_capacitor(),
-            interdigital_capacitor(half=True),
-        )
-    ):
-        (c << component).move((i * 200, 0))
-    c.pprint_ports()
-    c.show()
+
+    show_components(
+        plate_capacitor_single,
+        plate_capacitor,
+        coupler_tunable,
+        interdigital_capacitor,
+        partial(interdigital_capacitor, half=True),
+    )

--- a/qpdk/cells/capacitor.py
+++ b/qpdk/cells/capacitor.py
@@ -8,10 +8,10 @@ from math import ceil, floor
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
+import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
-import gdsfactory as gf
 from qpdk.cells.waveguides import straight
 from qpdk.helper import show_components
 from qpdk.tech import LAYER
@@ -467,8 +467,6 @@ def coupler_tunable(
 
 
 if __name__ == "__main__":
-
-
     show_components(
         plate_capacitor_single,
         plate_capacitor,

--- a/qpdk/cells/junction.py
+++ b/qpdk/cells/junction.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
+import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 from klayout.db import DCplxTrans
 
-import gdsfactory as gf
 from qpdk.cells.waveguides import straight
 from qpdk.helper import show_components
 from qpdk.tech import (

--- a/qpdk/cells/junction.py
+++ b/qpdk/cells/junction.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
-import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, LayerSpec
 from klayout.db import DCplxTrans
 
+import gdsfactory as gf
 from qpdk.cells.waveguides import straight
+from qpdk.helper import show_components
 from qpdk.tech import (
     LAYER,
     josephson_junction_cross_section_narrow,
@@ -260,12 +261,4 @@ def squid_junction(
 
 
 if __name__ == "__main__":
-    from qpdk import PDK
-
-    PDK.activate()
-
-    # c = josephson_junction()
-    c = squid_junction()
-
-    c.pprint_ports()
-    c.show()
+    show_components(josephson_junction, squid_junction)

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from functools import partial
 from typing import TypedDict
 
-import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+import gdsfactory as gf
 from qpdk.cells.waveguides import bend_circular, straight
+from qpdk.helper import show_components
 
 
 class ResonatorParams(TypedDict):
@@ -219,22 +220,12 @@ def resonator_coupled(
 
 
 if __name__ == "__main__":
-    from qpdk import PDK
-
-    PDK.activate()
-    c = gf.Component()
-    for i, component in enumerate(
-        (
-            resonator(),
-            resonator_quarter_wave(),
-            resonator_half_wave(),
-            resonator_coupled(),
-            resonator_coupled(
-                ResonatorParams(
-                    length=2000, meanders=4, open_start=False, open_end=True
-                )
-            ),
+    show_components(
+        resonator,
+        resonator_quarter_wave,
+        resonator_half_wave,
+        resonator_coupled,
+        partial(resonator_coupled,
+            ResonatorParams(length=2000, meanders=4, open_start=False, open_end=True)
         ),
-    ):
-        (c << component).move((i * 700, 0))
-    c.show()
+    )

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from functools import partial
 from typing import TypedDict
 
+import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-import gdsfactory as gf
 from qpdk.cells.waveguides import bend_circular, straight
 from qpdk.helper import show_components
 
@@ -225,7 +225,8 @@ if __name__ == "__main__":
         resonator_quarter_wave,
         resonator_half_wave,
         resonator_coupled,
-        partial(resonator_coupled,
-            ResonatorParams(length=2000, meanders=4, open_start=False, open_end=True)
+        partial(
+            resonator_coupled,
+            ResonatorParams(length=2000, meanders=4, open_start=False, open_end=True),
         ),
     )

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -7,6 +7,7 @@ from functools import partial, reduce
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
+import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components import rectangle
 from gdsfactory.export import to_stl
@@ -14,7 +15,6 @@ from gdsfactory.typings import ComponentSpec, LayerSpec
 from kfactory import kdb
 from klayout.db import DCplxTrans, Region
 
-import gdsfactory as gf
 from qpdk.cells.bump import indium_bump
 from qpdk.cells.helpers import transform_component
 from qpdk.cells.junction import squid_junction
@@ -575,7 +575,7 @@ def xmon_transmon(**kwargs: Unpack[XmonTransmonParams]) -> Component:
 if __name__ == "__main__":
     show_components(
         double_pad_transmon,
-        partial(double_pad_transmon,junction_displacement=DCplxTrans(0, 150)),
+        partial(double_pad_transmon, junction_displacement=DCplxTrans(0, 150)),
         double_pad_transmon_with_bbox,
         flipmon,
         flipmon_with_bbox,

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -7,7 +7,6 @@ from functools import partial, reduce
 from operator import itemgetter
 from typing import TypedDict, Unpack
 
-import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.components import rectangle
 from gdsfactory.export import to_stl
@@ -15,9 +14,11 @@ from gdsfactory.typings import ComponentSpec, LayerSpec
 from kfactory import kdb
 from klayout.db import DCplxTrans, Region
 
+import gdsfactory as gf
 from qpdk.cells.bump import indium_bump
 from qpdk.cells.helpers import transform_component
 from qpdk.cells.junction import squid_junction
+from qpdk.helper import show_components
 from qpdk.tech import LAYER, LAYER_STACK_FLIP_CHIP
 
 
@@ -572,22 +573,14 @@ def xmon_transmon(**kwargs: Unpack[XmonTransmonParams]) -> Component:
 
 
 if __name__ == "__main__":
-    from qpdk import PDK
-
-    PDK.activate()
-    c = gf.Component()
-    for i, component in enumerate(
-        (
-            double_pad_transmon(),
-            double_pad_transmon(junction_displacement=DCplxTrans(0, 150)),
-            double_pad_transmon_with_bbox(),
-            flipmon(),
-            flipmon_with_bbox(),
-            xmon_transmon(),
-        )
-    ):
-        (c << component).move((0, i * 700))
-    c.show()
+    show_components(
+        double_pad_transmon,
+        partial(double_pad_transmon,junction_displacement=DCplxTrans(0, 150)),
+        double_pad_transmon_with_bbox,
+        flipmon,
+        flipmon_with_bbox,
+        xmon_transmon,
+    )
 
     # Visualize flip-chip flipmon
     c = gf.Component()

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -3,11 +3,12 @@
 from functools import partial
 from typing import TypedDict, Unpack
 
-import gdsfactory as gf
 from gdsfactory.typings import CrossSectionSpec, Ints, LayerSpec, Size
 from klayout.db import DCplxTrans
 
+import gdsfactory as gf
 from qpdk import tech
+from qpdk.helper import show_components
 
 _DEFAULT_CROSS_SECTION = tech.cpw
 _DEFAULT_KWARGS = {"cross_section": _DEFAULT_CROSS_SECTION}
@@ -308,20 +309,14 @@ def bend_circular_all_angle(
 
 
 if __name__ == "__main__":
-    from qpdk import PDK
-
-    PDK.activate()
-
-    for c in [
-        taper_cross_section(),
-        # bend_euler(),
-        # bend_circular(),
-        # tee(),
-        # bend_s(),
-        # straight(),
-        # straight_all_angle(),
-        # bend_euler_all_angle(angle=33),
-        # rectangle(),
-    ]:
-        c.pprint_ports()
-        c.show()
+    show_components(
+        taper_cross_section,
+        bend_euler,
+        bend_circular,
+        tee,
+        bend_s,
+        straight,
+        straight_all_angle,
+        partial(bend_euler_all_angle, angle=33),
+        rectangle,
+    )

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -3,10 +3,10 @@
 from functools import partial
 from typing import TypedDict, Unpack
 
+import gdsfactory as gf
 from gdsfactory.typings import CrossSectionSpec, Ints, LayerSpec, Size
 from klayout.db import DCplxTrans
 
-import gdsfactory as gf
 from qpdk import tech
 from qpdk.helper import show_components
 

--- a/qpdk/helper.py
+++ b/qpdk/helper.py
@@ -2,10 +2,9 @@
 
 from collections.abc import Sequence
 
+from gdsfactory import Component, ComponentAllAngle, get_component
 from gdsfactory.technology import LayerViews
 from gdsfactory.typings import ComponentAllAngleSpec, ComponentSpec
-
-from gdsfactory import Component, ComponentAllAngle, get_component
 
 
 def denest_layerviews_to_layer_tuples(

--- a/qpdk/notebooks/resonator_frequency_model.py
+++ b/qpdk/notebooks/resonator_frequency_model.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     frequencies = jnp.linspace(0.5e9, 10e9, 1001)
     TARGET_FREQUENCY = 6e9  # Target resonance frequency in Hz
 
-    def loss_fn(config: dict[str, float]) -> float:
+    def loss_fn(config: dict[str, float]) -> dict[str, float]:
         """Loss function to minimize the difference between the actual and target resonance frequencies.
 
         Args:
@@ -140,7 +140,7 @@ if __name__ == "__main__":
             metric="mse",
             mode="min",
             num_samples=10,
-            max_concurrent_trials=math.ceil(os.cpu_count() / 4),
+            max_concurrent_trials=math.ceil((os.cpu_count() or 1) / 4),
             reuse_actors=True,
             search_alg=ray.tune.search.optuna.OptunaSearch(),
         ),


### PR DESCRIPTION
- **Update astral.sh and meta pre-commits**
- **Add helper for showing a sequence of components**

## Summary by Sourcery

Add a show_components utility for consistently displaying multiple components and update cell example scripts to use it, alongside upgrading pre-commit configurations and adjusting lint settings.

New Features:
- Introduce show_components helper to display a sequence of components in a single layout

Enhancements:
- Refactor example __main__ blocks in waveguides, resonator, transmon, capacitor, and junction modules to use show_components instead of manual loops

Build:
- Bump pre-commit hook versions for ruff, uv-lock, and pyrefly and enable pass_filenames for pyrefly
- Add missing-module-attribute ignore rule in pyproject.toml