### PR TITLE
Enable collision checking for CPW route bundles

### DIFF
--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -386,6 +386,8 @@ route_bundle = route_bundle_cpw = partial(
     gf.routing.route_bundle,
     cross_section=cpw,
     bend="bend_circular",
+    collision_check_layers=[LAYER.WG],
+    on_collision="error",
 )
 route_bundle_all_angle = route_bundle_all_angle_cpw = partial(
     gf.routing.route_bundle_all_angle,


### PR DESCRIPTION
Updates the `route_bundle` and `route_bundle_cpw` routing functions to include collision checking on the `LAYER.WG` layer. The router is now configured to raise an error if a collision is detected during routing.

## Summary by Sourcery

Enhancements:
- Configure CPW route bundle helpers to perform collision checking on the waveguide layer and fail routing when collisions are detected.