### PR TITLE
Downgrade actions/checkout from v7 to v6

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           lfs: true
       - name: Install uv


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the Copilot setup workflow to use actions/checkout@v6 instead of v7.