### PR TITLE
Add sheron-lian and thanojo to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola
+* @joamatab @ThomasPluck @nikosavola @sheron-lian @thanojo


### PR DESCRIPTION
## Summary
- Add @sheron-lian and @thanojo as code owners

## Summary by Sourcery

Keep CODEOWNERS file unchanged after reverting previous edits that added new owners.