### PR TITLE
Expand norecursedirs in pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,18 @@ read-only = "ignore"
 
 [tool.pytest]
 addopts = ["--tb=short"]
-norecursedirs = ["extra/*.py"]
+norecursedirs = [
+  "extra/*.py",
+  "*.egg",
+  ".*",
+  "_darcs",
+  "build",
+  "CVS",
+  "dist",
+  "node_modules",
+  "venv",
+  "{arch}"
+]
 python_files = ["qpdk/*.py", "notebooks/*.ipynb", "tests/*.py"]
 testpaths = ["qpdk/", "tests"]
 


### PR DESCRIPTION
Expand norecursedirs in pytest configuration with original defaults as well