### PR TITLE
Update dependency groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else { \
 	}'
 
 install: ##@ Install the package and all development dependencies
-	uv sync --all-extras
+	uv sync --all-extras --all-groups
 
 CLEAN_DIRS := dist build *.egg-info docs/_build docs/notebooks
 clean: ##@ Clean up all build, test, coverage and Python artifacts
@@ -28,7 +28,7 @@ clean: ##@ Clean up all build, test, coverage and Python artifacts
 # Testing #
 ###########
 
-PYTEST_COMMAND := uv run --extra dev pytest
+PYTEST_COMMAND := uv run --group dev pytest
 test: ##@ Run the full test suite in parallel using pytest
 	$(PYTEST_COMMAND) -n auto
 
@@ -56,10 +56,10 @@ build: ##@ Build the Python package (install build tool and create dist)
 #################
 
 write-cells: ##@ Write cell outputs into documentation notebooks (used when building docs)
-	uv run .github/write_cells.py
+	uv run --group docs .github/write_cells.py
 
 write-makefile-help: ##@ Write Makefile help output to documentation
-	uv run .github/write_makefile_help.py
+	uv run --group docs .github/write_makefile_help.py
 
 convert-notebooks: ##@ Convert jupytext scripts from notebooks/src to ipynb format in notebooks
 	./.github/convert-notebooks.sh notebooks/src/*.py
@@ -75,10 +75,10 @@ setup-ipython-config: ##@ Setup IPython configuration for documentation build
 	cp docs/qpdk.mplstyle ~/.config/matplotlib/stylelib/qpdk.mplstyle
 
 docs: write-cells write-makefile-help copy-sample-notebooks ##@ Build the HTML documentation
-	uv run jb build docs
+	uv run --group docs jb build docs
 
 docs-latex: write-cells write-makefile-help copy-sample-notebooks ##@ Setup LaTeX for PDF documentation
-	uv run jb build docs --builder latex
+	uv run --group docs jb build docs --builder latex
 
 docs-pdf: docs-latex ##@ Build PDF documentation (requires a TeXLive installation)
 	cd "docs/_build/latex" && latexmk -pdfxe -xelatex -interaction=nonstopmode -f -file-line-error

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Clone the repository and install at least the development dependencies:
 ```bash
 git clone https://github.com/gdsfactory/quantum-rf-pdk.git
 cd quantum-rf-pdk
-uv sync --extra dev
+uv sync --group dev
 ```
 
 > [!NOTE]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,25 +18,6 @@ classifiers = [
 dependencies = ["doroutes>=0.2.0", "gdsfactory>=9.15.0,<9.21.7"]
 
 [project.optional-dependencies]
-dev = [
-  "hypothesis",
-  "jsondiff",
-  "prek",
-  "pytest>=9.0.0",
-  "pytest-cov",
-  "pytest-github-actions-annotate-failures",
-  "pytest-xdist",
-  "pytest_regressions",
-]
-docs = [
-  "jinja2",
-  "jupyter-book>=1.0.4,<2",
-  "jupytext",
-  "matplotlib",
-  "pydata-sphinx-theme",
-  "sphinxcontrib-katex",
-  "sphinxcontrib-svgbob",
-]
 models = [
   "gplugins[meshwell]>=2.0.0",
   "jaxellip",
@@ -47,6 +28,28 @@ models = [
   "scqubits",
   "sympy",
   "polars",
+]
+
+[dependency-groups]
+dev = [{ include-group = "lint" }, { include-group = "test" }]
+docs = [
+  "jinja2",
+  "jupyter-book>=1.0.4,<2",
+  "jupytext",
+  "matplotlib",
+  "pydata-sphinx-theme",
+  "sphinxcontrib-katex",
+  "sphinxcontrib-svgbob",
+]
+lint = ["prek"]
+test = [
+  "hypothesis",
+  "jsondiff",
+  "pytest>=9.0.0",
+  "pytest-cov",
+  "pytest-github-actions-annotate-failures",
+  "pytest_regressions",
+  "pytest-xdist",
 ]
 
 [build-system]


### PR DESCRIPTION
This PR updates the project to use the PEP735 `[dependency-groups]` feature in `uv`, replacing the previous `[project.optional-dependencies]` (which are now called `extras`).

Key changes:
- Migrated `dev` and `docs` optional dependencies to the new `[dependency-groups]` table in `pyproject.toml`.
- Updated `Makefile` commands to use `uv run --group <group>` instead of the deprecated `uv run --extra <extra>`.
- Updated `README.md` installation instructions to use `uv sync --group dev`.

This aligns the project with the latest `uv` standards and ensures that dependency management remains consistent.

## Summary by Sourcery

Adopt uv’s new dependency-groups feature by migrating legacy extras and updating relevant commands across the project

New Features:
- Define dev, docs, lint, and test dependency groups in pyproject.toml

Enhancements:
- Replace uv run --extra with uv run --group in Makefile targets and use uv sync --all-groups for installation

Documentation:
- Update README installation instructions to use uv sync --group dev

Chores:
- Remove obsolete [project.optional-dependencies] entries and tidy pyproject.toml formatting