### PR TITLE
Add DeepWiki MCP server to Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -40,7 +40,7 @@ jobs:
 
             Use `gh pr comment` for top-level feedback.
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Use `mcp__deepwiki__read_wiki_structure` and `mcp__deepwiki__read_wiki_contents` to understand imported libraries better if needed, and `mcp__deepwiki__ask_question` to ask for clarifications their codebase if necessary.
+            Use `mcp__deepwiki__read_wiki_structure` and `mcp__deepwiki__read_wiki_contents` to understand imported libraries better if needed, and `mcp__deepwiki__ask_question` to ask for clarifications about their codebase if necessary.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
             --mcp-config '{"mcpServers": {"deepwiki": {"serverUrl": "https://mcp.deepwiki.com/mcp"}}}'


### PR DESCRIPTION
Integrates the DeepWiki MCP server into the `claude-pr-review.yml` workflow to enhance automated pull request reviews with external documentation and codebase context.

### Changes:
- Added `deepwiki` MCP server configuration to `claude_args`.
- Whitelisted `deepwiki` tools: `read_wiki_structure`, `read_wiki_contents`, and `ask_question`.
- Updated the Claude prompt to encourage using these tools for better understanding of imported libraries and codebase clarifications.

## Summary by Sourcery

Integrate the DeepWiki MCP server into the Claude PR review GitHub workflow to enrich automated code reviews with external documentation context.

New Features:
- Enable the DeepWiki MCP server via MCP configuration in the Claude PR review workflow.
- Allow Claude PR review runs to use DeepWiki tools for reading wiki structure, contents, and asking questions about the codebase.

Enhancements:
- Update the Claude review prompt to encourage use of DeepWiki tools for understanding imported libraries and clarifying codebase details.