### PR TITLE
Make PyPI version badge clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![HTML Docs](https://img.shields.io/badge/%F0%9F%93%84_HTML-Docs-blue?style=flat)](https://gdsfactory.github.io/quantum-rf-pdk/)
 [![PDF Docs](https://img.shields.io/badge/%F0%9F%93%84_PDF-Docs-blue?style=flat&logo=adobeacrobatreader)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)
-![PyPI - Version](https://img.shields.io/pypi/v/qpdk?color=blue)
+[![PyPI - Version](https://img.shields.io/pypi/v/qpdk?color=blue)](https://pypi.org/p/qpdk)
 [![MIT](https://img.shields.io/github/license/gdsfactory/quantum-rf-pdk)](https://choosealicense.com/licenses/mit/)
 
 ______________________________________________________________________


### PR DESCRIPTION
## Summary by Sourcery

Make the PyPI version badge in the README link to the package’s PyPI page.

Enhancements:
- Wrap the PyPI version badge in a hyperlink to make it clickable.

Documentation:
- Update README.md to link the PyPI badge to the package page on pypi.org.