### PR TITLE
Update flipmon test chip routing and placements

### DIFF
--- a/qpdk/samples/flipmon_test_chip.pic.yml
+++ b/qpdk/samples/flipmon_test_chip.pic.yml
@@ -23,7 +23,6 @@ instances:
     component: flipmon_with_resonator_and_probeline
     settings:
       resonator_length: 5000
-      resonator_meanders: 5
   qubit2:
     component: flipmon_with_resonator_and_probeline
     settings:
@@ -38,7 +37,6 @@ instances:
     component: flipmon_with_resonator_and_probeline
     settings:
       resonator_length: 4400
-      resonator_meanders: 5
   tee_bot:
     component: tee
     settings: {}
@@ -65,7 +63,7 @@ connections:
 routes:
   flux_line_bot:
     links:
-      launcher_bot,o1: tee_bot,o2
+      tee_bot,o2: launcher_bot,o1
     routing_strategy: route_bundle_cpw
     settings:
       auto_taper: false
@@ -75,44 +73,17 @@ routes:
     routing_strategy: route_bundle_cpw
     settings:
       auto_taper: false
-  probeline_input:
-    links:
-      launcher_in,o1: input_cap1,o1
-    routing_strategy: route_bundle_cpw
-    settings:
-      allow_width_mismatch: true
-      auto_taper: false
   probeline_cap1_to_qubit1:
     links:
       input_cap1,o2: qubit1,coupling_o1
-    routing_strategy: route_bundle_cpw
+    routing_strategy: route_bundle_sbend_cpw
     settings:
-      allow_width_mismatch: true
-      auto_taper: false
-  probeline_qubit1_to_qubit2:
+      allow_layer_mismatch: false
+      allow_type_mismatch: false
+      allow_width_mismatch: false
+  probeline_input:
     links:
-      qubit1,coupling_o2: qubit2,coupling_o1
-    routing_strategy: route_bundle_cpw
-    settings:
-      auto_taper: false
-  probeline_qubit2_to_qubit3:
-    links:
-      qubit2,coupling_o2: qubit3,coupling_o2
-    routing_strategy: route_bundle_cpw
-    settings:
-      auto_taper: false
-      steps:
-      - dx: 200
-      - dy: -952
-  probeline_qubit3_to_qubit4:
-    links:
-      qubit3,coupling_o1: qubit4,coupling_o2
-    routing_strategy: route_bundle_cpw
-    settings:
-      auto_taper: false
-  probeline_qubit4_to_cap2:
-    links:
-      qubit4,coupling_o1: input_cap2,o2
+      launcher_in,o1: input_cap1,o1
     routing_strategy: route_bundle_cpw
     settings:
       allow_width_mismatch: true
@@ -123,6 +94,39 @@ routes:
     routing_strategy: route_bundle_cpw
     settings:
       auto_taper: false
+  probeline_qubit1_to_qubit2:
+    links:
+      qubit1,coupling_o2: qubit2,coupling_o1
+    routing_strategy: route_bundle_sbend_cpw
+    settings:
+      allow_layer_mismatch: false
+      allow_type_mismatch: false
+      allow_width_mismatch: false
+  probeline_qubit2_to_qubit3:
+    links:
+      qubit2,coupling_o2: qubit3,coupling_o2
+    routing_strategy: route_bundle_cpw
+    settings:
+      allow_layer_mismatch: false
+      allow_type_mismatch: false
+      allow_width_mismatch: true
+      auto_taper: false
+  probeline_qubit3_to_qubit4:
+    links:
+      qubit3,coupling_o1: qubit4,coupling_o2
+    routing_strategy: route_bundle_sbend_cpw
+    settings:
+      allow_layer_mismatch: false
+      allow_type_mismatch: false
+      allow_width_mismatch: false
+  probeline_qubit4_to_cap2:
+    links:
+      qubit4,coupling_o1: input_cap2,o2
+    routing_strategy: route_bundle_sbend_cpw
+    settings:
+      allow_layer_mismatch: false
+      allow_type_mismatch: false
+      allow_width_mismatch: false
 nets: []
 ports:
   o1: launcher_in,waveport
@@ -153,21 +157,30 @@ placements:
     y: 3000
     rotation: -90
   qubit1:
-    x: 2200
-    y: 1750
-    mirror: false
-  qubit2:
-    x: 3800
-    y: 1750
+    x: 0
+    y: 0
+    dx: 2385
+    dy: 1625
     rotation: 0
-    mirror: false
+  qubit2:
+    x: 0.0
+    y: 0.0
+    dx: 3615.0
+    dy: 1625.0
+    rotation: 0
   qubit3:
