### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,4 +1,6 @@
 name: Copilot Setup Steps
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/38](https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/38)

In general, fix this by explicitly specifying a least-privilege `permissions` block either at the workflow root (to apply to all jobs) or under the specific job. For this workflow, we only need read access to repository contents for `actions/checkout` to function, and no other scopes, so we can set `permissions: contents: read`.

The single best fix with minimal behavioral impact is to add a workflow-level `permissions` block right after the `name:` (or after the `on:` block), e.g.:

```yaml
name: Copilot Setup Steps
permissions:
  contents: read
on:
  workflow_dispatch:
```

This will apply to the `copilot-setup-steps` job (and any future jobs in this workflow that don’t override permissions) and ensures the `GITHUB_TOKEN` is restricted to read-only contents. No imports, additional methods, or other definitions are needed; this is a pure YAML configuration change within `.github/workflows/copilot-setup-steps.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a workflow-level permissions block to limit the GITHUB_TOKEN in the Copilot setup workflow to contents: read.