### PR TITLE
Fix duplicate ISBN in bibliography.bib

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -472,7 +472,7 @@
   publisher = {Wiley Interscience},
   address = {New York},
   doi = {10.1002/0471224758},
-  isbn = {978-0-471-22475-4 978-0-471-46393-1},
+  isbn = {978-0-471-46393-1},
   langid = {english}
 }
 @book{tinkhamIntroductionSuperconductivity2015,


### PR DESCRIPTION
Removed duplicate ISBN from bibliography entry.

## Summary by Sourcery

Bug Fixes:
- Remove duplicated ISBN value from a bibliography entry to ensure correct citation metadata.