### PR TITLE
Potential fix for code scanning alert no. 37: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/37](https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/37)

To fix this, explicitly define restrictive `GITHUB_TOKEN` permissions for the workflow so that jobs run with least privilege. The simplest and safest approach here is to add a `permissions` block at the top level of `.github/workflows/test.yml`, right under `name: Test` (or under `on:`) so that it applies to all jobs that don’t override it.

Given the workflow steps:
- `actions/checkout` requires `contents: read` (read-only).
- `upload-artifact`, `setup-uv`, `setup-just`, and `j178/prek-action` do not require repository write permissions; they work with the runner filesystem and GitHub’s artifact service.
- No steps are using `GITHUB_TOKEN` to push, create releases, modify issues, etc.

So a minimal, appropriate permissions block is:

```yaml
permissions:
  contents: read
```

This will keep the workflow functional while preventing unnecessary write access. Concretely, in `.github/workflows/test.yml`, insert this `permissions` block near the top (e.g., after line 1), without altering any existing jobs or steps.

No additional methods, imports, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Set the test workflow's GITHUB_TOKEN permissions to read-only repository contents.