### PR TITLE
Update command to 'make convert-notebooks'

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -19,7 +19,7 @@ uvx jupytext --to ipynb <script>.py
 or all-at once with
 
 ```bash
-convert-notebooks
+make convert-notebooks
 ```
 
 There is also a pre-commit hook checking that the notebooks are in-sync with the source files


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace standalone "convert-notebooks" invocation with "make convert-notebooks" in notebooks/README.md