### PR TITLE
Improve install-tech output and fix symlink logic

### DIFF
--- a/qpdk/install_tech.py
+++ b/qpdk/install_tech.py
@@ -25,10 +25,10 @@ def make_link(src: str | Path, dest: str | Path, overwrite: bool = True) -> None
         raise FileNotFoundError(f"{src} does not exist")
 
     if dest.exists() and not overwrite:
-        logger.warning(f"Technology already exists at {dest}")
+        logger.warning("Technology already exists at {}", dest)
         return
     if dest.exists() or dest.is_symlink():
-        logger.info(f"Removing existing technology files: {dest}")
+        logger.info("Removing existing technology files: {}", dest)
         remove_path_or_dir(dest)
     try:
         dest.symlink_to(src, target_is_directory=True)
@@ -36,9 +36,9 @@ def make_link(src: str | Path, dest: str | Path, overwrite: bool = True) -> None
     except OSError:
         shutil.copytree(src, dest)
         link_type = "Copied"
-    logger.info(f"{link_type} technology files:")
-    logger.info(f"  From: {src}")
-    logger.info(f"  To:   {dest}")
+    logger.info("{} technology files:", link_type)
+    logger.info("  From: {}", src)
+    logger.info("  To:   {}", dest)
 
 
 if __name__ == "__main__":

--- a/qpdk/install_tech.py
+++ b/qpdk/install_tech.py
@@ -4,7 +4,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from qpdk.logger import logger
+from qpdk.logger import configure_logger, logger
 
 
 def remove_path_or_dir(dest: Path) -> None:
@@ -25,21 +25,25 @@ def make_link(src: str | Path, dest: str | Path, overwrite: bool = True) -> None
         raise FileNotFoundError(f"{src} does not exist")
 
     if dest.exists() and not overwrite:
-        logger.warning("{} already exists", dest)
+        logger.warning(f"Technology already exists at {dest}")
         return
     if dest.exists() or dest.is_symlink():
-        logger.info("removing {} already installed", dest)
+        logger.info(f"Removing existing technology files: {dest}")
         remove_path_or_dir(dest)
     try:
-        Path.symlink_to(src, dest, target_is_directory=True)
+        dest.symlink_to(src, target_is_directory=True)
+        link_type = "Symlinked"
     except OSError:
         shutil.copytree(src, dest)
-    logger.info("link made:")
-    logger.info("From: {}", src)
-    logger.info("To:   {}", dest)
+        link_type = "Copied"
+    logger.info(f"{link_type} technology files:")
+    logger.info(f"  From: {src}")
+    logger.info(f"  To:   {dest}")
 
 
 if __name__ == "__main__":
+    configure_logger(log_format="<level>{message}</level>")
+    logger.info("Installing KLayout technology...")
     klayout_folder = "KLayout" if sys.platform == "win32" else ".klayout"
     home = Path.home()
     dest_folder = home / klayout_folder / "tech"
@@ -49,3 +53,4 @@ if __name__ == "__main__":
     src = repo_root / "qpdk" / "klayout"
     dest = dest_folder / "qpdk"
     make_link(src=src, dest=dest)
+    logger.info("Successfully installed KLayout technology.")

--- a/qpdk/install_tech.py
+++ b/qpdk/install_tech.py
@@ -9,10 +9,11 @@ from qpdk.logger import configure_logger, logger
 
 def remove_path_or_dir(dest: Path) -> None:
     """Remove a path or directory."""
-    if not dest.exists():
+    if dest.is_symlink():
+        dest.unlink()
+    elif not dest.exists():
         raise FileNotFoundError(f"Path does not exist: {dest}")
-
-    if dest.is_dir():
+    elif dest.is_dir():
         shutil.rmtree(dest)
     else:
         dest.unlink()

--- a/qpdk/logger.py
+++ b/qpdk/logger.py
@@ -13,16 +13,17 @@ FANCY_FORMAT = (
 )
 
 
-def configure_logger(level: str = "INFO"):
+def configure_logger(level: str = "INFO", log_format: str = FANCY_FORMAT):
     """Configures the logger with a fancy format.
 
     Args:
         level: The logging level to use.
+        log_format: The format to use.
     """
     logger.remove()  # Remove default handler
     logger.add(
         sys.stderr,
-        format=FANCY_FORMAT,
+        format=log_format,
         level=level,
         colorize=True,
     )


### PR DESCRIPTION
This PR refactors the technology installation script for cleaner CLI output and improved robustness.

### Changes
- **Cleaner Output**: Simplified logger format in `install_tech.py` and implemented lazy logging for better performance.
- **Bug Fixes**: Corrected symlink creation logic in `make_link` and added specialized symlink handling in `remove_path_or_dir` to prevent `shutil.rmtree` errors.
- **Flexible Logging**: Updated `qpdk/logger.py` to support custom log formats across the PDK.

## Summary by Sourcery

Improve technology installation script output and robustness while making logger configuration more flexible.

Bug Fixes:
- Prevent errors when removing existing symlinked technology paths before reinstalling.
- Correct symlink creation by linking from the destination path to the source directory with appropriate directory handling.

Enhancements:
- Streamline CLI logging messages in the technology installer for clearer user feedback.
- Allow the shared logger configuration to accept a customizable log format, enabling simpler output styles for specific scripts.