### PR TITLE
Remove empty title field from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report a bug or issue with the quantum-rf-pdk
-title: ""
 type: "Bug"
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,6 +1,5 @@
 name: Documentation Issue
 description: Report an issue with documentation or suggest improvements
-title: ""
 labels: ["documentation"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for quantum-rf-pdk
-title: ""
 type: "Feature"
 labels: ["enhancement"]
 body:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,6 +1,5 @@
 name: Question or Help
 description: Ask a question or get help using quantum-rf-pdk
-title: ""
 labels: ["question"]
 body:
   - type: markdown


### PR DESCRIPTION
This PR removes the empty `title: ""` field from all GitHub issue templates (bug report, documentation, feature request, and question). This resolves an issue where the title was prefilled with an empty string instead of using the default GitHub behavior.

## Summary by Sourcery

Chores:
- Remove redundant empty title fields from all GitHub issue templates.