### PR TITLE
Clean up bibliography by removing URLs and urldates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,9 +105,9 @@ All PRs must pass:
 1. **Use JAX for analytical models**: When implementing analytical models for S-parameters, prefer using JAX-compatible
    functions (e.g., `jnp` instead of `np`, `jaxellip` for elliptic integrals) and enable JIT compilation with
    `@partial(jax.jit, inline=True)` for helper functions.
-1. **Manage bibliography entries cleanly**: When editing the `bibliography.bib` file,
-   ensure that if a reference contains a valid `doi` field, it should **not** include
-   a `url` or `urldate` field to avoid redundant citation information.
+1. **Manage bibliography entries cleanly**: When editing the `bibliography.bib` file, ensure that if a reference
+   contains a valid `doi` field, it should **not** include a `url` or `urldate` field to avoid redundant citation
+   information.
 
 ## Testing Guidelines
 

--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -364,7 +364,7 @@
   pages = {100311},
   year = {2019},
   publisher = {Elsevier},
-  doi = {10.1016/j.softx.2019.100311},
+  doi = {10.1016/j.softx.2019.100311}
 }
 @article{netket3:2022,
   title = {NetKet 3: Machine Learning Toolbox for Many-Body Quantum Systems},
@@ -373,7 +373,7 @@
   pages = {7},
   year = {2022},
   publisher = {SciPost},
-  doi = {10.21468/SciPostPhysCodeb.7},
+  doi = {10.21468/SciPostPhysCodeb.7}
 }
 @article{norrisImprovedParameterTargeting2024,
   title = {Improved Parameter Targeting in {{3D-integrated}} Superconducting Circuits through a Polymer Spacer Process},
@@ -443,7 +443,7 @@
   number = {2},
   pages = {025009},
   issn = {0953-2048, 1361-6668},
-  doi = {10.1088/0953-2048/28/2/025009},
+  doi = {10.1088/0953-2048/28/2/025009}
 }
 @article{shoreJaynesCummingsModel1993,
   title = {The {{Jaynes}}--{{Cummings Model}}},


### PR DESCRIPTION
Removed URLs and urldates from multiple bibliography entries.

## Summary by Sourcery

Documentation:
- Remove URL and urldate metadata fields from several bibliography entries in the documentation to simplify references.