### PR TITLE
Fix ModuleNotFoundError when importing qpdk.samples

### DIFF
--- a/qpdk/samples/__init__.py
+++ b/qpdk/samples/__init__.py
@@ -1,0 +1,1 @@
+"""Sample scripts for QPDK."""


### PR DESCRIPTION
## Description
Fixes a `ModuleNotFoundError` that occurs when importing `qpdk.samples` from a distributed PyPI package (wheel). The issue was caused by a missing `__init__.py` file, which prevented the directory from being recognized as a subpackage.

## Changes
* Added `qpdk/samples/__init__.py` to ensure the package is correctly built and included in the wheel distribution.
* Added a new test in `tests/test_build.py` that builds the wheel and checks the zipfile contents to ensure all `__init__.py` files for essential subpackages are present.

## Summary by Sourcery

Bug Fixes:
- Resolve ModuleNotFoundError when importing qpdk.samples from the installed wheel by adding the missing __init__.py file.