### PR TITLE
Update Claude PR review workflow to v1

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,51 +1,40 @@
-name: Claude PR Review
+name: Claude Auto Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  issue_comment:
-    types: [created]
 permissions:
   contents: read
   pull-requests: write
   issues: write
   id-token: write
 jobs:
-  claude-review:
-    # Run on PR events, or on issue comments that mention @claude
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
+  review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@beta
+          fetch-depth: 1
+      - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude"
-          model: "claude-sonnet-4-20250514"
-          timeout_minutes: 30
-          allowed_tools: |
-            Read
-            Glob
-            Grep
-            WebFetch
-            WebSearch
-          custom_instructions: |
-            You are a code reviewer for a GDSFactory PDK (Process Design Kit) repository.
-            This repository contains photonic IC design components and models.
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
-            When reviewing PRs, focus on:
-            1. Code quality and adherence to Python best practices
-            2. Proper use of type hints
-            3. Notebook quality and documentation
-            4. Potential bugs or issues
-            5. Pre-commit hook compliance (ruff formatting, pyright type checking)
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
 
-            Be constructive and helpful in your feedback. Suggest improvements where appropriate.
-            Reference the AGENTS.md file for AI agent best practices in this repository.
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Updated the `claude-pr-review.yml` workflow to use `anthropics/claude-code-action@v1`. This update simplifies the workflow, refines the review prompt, and explicitly allows necessary tools for inline comments and PR interaction via the GitHub CLI.

Key changes:
- Switched to `v1` of the Claude code action.
- Simplified triggers and permissions.
- Updated the review prompt to focus on code quality, bugs, security, and performance.
- Configured `claude_args` to allow `gh` and MCP-based inline commenting.

## Summary by Sourcery

Update the Claude PR review GitHub Actions workflow to use the stable v1 Claude code action with a streamlined configuration focused on automated PR reviews.

CI:
- Simplify the Claude PR review workflow triggers and permissions to run only on pull request events.
- Upgrade the workflow to use anthropics/claude-code-action@v1 with a reduced checkout depth for PR branches.
- Refine the review prompt to emphasize code quality, bugs, security, and performance, and configure allowed tools for GitHub CLI and MCP-based inline commenting.