### PR TITLE
Cast n_points to integer in taper_cross_section

### DIFF
--- a/qpdk/models/waveguides.py
+++ b/qpdk/models/waveguides.py
@@ -478,6 +478,7 @@ def taper_cross_section(
     Returns:
         sax.SDict: S-parameters dictionary
     """
+    n_points = int(n_points)
     w1, g1 = get_cpw_dimensions(cross_section_1)
     w2, g2 = get_cpw_dimensions(cross_section_2)
 


### PR DESCRIPTION
Ensure n_points is explicitly cast to an integer in the taper_cross_section model to avoid potential type issues during calculation or indexing.

## Summary by Sourcery

Bug Fixes:
- Prevent type-related issues in taper_cross_section by explicitly casting n_points to an integer before calculations and indexing.