### PR TITLE
Include samples in package build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install just
-        uses: extractions/setup-just@v3
-      - name: Remove samples
-        run: just rm-samples
+      - uses: extractions/setup-just@v3
       - uses: astral-sh/setup-uv@v7
       - run: just build
       - uses: actions/upload-artifact@v6

--- a/justfile
+++ b/justfile
@@ -10,10 +10,6 @@ install:
 install-tech:
     uv run --dev qpdk/install_tech.py
 
-# Remove samples folder
-rm-samples:
-    rm -rf qpdk/samples
-
 # Clean up all build, test, coverage and Python artifacts
 clean:
     rm -rf dist build *.egg-info docs/_build docs/notebooks


### PR DESCRIPTION
Removed the step that explicitly deleted the samples directory before building the package. This ensures that the qpdk/samples folder is included in the published distribution.

## Summary by Sourcery

Include the qpdk/samples directory in built packages by no longer deleting it during the build workflow.

Build:
- Update build workflow to stop removing the samples directory before packaging so it is included in the distribution.

CI:
- Simplify GitHub Actions build job by removing the explicit sample-removal step and relying on the standard build process.