### PR TITLE
Refactor CPW models and integrate scikit-rf

### DIFF
--- a/.github/write_models.py
+++ b/.github/write_models.py
@@ -19,12 +19,24 @@ skip_plots = {
     "cpw_media_skrf",
 }
 
+# Models that should NOT be documented at all (re-exported from other packages)
+skip_autodoc = {
+    "admittance",
+    "capacitor",
+    "electrical_open",
+    "electrical_short",
+    "gamma_0_load",
+    "impedance",
+    "inductor",
+    "tee",
+}
+
 # Collect all public functions/classes in qpdk.models
 if qpdk.models is not None:
     models = {
         name: obj
         for name, obj in qpdk.models.__dict__.items()
-        if callable(obj) and not name.startswith("_")
+        if callable(obj) and not name.startswith("_") and name not in skip_autodoc
     }
 else:
     models = {}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -17,6 +17,14 @@ execute:
     - "notebooks/hfss*.ipynb"
   timeout: -1
   allow_errors: false
+parse:
+  myst_enable_extensions:
+    - amsmath
+    - colon_fence
+    - dollarmath
+    - substitution
+    - tasklist
+    - linkify
 latex:
   latex_engine: &latex_engine xelatex
   use_jupyterbook_latex: true # use sphinx-jupyterbook-latex for pdf builds as default
@@ -51,6 +59,7 @@ sphinx:
     - "sphinxcontrib.katex"
     - "sphinxcontrib.svgbob"
     - "matplotlib.sphinxext.plot_directive"
+    - "sphinx_copybutton"
   config:
     autodoc_type_aliases:
       "ComponentSpec": "ComponentSpec"

--- a/docs/templates/models_static.rst.j2
+++ b/docs/templates/models_static.rst.j2
@@ -27,15 +27,15 @@
    plt.title("{{ func_name }}", fontsize=14)
 
    for (pout, pin), sij in s_model.items():
-    i = int(pout[-1])  # "o2" -> 2
-    j = int(pin[-1])   # "o1" -> 1
+      i = int(pout[-1])  # "o2" -> 2
+      j = int(pin[-1])   # "o1" -> 1
 
-    if i >= j:
-        plt.plot(
-            freq_ghz,
-            20 * jnp.log10(jnp.abs(sij)),
-            label = "$S_{" + str(i) + str(j) + "}$"
-        )
+      if i >= j:
+          plt.plot(
+              freq_ghz,
+              20 * jnp.log10(jnp.abs(sij)),
+              label = "$S_{" + str(i) + str(j) + "}$"
+          )
    plt.xlabel("Frequency [GHz]", fontsize=12)
    plt.ylabel("Magnitude [dB]", fontsize=12)
    plt.grid(True)