-    x: 3800
-    y: -1750
+    x: 0.0
+    y: 0.0
+    dx: 3615.0
+    dy: -1627.421
+    rotation: 0
     mirror: true
   qubit4:
-    x: 2200
-    y: -1750
+    x: 0.0
+    y: 0.0
+    dx: 2385.0
+    dy: -1628.351
+    rotation: 0
     mirror: true
   tee_bot:
     x: 3000

--- a/qpdk/samples/flipmon_test_chip.scm.yml
+++ b/qpdk/samples/flipmon_test_chip.scm.yml
@@ -1,8 +1,8 @@
 exploded: ''
 camera_transform:
   translation:
-    x: 1154.6355
-    y: 1968.5801
+    x: 1297.5784
+    y: 1307.9275
     z: 0.0
   rotation:
     x: 0.0
@@ -10,14 +10,14 @@ camera_transform:
     z: 0.0
     w: 1.0
   scale:
-    x: 3.9917555
-    y: 3.9917555
+    x: 1.9595827
+    y: 1.9595827
     z: 1.0
 transforms:
   input_cap1:
     translation:
-      x: 583.8946
-      y: 1600.7871
+      x: 539.56586
+      y: 1793.5472
       z: 1.0
     rotation:
       x: 0.0
@@ -30,8 +30,8 @@ transforms:
       z: 1.0
   input_cap2:
     translation:
-      x: 552.90234
-      y: 1385.7863
+      x: 506.75354
+      y: 1163.135
       z: 1.0
     rotation:
       x: 0.0
@@ -44,8 +44,8 @@ transforms:
       z: 1.0
   launcher_bot:
     translation:
-      x: 1384.9181
-      y: 715.62994
+      x: 1371.8857
+      y: 641.8555
       z: 1.0
     rotation:
       x: 0.0
@@ -58,8 +58,8 @@ transforms:
       z: 1.0
   launcher_in:
     translation:
-      x: 0.0
-      y: 1600.0
+      x: -44.676025
+      y: 1792.9337
       z: 1.0
     rotation:
       x: 0.0
@@ -72,8 +72,8 @@ transforms:
       z: 1.0
   launcher_out:
     translation:
-      x: 11.552277
-      y: 1377.3861
+      x: -34.596527
+      y: 1154.7349
       z: 1.0
     rotation:
       x: 0.0
@@ -86,8 +86,8 @@ transforms:
       z: 1.0
   launcher_top:
     translation:
-      x: 1394.8994
-      y: 2196.2517
+      x: 1377.9768
+      y: 2189.6777
       z: 1.0
     rotation:
       x: 0.0
@@ -100,8 +100,8 @@ transforms:
       z: 1.0
   o1:
     translation:
-      x: -150.0
-      y: 1600.0
+      x: -194.9941
+      y: 1792.8542
       z: 1.0
     rotation:
       x: 0.0
@@ -114,8 +114,8 @@ transforms:
       z: 1.0
   o2:
     translation:
-      x: -138.44772
-      y: 1377.3861
+      x: -184.59653
+      y: 1154.7349
       z: 1.0
     rotation:
       x: 0.0
@@ -128,8 +128,8 @@ transforms:
       z: 1.0
   qubit1:
     translation:
-      x: 968.84845
-      y: 1810.4034
+      x: 968.71106
+      y: 1810.6458
       z: 1.0
     rotation:
       x: 0.0
@@ -142,8 +142,8 @@ transforms:
       z: 1.0
   qubit2:
     translation:
-      x: 1872.4137
-      y: 1805.938
+      x: 1910.698
+      y: 1808.5428
       z: 1.0
     rotation:
       x: 0.0
@@ -156,8 +156,8 @@ transforms:
       z: 1.0
   qubit3:
     translation:
-      x: 1898.8032
-      y: 1158.6511
+      x: 1911.0339
+      y: 1122.0533
       z: 1.0
     rotation:
       x: 0.0
@@ -165,13 +165,13 @@ transforms:
       z: 0.0
       w: 1.0
     scale:
-      x: 1.0
+      x: -1.0
       y: 1.0
       z: 1.0
   qubit4:
     translation:
-      x: 876.46045
-      y: 1180.6343
+      x: 944.208
+      y: 1142.583
       z: 1.0
     rotation:
       x: 0.0
@@ -179,13 +179,13 @@ transforms:
       z: 0.0
       w: 1.0
     scale:
-      x: 1.0
+      x: -1.0
       y: 1.0
       z: 1.0
   tee_bot:
     translation:
-      x: 1380.7828
-      y: 1141.388
+      x: 1371.9008
+      y: 975.24207
       z: 1.0
     rotation:
       x: 0.0
