### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
   build:
     needs: check_and_tag
     if: needs.check_and_tag.outputs.new_tag_created == 'true'
+    permissions:
+      contents: read
     uses: ./.github/workflows/build.yml
   release_environment:
     needs: check_and_tag


### PR DESCRIPTION
Potential fix for [https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/28](https://github.com/gdsfactory/quantum-rf-pdk/security/code-scanning/28)

To fix the problem, add an explicit `permissions` block to the `build` job so that its `GITHUB_TOKEN` is limited to the least privileges required. Since the `build` job just calls a reusable workflow and there is no evidence here that it needs write access, we can use the minimal safe default recommended by GitHub: `contents: read`. This documents the intended permissions and prevents the job from silently inheriting broader defaults if they change later or if the workflow is copied.

Concretely:
- Edit `.github/workflows/release.yml`.
- In the `build` job (lines 39–42), insert a `permissions:` section between `if:` and `uses:`:
  - `permissions:`
  - `contents: read`
- No imports or additional definitions are needed; this is a pure YAML configuration change and does not alter the existing job behavior aside from tightening its token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add an explicit read-only contents permissions block to the release workflow build job to limit the GITHUB_TOKEN scope.