--- a/notebooks/circuit_simulation_demo.ipynb
+++ b/notebooks/circuit_simulation_demo.ipynb
@@ -291,12 +291,10 @@
  ],
  "metadata": {
   "jupytext": {
-   "cell_metadata_filter": "tags,title,-all",
-   "main_language": "python",
-   "notebook_metadata_filter": "-all"
+   "notebook_metadata_filter": "language_info"
   },
   "kernelspec": {
-   "display_name": "quantum-rf-pdk",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -310,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/src/circuit_simulation_demo.py
+++ b/notebooks/src/circuit_simulation_demo.py
@@ -1,3 +1,27 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.17.3
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.12.9
+# ---
+
 # %% [markdown]
 # # Circuit Simulation with QPDK
 #

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -108,7 +108,7 @@ def straight_double_open(
     r"""Returns a straight waveguide with etched gaps at both ends.
 
     Note:
-        This may be treated as a :math:`\lambda/2` as a straight resonator in some contexts.
+        This may be treated as a :math:`\lambda/2` straight resonator in some contexts.
 
     Args:
         length: Length of the straight waveguide in μm.

--- a/qpdk/models/couplers.py
+++ b/qpdk/models/couplers.py
@@ -41,6 +41,7 @@ def cpw_cpw_coupling_capacitance_per_length_analytical(
 
     .. math::
 
+        \begin{aligned}
         x_1 &= s_c / 2 \\
         x_2 &= x_1 + W \\
         x_3 &= x_2 + G \\
@@ -49,6 +50,7 @@ def cpw_cpw_coupling_capacitance_per_length_analytical(
         C_{\text{even}} &= 2 \epsilon_0 \epsilon_{\text{eff}} \frac{K(k_e)}{K(k_e')} \\
         C_{\text{odd}} &= 2 \epsilon_0 \epsilon_{\text{eff}} \frac{K(k_o')}{K(k_o)} \\
         C_m &= \frac{C_{\text{odd}} - C_{\text{even}}}{2}
+        \end{aligned}
 
     where :math:`s_c` is the separation (gap) between inner edges, :math:`W` is the
     center conductor width, and :math:`G` is the gap to the ground plane.

--- a/qpdk/models/cpw.py
+++ b/qpdk/models/cpw.py
@@ -69,6 +69,7 @@ def cpw_epsilon_eff(
 
     .. math::
 
+        \begin{aligned}
         k_0     &= \frac{w}{w + 2s} \\
         k_1     &= \frac{\sinh(\pi w / 4h)}
                          {\sinh\bigl(\pi(w + 2s) / 4h\bigr)} \\
@@ -76,6 +77,7 @@ def cpw_epsilon_eff(
                          {K(k_0^2)\,/\,K(1 - k_0^2)}  \\
         \varepsilon_{\mathrm{eff}}
                 &= 1 + \frac{q_1\,(\varepsilon_r - 1)}{2}
+        \end{aligned}
 
     where :math:`K` is the complete elliptic integral of the first kind in
     the *parameter* convention (:math:`m = k^2`).
@@ -459,10 +461,12 @@ def transmission_line_s_params(
 
     .. math::
 
+        \begin{aligned}
         S_{11} &= \frac{A + B/Z_{\mathrm{ref}} - C\,Z_{\mathrm{ref}} - D}
                        {A + B/Z_{\mathrm{ref}} + C\,Z_{\mathrm{ref}} + D} \\
         S_{21} &= \frac{2}
                        {A + B/Z_{\mathrm{ref}} + C\,Z_{\mathrm{ref}} + D}
+        \end{aligned}
 
     When ``z_ref`` is ``None`` the reference impedance defaults to ``z0``
     (matched case), giving :math:`S_{11} = 0` and

--- a/qpdk/models/perturbation.py
+++ b/qpdk/models/perturbation.py
@@ -53,10 +53,12 @@ def transmon_resonator_hamiltonian() -> tuple[
 
     .. math::
 
+        \begin{aligned}
         H_0 &= -\omega_t\, a_t^\dagger a_t
               + \frac{\alpha}{2}\, a_t^{\dagger 2} a_t^2
               + \omega_r\, a_r^\dagger a_r \\
         H_p &= -g\,(a_t^\dagger - a_t)(a_r^\dagger - a_r)
+        \end{aligned}
 
     Returns:
         A tuple ``(H_0, H_p, symbols)`` where ``symbols`` is
@@ -196,8 +198,10 @@ def ej_ec_to_frequency_and_anharmonicity(
 
     .. math::
 
-        \omega_q \approx \sqrt{8 E_J E_C} - E_C
-        \alpha \approx E_C
+        \begin{aligned}
+        \omega_q &\approx \sqrt{8 E_J E_C} - E_C \\
+        \alpha &\approx E_C
+        \end{aligned}
 
     Note:
         The physical anharmonicity of a transmon is *negative*

--- a/qpdk/models/qubit.py
+++ b/qpdk/models/qubit.py
@@ -58,19 +58,19 @@ def ec_to_capacitance(ec_ghz: float) -> float:
 
 @partial(jax.jit, inline=True)
 def ej_to_inductance(ej_ghz: float) -> float:
-    r"""Convert Josephson energy :math:`E_J` to Josephson inductance :math:`L_J`.
+    r"""Convert Josephson energy :math:`E_J` to Josephson inductance :math:`L_\text{J}`.
 
     The Josephson energy is related to inductance by:
 
     .. math::
 
-        E_J = \frac{\Phi_0^2}{4 \pi^2 L_J} = \frac{(\hbar / 2e)^2}{L_J}
+        E_J = \frac{\Phi_0^2}{4 \pi^2 L_\text{J}} = \frac{(\hbar / 2e)^2}{L_\text{J}}
 
     This is equivalent to:
 
     .. math::
 
-        L_J = \frac{\Phi_0}{2 \pi I_c}
+        L_\text{J} = \frac{\Phi_0}{2 \pi I_c}
 
     where :math:`I_c` is the critical current and :math:`\Phi_0` is the magnetic flux quantum.
 
@@ -175,7 +175,7 @@ def double_island_transmon(
     Args:
         f: Array of frequency points in Hz.
         capacitance: Total capacitance :math:`C_\Sigma` of the qubit in Farads.
-        inductance: Josephson inductance :math:`L_J` in Henries.
+        inductance: Josephson inductance :math:`L_\text{J}` in Henries.
 
     Returns:
         sax.SDict: S-parameters dictionary with ports o1 and o2.
@@ -275,7 +275,7 @@ def shunted_transmon(
     Args:
         f: Array of frequency points in Hz.
         capacitance: Total capacitance :math:`C_\Sigma` of the qubit in Farads.
-        inductance: Josephson inductance :math:`L_J` in Henries.
+        inductance: Josephson inductance :math:`L_\text{J}` in Henries.
 
     Returns:
         sax.SDict: S-parameters dictionary with ports o1 and o2.
@@ -327,7 +327,7 @@ def transmon_coupled(
     Args:
         f: Array of frequency points in Hz.
         capacitance: Total capacitance :math:`C_\Sigma` of the qubit in Farads.
-        inductance: Josephson inductance :math:`L_J` in Henries.
+        inductance: Josephson inductance :math:`L_\text{J}` in Henries.
         grounded: If True, the qubit is a shunted transmon (grounded).
             If False, it is a double-pad transmon (ungrounded).
         coupling_capacitance: Coupling capacitance :math:`C_c` in Farads.
@@ -389,7 +389,7 @@ def qubit_with_resonator(
         f: Array of frequency points in Hz.
         qubit_capacitance: Total capacitance :math:`C_\Sigma` of the qubit in Farads.
             Convert from charging energy using :func:`ec_to_capacitance`.
-        qubit_inductance: Josephson inductance :math:`L_J` in Henries.
+        qubit_inductance: Josephson inductance :math:`L_\text{J}` in Henries.
             Convert from Josephson energy using :func:`ej_to_inductance`.
         qubit_grounded: If True, the qubit is a shunted transmon (grounded).
             If False, it is a double-island transmon (ungrounded).

--- a/qpdk/models/resonator.py
+++ b/qpdk/models/resonator.py
@@ -160,8 +160,10 @@ def resonator_frequency(
 
     .. math::
 
+        \begin{aligned}
         f &= \frac{v_p}{4L}  \mathtt{ (quarter-wave resonator)} \\
         f &= \frac{v_p}{2L}  \mathtt{ (half-wave resonator)}
+        \end{aligned}
 
     The phase velocity is :math:`v_p = c_0 / \sqrt{\varepsilon_{\mathrm{eff}}}`.
 


### PR DESCRIPTION
Refactors CPW modeling by introducing a new `qpdk.models.media` module and integrating `scikit-rf`.

### Key Changes
- **New `qpdk.models.media` module**: Centralizes layout-to-model conversion and transmission media definitions.
- **scikit-rf Integration**: Added `cpw_media_skrf` to leverage `scikit-rf` for CPW properties while maintaining JAX-jittable quasi-static models in `qpdk.models.cpw`.
- **API Improvements**: Deprecated legacy layout-to-model helpers in favor of more robust JAX-compatible alternatives.
- **Enhanced Documentation**: Improved MathJax formatting in model docstrings and added `scikit-rf` to the modeling library list.
- **Maintenance**: Removed redundant parallel `all` target from the `justfile` and updated internal imports across notebooks and tests.

### Verification
- All pre-commit hooks passed.
- Unit tests for the new `media` module added and passing.
- Notebooks and existing model tests verified.

## Summary by Sourcery

Tighten documentation and tooling for models and examples, improving math rendering, autodoc selection, and notebook metadata without changing modeling behavior.

Enhancements:
- Exclude selected re-exported utility models from auto-generated API documentation to keep the public model list focused.
- Adjust S-parameter plotting template indentation for clearer, consistent generated example code.
- Refine MathJax/LaTeX formatting across several model docstrings for clearer equations and symbols.
- Update waveguide documentation wording for clearer physical interpretation.

Documentation:
- Enable additional MyST and Sphinx extensions (e.g. amsmath, dollarmath, copybutton) to improve documentation rendering and UX.
- Normalize notebook and jupytext metadata for the circuit simulation demo to match standard Python 3 kernels and configuration.