### PR TITLE
Simplify Makefile to a thin shim for just

### DIFF
--- a/.github/.checkmake.ini
+++ b/.github/.checkmake.ini
@@ -1,2 +1,5 @@
 [maxbodylength]
 maxBodyLength = 14
+
+[minphony]
+disabled = true

--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,23 @@
-.PHONY: all install check-lfs test clean help
+.PHONY: docs build dev
 
 # Makefile — compatibility shim for gdsfactory PDK CI tooling
 #
-# This project uses `just` as its primary task runner (see justfile).
-# This Makefile provides the `install` and `test` targets expected by
-# the gdsfactory PDK CI workflows (https://github.com/doplaydo/pdk-ci-workflow),
-# and forwards every other target to just.
+# This project uses `just` as its primary task runner (see justfile)
+# and forwards all targets to just.
 
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := "--list"
 
-all: install ## Default target (alias for install)
+JUST_CMD := uvx --from rust-just just
 
-install: ## Install the package and all development dependencies
-	uv sync --all-extras
+docs:
+	@$(JUST_CMD) docs
 
-check-lfs: ## Check if Git LFS is available and pull LFS files
-	@if ! command -v git-lfs >/dev/null 2>&1; then \
-	echo ""; \
-	echo "Error: Git LFS is not installed!"; \
-	echo ""; \
-	echo "This repository uses Git LFS to store test data files."; \
-	echo "Please install Git LFS before running tests:"; \
-	echo ""; \
-	echo "  Ubuntu/Debian:  sudo apt-get install git-lfs"; \
-	echo "  RHEL/Rocky:     sudo dnf install git-lfs"; \
-	echo "  macOS:          brew install git-lfs"; \
-	echo "  Windows:        Download from https://git-lfs.github.com/"; \
-	echo ""; \
-	echo "After installing, run: git lfs install && git lfs pull"; \
-	echo ""; \
-	exit 1; \
-	fi
-	@echo "Git LFS is available. Pulling LFS files…"
-	@git lfs pull
+build:
+	@$(JUST_CMD) build
 
-test: check-lfs ## Run the full test suite (honors PYTEST_ADDOPTS)
-	uv run --extra models --extra graphics --extra hfss --extra qutip --group dev pytest -n auto
-
-clean: ## Clean up build artifacts
-	@just clean
-
-help: ## Show this help message
-
-	@echo "Makefile targets (compatibility shim — prefer 'just' for development):"
-	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
-	awk 'BEGIN {FS = ":.*## "}; {printf "  %-20s %s\n", $$1, $$2}'
-	@echo ""
-	@echo "Any other target is forwarded to 'just <target>'."
-	@echo "Run 'just --list' for all available commands."
+dev:
+	@$(JUST_CMD) install
 
 # Any target not explicitly defined above is forwarded to just.
 %:
-	@just $@
+	@$(JUST_CMD) $@

--- a/docs/docs.just
+++ b/docs/docs.just
@@ -13,29 +13,6 @@ write-cells:
 write-models:
     @uv run --extra models --group docs .github/write_models.py
 
-# Write Makefile help output to documentation
-[private]
-[group('docs')]
-[working-directory: 'docs']
-[script('uv', 'run', '--script')]
-write-makefile-help:
-    import shutil
-    import subprocess
-    from pathlib import Path
-
-    output_file = Path("makefile_help.txt")
-    result = subprocess.run(  # noqa: S603
-        [shutil.which("make"), "-C", "..", "--no-print-directory", "help"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-    output = result.stdout.rstrip()
-    output_file.write_text(output)
-
-    print(f"Makefile help written to {output_file}")
-
 # Write Justfile help output to documentation
 [private]
 [group('docs')]
@@ -99,7 +76,7 @@ setup-ipython-config-temporary-after:
 [private]
 [parallel]
 [group('docs')]
-docs-prerequisites: write-cells write-models write-justfile-help write-makefile-help copy-sample-notebooks
+docs-prerequisites: write-cells write-models write-justfile-help copy-sample-notebooks
 
 # Build the HTML documentation
 [group('docs')]

--- a/docs/make_commands.md
+++ b/docs/make_commands.md
@@ -5,17 +5,6 @@ A `Makefile` is provided as a thin compatibility layer for the
 for day-to-day development; the Makefile exists so that `make install` and `make test` work out-of-the-box in CI
 environments that expect them.
 
-### Direct targets
-
-```{literalinclude} makefile_help.txt
-:language: text
-```
-
-### How it works
-
-The Makefile provides native implementations for `install` and `test` (including support for the `PYTEST_ADDOPTS`
-environment variable). Every other `make` target is automatically forwarded to `just`:
-
 ```bash
 make docs      # equivalent to: just docs
 make build     # equivalent to: just build


### PR DESCRIPTION
This PR simplifies the `Makefile` by removing redundant implementations and forwarding all targets to `just` using `uvx`.

### Key changes
- Refactored `Makefile` to forward all commands to `just` via `uvx --from rust-just just`.
- Removed redundant custom implementations of `install`, `test`, and `check-lfs` in the `Makefile`.
- Removed `Makefile` help generation from the documentation build process.
- Disabled `minphony` check in `.checkmake.ini`.

## Summary by Sourcery

Simplify the Makefile into a thin shim that delegates core targets to just and streamline related documentation and linting configuration.

Enhancements:
- Replace direct make implementations with a uvx-based just command for docs, build, and dev targets while forwarding all other targets to just.
- Remove Makefile help generation from the docs build and simplify documentation describing Makefile usage.
- Disable the minphony check in the checkmake configuration to align with the reduced set of phony targets.