### PR TITLE
ci(dependabot): switch to uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,30 @@
 version: 2
 updates:
-  - package-ecosystem: "uv"
-    cooldown:
-      default-days: 7
-    directory: "/"
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "doplaydo/*"
-
-  - package-ecosystem: github-actions
-    cooldown:
-      default-days: 7
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "doplaydo/*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    ignore:
+      - dependency-name: "doplaydo/*"
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: uv
-    directory: /
-    schedule:
-      interval: monthly
+  - package-ecosystem: "uv"
     cooldown:
       default-days: 7
-  - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     schedule:
       interval: monthly
-    cooldown:
-      default-days: 7
     ignore:
       - dependency-name: "doplaydo/*"
-  - package-ecosystem: docker
+
+  - package-ecosystem: github-actions
+    cooldown:
+      default-days: 7
     directory: /
     schedule:
       interval: monthly
-    cooldown:
-      default-days: 7
-  - package-ecosystem: pre-commit
-    directory: /
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
+    ignore:
+      - dependency-name: "doplaydo/*"


### PR DESCRIPTION
Add uv package-ecosystem with 7-day cooldown and ignore doplaydo/* for both uv and github-actions.

## Summary by Sourcery

Consolidate Dependabot configuration to use uv and GitHub Actions ecosystems with a 7-day cooldown and shared ignore rules.

CI:
- Update Dependabot to manage uv dependencies with a 7-day cooldown and ignore doplaydo/* packages.
- Simplify Dependabot configuration by retaining only uv and GitHub Actions ecosystems and aligning their schedules and ignore rules.