### PR TITLE
Update citations and cleanup HFSS capacitor notebook

### DIFF
--- a/notebooks/hfss_driven_capacitor.ipynb
+++ b/notebooks/hfss_driven_capacitor.ipynb
@@ -605,6 +605,18 @@
     "- Comparison with analytical models helps validate simulation setup\n",
     "- Frequency-dependent behavior reveals parasitic inductance at high frequencies"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "```{bibliography}\n",
+    ":filter: docname in docnames\n",
+    "```"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/src/hfss_driven_capacitor.py
+++ b/notebooks/src/hfss_driven_capacitor.py
@@ -450,3 +450,10 @@ print("HFSS session closed and temporary files cleaned up")
 # - S-parameters capture both capacitance and parasitic effects
 # - Comparison with analytical models helps validate simulation setup
 # - Frequency-dependent behavior reveals parasitic inductance at high frequencies
+
+# %% [markdown]
+# ## References
+#
+# ```{bibliography}
+# :filter: docname in docnames
+# ```


### PR DESCRIPTION
This PR updates the citation syntax to {cite:p} for compatibility, adds a reference to Pozar for Y-parameter extraction, and removes redundant Next Steps and References sections from the HFSS driven capacitor notebook and its source file.

## Summary by Sourcery

Update the HFSS driven capacitor notebook and its source script to use consistent citation syntax and streamline the summary section.

Documentation:
- Switch citation markup to {cite:p} syntax and add a Pozar reference for the Y-parameter-based mutual capacitance extraction discussion.
- Remove redundant Next Steps and References sections from the HFSS driven capacitor notebook and its source script to simplify the narrative.