@@ -198,8 +198,8 @@ transforms:
       z: 1.0
   tee_bot_straight_1:
     translation:
-      x: 1665.3477
-      y: 1130.1846
+      x: 1773.9359
+      y: 970.6402
       z: 1.0
     rotation:
       x: 0.0
@@ -212,8 +212,8 @@ transforms:
       z: 1.0
   tee_bot_straight_2:
     translation:
-      x: 1146.1787
-      y: 1143.3328
+      x: 1095.4816
+      y: 973.8771
       z: 1.0
     rotation:
       x: 0.0
@@ -221,13 +221,13 @@ transforms:
       z: 0.0
       w: 1.0
     scale:
-      x: -1.0
+      x: 1.0
       y: 1.0
       z: 1.0
   tee_top:
     translation:
-      x: 1391.5497
-      y: 1822.2394
+      x: 1377.1594
+      y: 1906.6718
       z: 1.0
     rotation:
       x: 0.0
@@ -240,8 +240,8 @@ transforms:
       z: 1.0
   tee_top_straight_1:
     translation:
-      x: 1183.2004
-      y: 1836.0679
+      x: 1126.3461
+      y: 1909.2694
       z: 1.0
     rotation:
       x: 0.0
@@ -249,13 +249,13 @@ transforms:
       z: 0.0
       w: 1.0
     scale:
-      x: -1.0
+      x: 1.0
       y: 1.0
       z: 1.0
   tee_top_straight_2:
     translation:
-      x: 1644.9161
-      y: 1822.7427
+      x: 1716.6571
+      y: 1908.1486
       z: 1.0
     rotation:
       x: 0.0
@@ -335,27 +335,47 @@ layers:
   tee_top_straight_2: 0
 fan_point_positions:
   flux_line_bot:
-  - x: 1384.9181
-    y: 805.53394
+  - x: 1372.1116
+    y: 843.9535
   - x: 1371.6542
-    y: 885.3419
+    y: 768.6602
   flux_line_top:
-  - x: 1391.5497
-    y: 1941.6421
-  - x: 1390.2017
-    y: 2076.4321
+  - x: 1375.8396
+    y: 1972.9556
+  - x: 1376.2816
+    y: 2028.155
+  probeline_cap1_to_qubit1:
+  - x: 713.7246
+    y: 1792.9844
+  - x: 847.61
+    y: 1791.0701
   probeline_input:
-  - x: 173.50366
-    y: 1601.7128
-  - x: 388.63098
-    y: 1601.6346
-  probeline_input_to_output:
-  - x: 2268.226
-    y: 1595.7314
-  - x: 2269.036
-    y: 1381.492
+  - x: 179.39496
+    y: 1794.401
+  - x: 355.00122
+    y: 1790.1499
   probeline_output:
-  - x: 209.20804
-    y: 1375.5281
-  - x: 163.55762
-    y: 1381.0898
+  - x: 236.45547
+    y: 1147.7219
+  - x: 171.65826
+    y: 1145.1831
+  probeline_qubit1_to_qubit2:
+  - x: 1219.7397
+    y: 1791.0701
+  - x: 1621.5223
+    y: 1786.6046
+  probeline_qubit2_to_qubit3:
+  - x: 1986.105
+    y: 1624.9569
+  - x: 1983.7812
+    y: 1303.9183
+  probeline_qubit3_to_qubit4:
+  - x: 1618.2175
+    y: 1139.3177
+  - x: 1157.0461
+    y: 1161.3009
+  probeline_qubit4_to_cap2:
+  - x: 786.78613
+    y: 1160.912
+  - x: 638.74133
+    y: 1183.1101


### PR DESCRIPTION
This PR updates the flipmon_test_chip sample with improved routing and placement configurations.

Key changes:
- Replaced several route_bundle_cpw segments with route_bundle_sbend_cpw for smoother probeline routing.
- Adjusted qubit placements and mirrored states for better layout alignment.
- Updated schematic metadata and fan point positions for the flipmon_test_chip.
- Simplified qubit settings by removing redundant resonator_meanders.

## Summary by Sourcery

Update the flipmon_test_chip sample layout for improved probeline routing and qubit arrangement.

New Features:
- Add explicit SBEND-based probeline routes between the input capacitor, qubits, and output capacitor.

Enhancements:
- Retune camera, instance transforms, and placement coordinates for qubits and launchers to align with the updated routing topology.
- Simplify flipmon qubit instance settings by removing redundant resonator meander configuration.
- Adjust fan point positions and flux line routing directions to match the new physical layout.