### PR TITLE
Refactor documentation build prerequisites

### DIFF
--- a/justfile
+++ b/justfile
@@ -116,6 +116,7 @@ setup-ipython-config:
     mkdir -p ~/.config/matplotlib/stylelib/
     cp docs/qpdk.mplstyle ~/.config/matplotlib/stylelib/qpdk.mplstyle
 
+# Shared prerequisites for building documentation (runs in parallel)
 [parallel]
 docs-prerequisites: write-cells write-models write-justfile-help copy-sample-notebooks
 


### PR DESCRIPTION
Consolidates documentation build steps into a single parallel target docs-prerequisites within the justfile to improve build efficiency.

## Summary by Sourcery

Refactor documentation build tasks by introducing a shared prerequisite target and updating HTML and LaTeX docs builds to depend on it.

Build:
- Add a parallel docs-prerequisites just target encapsulating shared steps for building documentation.
- Update docs and docs-latex just targets to depend on the new docs-prerequisites target instead of duplicating prerequisite commands.