### PR TITLE
Update GitHub Actions workflow for Copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,13 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           lfs: true
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: 'pyproject.toml'
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install just


### PR DESCRIPTION
Updated actions/checkout to v7 and removed Python setup step.

## Summary by Sourcery

Update the Copilot setup GitHub Actions workflow to use the latest checkout action and simplify the job steps.

CI:
- Bump actions/checkout to v7 in the Copilot setup workflow.
- Remove the Python setup step from the Copilot setup workflow.