### PR TITLE
ci(dependabot): switch to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,28 @@
 version: 2
 updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: monthly
-
-  - package-ecosystem: github-actions
-    cooldown:
-      default-days: 7
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "doplaydo/*"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,15 @@
 version: 2
 updates:
-  - package-ecosystem: uv
-    directory: /
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: monthly
-    cooldown:
-      default-days: 7
+
   - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly
-    cooldown:
-      default-days: 7
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-  - package-ecosystem: pre-commit
-    directory: /
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
+    ignore:
+      - dependency-name: "doplaydo/*"


### PR DESCRIPTION
Replaces the old pip-based Dependabot config with the centralized template from `doplaydo/pdk-ci-workflow/templates/.github/dependabot.yml`:

- `package-ecosystem: uv` (requires `uv.lock`)
- 7-day cooldown on github-actions updates
- Ignores `doplaydo/*` action updates (managed centrally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align Dependabot configuration with the centralized uv-based template and streamline monitored ecosystems.

CI:
- Configure Dependabot to use the uv package ecosystem with a monthly update schedule.
- Limit Dependabot monitoring to uv and GitHub Actions, removing docker and pre-commit ecosystems.
- Add a cooldown period and ignore rule for doplaydo/* GitHub Actions updates.