### PR TITLE
Use half the available threads for pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
       - id: bibtex-tidy
         args: ['--align=1', '--curly', '--months', '--sort', '--duplicates', '--strip-enclosing-braces']
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.13.1
+    rev: v2.14.0
     hooks:
       - id: hadolint
   - repo: https://github.com/checkmake/checkmake.git

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-gds-fail-fast: ##@ Run GDS regressions tests (tests/test_pdk.py) and stop a
 	uv run pytest -s tests/test_pdk.py -x
 
 update-pre: ##@ Update pre-commit hooks to the latest revisions
-	uvx pre-commit autoupdate
+	uvx pre-commit autoupdate -j $$(expr $$(nproc) / 2 + $$(expr $$(nproc) % 2))
 
 run-pre: ##@ Run all pre-commit hooks on all files
 	uvx pre-commit run --all-files


### PR DESCRIPTION
## Summary by Sourcery

Limit pre-commit autoupdate to use half of the available CPU threads and bump the hadolint-py hook to v2.14.0

Enhancements:
- Change the update-pre Makefile target to run pre-commit autoupdate with half of the system’s cores
- Upgrade hadolint-py hook version from v2.13.1 to v2.14.0