### PR TITLE
Try fixing PyPi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,9 @@ jobs:
       - uses: actions/download-artifact@v6
         with:
           name: dist
+          path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: ${{ secrets.PYPI_USERNAME }}
           password: ${{ secrets.PYPI_PASSWORD }}
+          packages-dir: dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "qpdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Quantum-RF generic PDK"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
## Summary by Sourcery

Fix PyPI release workflow by directing artifacts to the 'dist' directory and updating the package version for release.

Enhancements:
- Specify 'dist' path for download-artifact step
- Configure 'packages-dir' parameter for PyPI publish action

Chores:
- Bump project version to 0.1.1