### PR TITLE
Revert DeepWiki MCP server configuration in Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -40,8 +40,6 @@ jobs:
 
             Use `gh pr comment` for top-level feedback.
             Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues.
-            Use `mcp__deepwiki__read_wiki_structure` and `mcp__deepwiki__read_wiki_contents` to understand imported libraries better if needed, and `mcp__deepwiki__ask_question` to ask for clarifications about their codebase if necessary.
             Only post GitHub comments - don't submit review text as messages.
           claude_args: |
-            --mcp-config '{"mcpServers": {"deepwiki": {"serverUrl": "https://mcp.deepwiki.com/mcp"}}}'
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__deepwiki__read_wiki_structure,mcp__deepwiki__read_wiki_contents,mcp__deepwiki__ask_question"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
This PR removes the DeepWiki MCP server configuration, associated tools, and documentation-related instructions from the Claude PR review workflow, effectively reverting the changes introduced in PR #245.

## Summary by Sourcery

Enhancements:
- Remove DeepWiki-related instructions and tools from the Claude PR review workflow configuration, limiting allowed tools to GitHub inline comments and basic gh commands.