### PR TITLE
Change gplugins direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
   "sphinxcontrib-svgbob",
 ]
 models = [
-  "gplugins[meshwell]>=1.4.3",
+  "gplugins[meshwell]>=2.0.0",
   "jaxellip",
   "optuna",
   "ray[tune]",


### PR DESCRIPTION
This fixes upload to PyPi

Drafted until gplugins v1.4.3 or later is released.