### PR TITLE
Centralize pre-commit hooks and standardize project configuration

### DIFF
--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -8,6 +8,9 @@ config:
     code_block_line_length: 120
   # Allow punctuation in headings (useful for project names with versions)
   MD026: false
+  # Allow duplicate headings as long as they are not siblings (e.g., "Added" under different versions)
+  MD024:
+    siblings_only: true
   # Disable first-line-h1 rule for docs files that use includes
   MD041: false
 # Ignore specific files or patterns

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,6 @@ repos:
         priority: 10
       - id: check-version-sync
         priority: 10
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: ^uv\.lock$
 # 40: Global trailing-whitespace cleanup
 repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow
-    rev: main
+    rev: 6d46a20ed995ac59e898c16e0eea8f3216c1f147
     hooks:
       - id: check-required-files
         priority: 10
@@ -36,37 +36,42 @@ repos:
         priority: 10
       - id: check-version-sync
         priority: 10
-      - id: trailing-whitespace
-        priority: 40
-      - id: end-of-file-fixer
-        priority: 30
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
       - id: check-yaml
         priority: 10
         exclude: ^(conda\.recipe/meta\.yaml|conda_build/templates/.*\.yaml|docs/click/meta\.yaml|conda/meta\.yaml|conda/construct.yaml|.*\.pic\.yml|conda/constructor/Miniforge3/construct.yaml)
-      - id: check-added-large-files
+      - id: end-of-file-fixer
+        priority: 30
+      - id: trailing-whitespace
+        priority: 40
+      - id: detect-private-key
         priority: 10
-      - id: check-toml
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.9.1
+    hooks:
+      - id: nbstripout
         priority: 10
-      - id: ruff-lint
+        files: ".ipynb"
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+        priority: 10
+        exclude: ^docs/bibliography\.bib$
+        additional_dependencies:
+          - tomli
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff
         priority: 10
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
       - id: ruff-format
         priority: 20
         args: [--config=pyproject.toml]
-      - id: nbstripout
-        priority: 10
-        files: ".ipynb"
-      - id: codespell
-        priority: 10
-        exclude: ^docs/bibliography\.bib$
-      - id: pretty-format-toml
-        priority: 20
-
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: detect-private-key
-        priority: 10
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v0.9.12
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,41 +5,68 @@ exclude: ^uv\.lock$
 # 30: Global end-of-file-fixer
 # 40: Global trailing-whitespace cleanup
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: https://github.com/doplaydo/pdk-ci-workflow
+    rev: main
     hooks:
+      - id: check-required-files
+        priority: 10
+      - id: check-pyproject-sections
+        priority: 10
+      - id: check-package-init
+        priority: 10
+      - id: check-cells-structure
+        priority: 10
+      - id: check-tech-structure
+        priority: 10
+      - id: check-pdk-object
+        priority: 10
+      - id: check-test-structure
+        priority: 10
+      - id: check-makefile-targets
+        priority: 10
+      - id: check-workflows
+        priority: 10
+      - id: check-multi-band
+        priority: 10
+      - id: check-no-raw-layers
+        priority: 10
+      - id: check-no-main-in-cells
+        priority: 10
+      - id: check-precommit-config
+        priority: 10
+      - id: check-version-sync
+        priority: 10
+      - id: trailing-whitespace
+        priority: 40
+      - id: end-of-file-fixer
+        priority: 30
       - id: check-yaml
         priority: 10
         exclude: ^(conda\.recipe/meta\.yaml|conda_build/templates/.*\.yaml|docs/click/meta\.yaml|conda/meta\.yaml|conda/construct.yaml|.*\.pic\.yml|conda/constructor/Miniforge3/construct.yaml)
-      - id: end-of-file-fixer
-        priority: 30
-      - id: trailing-whitespace
-        priority: 40
-      - id: detect-private-key
+      - id: check-added-large-files
         priority: 10
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.9.1
-    hooks:
-      - id: nbstripout
+      - id: check-toml
         priority: 10
-        files: ".ipynb"
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
-    hooks:
-      - id: codespell
-        priority: 10
-        exclude: ^docs/bibliography\.bib$
-        additional_dependencies:
-          - tomli
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
-    hooks:
-      - id: ruff
+      - id: ruff-lint
         priority: 10
         args: [--fix, --exit-non-zero-on-fix, --config=pyproject.toml]
       - id: ruff-format
         priority: 20
         args: [--config=pyproject.toml]
+      - id: nbstripout
+        priority: 10
+        files: ".ipynb"
+      - id: codespell
+        priority: 10
+        exclude: ^docs/bibliography\.bib$
+      - id: pretty-format-toml
+        priority: 20
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: detect-private-key
+        priority: 10
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v0.9.12
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.6] - 2026-04-14
+
+### Fixed
+- Initial pre-commit hook fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,81 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [0.3.6] - 2026-04-14
 
 ### Fixed
 
 - Initial pre-commit hook fixes.
+- Resolved circular imports and implemented lazy-loading for model dependencies.
+- Fixed import redundancy issues ("Module is imported with 'import' and 'import from'").
+
+### Added
+
+- Added fluxonium qubit layout with superinductor and Josephson junction.
+- Introduced Monte Carlo CPW tolerance analysis for resonator simulations.
+- Added component tags and improved svgbob ASCII art diagrams for docstrings.
+- Enabled Google Colab support for notebooks.
+
+### Changed
+
+- Refactored waveguide models to use `sax[rf]`.
+- Switched PyPI publishing to OIDC Trusted Publisher.
+
+## [0.3.5] - 2026-03-29
+
+### Added
+
+- Implemented unimon qubit layout, SAX model, and Hamiltonian.
+- Added `just show` command for interactive component visualization.
+- Added lumped-element resonator with meander inductor.
+
+### Fixed
+
+- Fixed `M1_ETCH` overlap with `M1_DRAW` in `half_circle_coupler`.
+- Resolved LaTeX PDF documentation build warnings and errors.
+
+### Changed
+
+- Increased test coverage from 86% to 93%.
+- Upgraded `pyrefly` to 0.58.0 for stricter type checking.
+
+## [0.3.4] - 2026-03-25
+
+### Added
+
+- Added pulse-level simulation notebook with JAX backend via `qutip-qip`.
+- Introduced NetKet transmon qubit design notebook.
+- Added a component designer agent for quantum device visualization.
+
+### Changed
+
+- Removed `scikit-rf` dependency in favor of consolidated CPW models.
+- Refactored resonator length optimization to utilize Optax and JAX.
+- Migrated documentation from Jupyter Book to pure Sphinx.
+
+## [0.3.3] - 2026-03-12
+
+### Added
+
+- Added HFSS simulation support via PyAEDT and Q2D impedance extraction helpers.
+- Enabled collision checking for CPW route bundles.
+
+### Changed
+
+- Standardized logging using `gf.logger` across the library.
+- Refactored AEDT simulation utilities into a class-based structure.
+
+## [0.3.0] - 2026-03-09
+
+### Added
+
+- Replaced `scikit-rf` backend with JAX-native transmission line models.
+- Added `pymablock` dispersive shift notebook and perturbation theory helpers.
+
+### Changed
+
+- Enhanced models for airbridge physics and SQUID junctions.
+- Optimized cell layouts using `gf.pack`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,5 @@ All notable changes to this project will be documented in this file.
 ## [0.3.6] - 2026-04-14
 
 ### Fixed
+
 - Initial pre-commit hook fixes.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs build dev
+.PHONY: docs build install dev test
 
 # Makefile — compatibility shim for gdsfactory PDK CI tooling
 #
@@ -15,8 +15,14 @@ docs:
 build:
 	@$(JUST_CMD) build
 
-dev:
+install:
 	@$(JUST_CMD) install
+
+dev: install
+	@$(JUST_CMD) install-pre
+
+test:
+	@$(JUST_CMD) test
 
 # Any target not explicitly defined above is forwarded to just.
 %:

--- a/justfile
+++ b/justfile
@@ -34,7 +34,12 @@ update-pre:
 # Run all pre-commit hooks on all files
 [group('lint')]
 run-pre:
-    uvx prek run --all-files
+    @uvx prek run --all-files
+
+# Install pre-commit hooks to run on `git commit`
+[group('lint')]
+install-pre:
+    @uvx prek install
 
 # Build the Python package (install build tool and create dist)
 [group('build')]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = [
   "doroutes>=0.2.0",
   "gdsfactory>=9.39.0,<9.40.0",
-  "typing-extensions>=4.12.0"
+  "typing-extensions>=4.12.0",
 ]
 
 [project.urls]
@@ -104,7 +104,7 @@ docs-models = [
   "scikit-rf",
   "scqubits",
   "sympy",
-  "tqdm"
+  "tqdm",
 ]
 github = ["genbadge[coverage]", "setuptools"]
 lint = ["prek", { include-group = "stubs" }]
@@ -123,8 +123,36 @@ test = [
 requires = ["uv_build>=0.10.8,<0.12.0"]
 build-backend = "uv_build"
 
+[tool.setuptools.package-data]
+"*" = ["*.yaml", "*.lyp", "*.lyt", "*.csv", "*.gds", "*.oas"]
+
+[tool.tbump]
+[[tool.tbump.file]]
+src = "pyproject.toml"
+
+[[tool.tbump.file]]
+src = "qpdk/__init__.py"
+
+[[tool.tbump.file]]
+src = "README.md"
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "0.3.6"
+
+[tool.mypy]
+strict = true
+
+[tool.towncrier]
+directory = ".changelog.d"
+filename = "CHANGELOG.md"
+template = ".changelog.d/changelog_template.jinja"
+
 [tool.codespell]
-ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, scheme, Commun, Ue, inout"
+ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, scheme, schem, Commun, Ue, inout"
 skip = "bibliography.bib"
 
 [tool.coverage.run]
@@ -291,6 +319,7 @@ select = [
   "DOC",  # pydoclint
   "ASYNC",  # flake8-async
   "TID",  # flake8-tidy-imports
+  "C",  # flake8-comprehensions
 ]
 
 [tool.ruff.lint.flake8-tidy-imports]
@@ -310,7 +339,7 @@ require-lazy = [
   "pymablock",
   "qutip-jax",
   "qutip-qip",
-  "scqubits"
+  "scqubits",
 ]
 
 [tool.ruff.lint.isort]
@@ -318,6 +347,8 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 "notebooks/**/*.py" = ["D100", "T201"]
+"qpdk/cells/__init__.py" = ["F403"]
+"qpdk/models/__init__.py" = ["F403"]
 "qpdk/**/__init__.py" = ["F403"]  # allowing star imports to aggregate cells
 "qpdk/samples/**/*.py" = [
   "D100",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,34 +123,6 @@ test = [
 requires = ["uv_build>=0.10.8,<0.12.0"]
 build-backend = "uv_build"
 
-[tool.setuptools.package-data]
-"*" = ["*.yaml", "*.lyp", "*.lyt", "*.csv", "*.gds", "*.oas"]
-
-[tool.tbump]
-[[tool.tbump.file]]
-src = "pyproject.toml"
-
-[[tool.tbump.file]]
-src = "qpdk/__init__.py"
-
-[[tool.tbump.file]]
-src = "README.md"
-
-[tool.tbump.git]
-message_template = "Bump to {new_version}"
-tag_template = "v{new_version}"
-
-[tool.tbump.version]
-current = "0.3.6"
-
-[tool.mypy]
-strict = true
-
-[tool.towncrier]
-directory = ".changelog.d"
-filename = "CHANGELOG.md"
-template = ".changelog.d/changelog_template.jinja"
-
 [tool.codespell]
 ignore-words-list = "te, te/tm, te, ba, fpr, fpr_spacing, ro, nd, donot, scheme, schem, Commun, Ue, inout"
 skip = "bibliography.bib"
@@ -193,6 +165,9 @@ ignore-nested-functions = true
 ignore-regex = ["^test_.*"]
 omit-covered-files = true
 verbose = 2
+
+[tool.mypy]
+strict = true
 
 [tool.pylsp-mypy]
 enabled = true
@@ -366,8 +341,33 @@ ignore-one-line-docstrings = true
 [tool.ruff.lint.pycodestyle]
 ignore-overlong-task-comments = true
 
+[tool.setuptools.package-data]
+"*" = ["*.yaml", "*.lyp", "*.lyt", "*.csv", "*.gds", "*.oas"]
+
+[tool.tbump]
+[[tool.tbump.file]]
+src = "pyproject.toml"
+
+[[tool.tbump.file]]
+src = "qpdk/__init__.py"
+
+[[tool.tbump.file]]
+src = "README.md"
+
+[tool.tbump.git]
+message_template = "Bump to {new_version}"
+tag_template = "v{new_version}"
+
+[tool.tbump.version]
+current = "0.3.6"
+
 [tool.tombi.schema]
 strict = false
+
+[tool.towncrier]
+directory = ".changelog.d"
+filename = "CHANGELOG.md"
+template = ".changelog.d/changelog_template.jinja"
 
 [tool.uv]
 default-groups = ["dev", "lint", "stubs", "test"]

--- a/qpdk/__init__.py
+++ b/qpdk/__init__.py
@@ -80,4 +80,4 @@ __all__ = [
     "logger",
     "tech",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.6"

--- a/qpdk/cells/__init__.py
+++ b/qpdk/cells/__init__.py
@@ -8,7 +8,6 @@ from .capacitor import *
 from .chip import *
 from .derived import *
 from .fluxonium import *
-from .helpers import *
 from .inductor import *
 from .junction import *
 from .launcher import *

--- a/qpdk/cells/__init__.py
+++ b/qpdk/cells/__init__.py
@@ -2,20 +2,21 @@
 
 import gdsfactory as gf
 
-from qpdk.cells.airbridge import *
-from qpdk.cells.bump import *
-from qpdk.cells.capacitor import *
-from qpdk.cells.chip import *
-from qpdk.cells.derived import *
-from qpdk.cells.fluxonium import *
-from qpdk.cells.inductor import *
-from qpdk.cells.junction import *
-from qpdk.cells.launcher import *
-from qpdk.cells.resonator import *
-from qpdk.cells.snspd import *
-from qpdk.cells.transmon import *
-from qpdk.cells.tsv import *
-from qpdk.cells.unimon import *
-from qpdk.cells.waveguides import *
+from .airbridge import *
+from .bump import *
+from .capacitor import *
+from .chip import *
+from .derived import *
+from .fluxonium import *
+from .helpers import *
+from .inductor import *
+from .junction import *
+from .launcher import *
+from .resonator import *
+from .snspd import *
+from .transmon import *
+from .tsv import *
+from .unimon import *
+from .waveguides import *
 
 circle = gf.components.circle

--- a/qpdk/cells/airbridge.py
+++ b/qpdk/cells/airbridge.py
@@ -170,14 +170,3 @@ def cpw_with_airbridges(
 
     # Create a copy with airbridges using Pydantic model_copy
     return base_xs.model_copy(update={"components_along_path": (component_along_path,)})
-
-
-if __name__ == "__main__":
-    # Example usage and testing
-    from qpdk import PDK
-
-    PDK.activate()
-
-    # Create and display a single airbridge
-    bridge = airbridge()
-    bridge.show()

--- a/qpdk/cells/bump.py
+++ b/qpdk/cells/bump.py
@@ -23,7 +23,7 @@ def indium_bump(diameter: float = 15.0) -> Component:
     c = Component()
     circle = gf.components.circle(radius=diameter / 2, layer=LAYER.IND)
     ref = c.add_ref(circle)
-    ref.move((0, 0))
+    ref.move((0.0, 0.0))
     c.add_port(
         name="center",
         center=(
@@ -36,8 +36,3 @@ def indium_bump(diameter: float = 15.0) -> Component:
         port_type="placement",
     )
     return c
-
-
-if __name__ == "__main__":
-    bump = indium_bump()
-    bump.show()

--- a/qpdk/cells/capacitor.py
+++ b/qpdk/cells/capacitor.py
@@ -9,9 +9,9 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
-from qpdk.cells.helpers import merge_layers_with_etch as _merge_layers_with_etch
 from qpdk.cells.waveguides import add_etch_gap, bend_circular, straight
 from qpdk.tech import LAYER, get_etch_section, get_etch_sections
+from qpdk.utils import merge_layers_with_etch as _merge_layers_with_etch
 
 
 @gf.cell(tags=("capacitors", "couplers"))

--- a/qpdk/cells/capacitor.py
+++ b/qpdk/cells/capacitor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from functools import partial
 from itertools import chain
 from math import ceil, floor
 
@@ -12,7 +11,6 @@ from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
 from qpdk.cells.helpers import merge_layers_with_etch as _merge_layers_with_etch
 from qpdk.cells.waveguides import add_etch_gap, bend_circular, straight
-from qpdk.helper import show_components
 from qpdk.tech import LAYER, get_etch_section, get_etch_sections
 
 
@@ -205,7 +203,7 @@ def interdigital_capacitor(
     )  # total length
     height = fingers * thickness + (fingers - 1) * finger_gap  # total height
     points_1 = [
-        (0, 0),
+        (0.0, 0.0),
         (0, height),
         (thickness + finger_length, height),
         (thickness + finger_length, height - thickness),
@@ -226,7 +224,7 @@ def interdigital_capacitor(
             for i in range(ceil(fingers / 2))
         ),
         (thickness, 0),
-        (0, 0),
+        (0.0, 0.0),
     ]
     c.add_polygon(points_1, layer=layer_metal)
 
@@ -369,7 +367,7 @@ def plate_capacitor(
     pad2 = c.add_ref(single_capacitor)
     pad2.rotate(180)
     pad2.move((width + gap, 0))
-    c.center = (0, 0)
+    c.center = (0.0, 0.0)
 
     # Add ports
     c.add_port(name="o1", port=pad1.ports["o1"])
@@ -435,7 +433,7 @@ def plate_capacitor_single(
     c = Component()
 
     points = [
-        (0, 0),
+        (0.0, 0.0),
         (0, length),
         (width, length),
         (width, 0),
@@ -479,13 +477,3 @@ def plate_capacitor_single(
     c.move((-width / 2, -length / 2))
 
     return c
-
-
-if __name__ == "__main__":
-    show_components(
-        half_circle_coupler,
-        plate_capacitor_single,
-        plate_capacitor,
-        interdigital_capacitor,
-        partial(interdigital_capacitor, half=True),
-    )

--- a/qpdk/cells/chip.py
+++ b/qpdk/cells/chip.py
@@ -4,7 +4,6 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 from qpdk.cells.waveguides import rectangle
-from qpdk.helper import show_components
 
 
 @gf.cell(tags=("chip",))
@@ -28,8 +27,8 @@ def chip_edge(
     # Create the hollow rectangle frame using four rectangles
     rect_configs = [
         {"size": (size[0], width), "position": (0, size[1] - width)},  # Top edge
-        {"size": (size[0], width), "position": (0, 0)},  # Bottom edge
-        {"size": (width, size[1]), "position": (0, 0)},  # Left edge
+        {"size": (size[0], width), "position": (0.0, 0.0)},  # Bottom edge
+        {"size": (width, size[1]), "position": (0.0, 0.0)},  # Left edge
         {"size": (width, size[1]), "position": (size[0] - width, 0)},  # Right edge
     ]
 
@@ -44,10 +43,3 @@ def chip_edge(
         rect.move(config["position"])
 
     return c
-
-
-if __name__ == "__main__":
-    show_components(
-        chip_edge,
-        spacing=50,
-    )

--- a/qpdk/cells/fluxonium.py
+++ b/qpdk/cells/fluxonium.py
@@ -361,12 +361,3 @@ def fluxonium_with_bbox(
 
     c.add_ports(flux_ref.ports)
     return c
-
-
-if __name__ == "__main__":
-    from qpdk.helper import show_components
-
-    show_components(
-        fluxonium,
-        fluxonium_with_bbox,
-    )

--- a/qpdk/cells/fluxonium.py
+++ b/qpdk/cells/fluxonium.py
@@ -10,7 +10,6 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 from klayout.db import DCplxTrans
 
-from qpdk.cells.helpers import add_rect, transform_component
 from qpdk.cells.inductor import meander_inductor
 from qpdk.cells.junction import josephson_junction
 from qpdk.tech import (
@@ -18,6 +17,7 @@ from qpdk.tech import (
     get_etch_section,
     superinductor_cross_section,
 )
+from qpdk.utils import add_rect, transform_component
 
 __all__ = ["fluxonium", "fluxonium_with_bbox"]
 

--- a/qpdk/cells/helpers.py
+++ b/qpdk/cells/helpers.py
@@ -18,6 +18,10 @@ def transform_component(component: gf.Component, transform: DCplxTrans) -> gf.Co
 
     For use with :func:`~gdsfactory.container`.
 
+    Args:
+        component: The component to transform.
+        transform: The complex transformation to apply.
+
     Returns:
         The transformed component.
     """
@@ -86,7 +90,6 @@ _EXCLUDE_LAYERS_DEFAULT_M2 = [
 ]
 
 
-@gf.cell
 def fill_magnetic_vortices(
     component: Component | None = None,
     rectangle_size: tuple[float, float] = (15.0, 15.0),
@@ -255,6 +258,9 @@ def apply_additive_metals(component: Component) -> Component:
 
     TODO: Implement without flattening. Maybe with a KLayout dataprep script?
 
+    Args:
+        component: The component to apply additive metals to.
+
     Returns:
         Component with additive metals applied.
     """
@@ -276,7 +282,6 @@ def apply_additive_metals(component: Component) -> Component:
     return component
 
 
-@gf.cell
 def invert_mask_polarity(component: Component) -> Component:
     """Invert mask polarity of a component.
 
@@ -420,17 +425,3 @@ def remove_metadata_layers(component: Component) -> Component:
                 c.shapes(layer_index).insert(other_region)
 
     return c
-
-
-if __name__ == "__main__":
-    from qpdk import PDK
-    from qpdk.cells.resonator import resonator
-
-    PDK.activate()
-    c = resonator(length=2000)
-    c = apply_additive_metals(c.copy())
-    c = invert_mask_polarity(c)
-    c = add_margin_to_layer(
-        c, layer_margins=[(LAYER.M1_DRAW, 50.0), (LAYER.M2_DRAW, 50.0)]
-    )
-    c.show()

--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -520,12 +520,3 @@ def _draw_interdigital_fingers_right(
             ],
             layer=layer,
         )
-
-
-if __name__ == "__main__":
-    from qpdk.helper import show_components
-
-    show_components(
-        meander_inductor,
-        lumped_element_resonator,
-    )

--- a/qpdk/cells/junction.py
+++ b/qpdk/cells/junction.py
@@ -8,7 +8,6 @@ from gdsfactory.typings import ComponentSpec, CrossSectionSpec, LayerSpec
 from klayout.db import DCplxTrans
 
 from qpdk.cells.waveguides import straight
-from qpdk.helper import show_components
 from qpdk.tech import (
     LAYER,
     josephson_junction_cross_section_narrow,
@@ -296,7 +295,3 @@ def squid_junction(
         port_type="placement",
     )
     return c
-
-
-if __name__ == "__main__":
-    show_components(josephson_junction, squid_junction)

--- a/qpdk/cells/launcher.py
+++ b/qpdk/cells/launcher.py
@@ -92,14 +92,3 @@ def launcher(
     )
 
     return c
-
-
-if __name__ == "__main__":
-    # Example usage and testing
-    from qpdk import PDK
-
-    PDK.activate()
-
-    # Create and display a launcher with default parameters
-    c = launcher()
-    c.show()

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -10,7 +10,6 @@ from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
 from qpdk.cells.waveguides import bend_circular, straight
-from qpdk.helper import show_components
 from qpdk.tech import get_etch_section
 
 
@@ -396,21 +395,3 @@ def quarter_wave_resonator_coupled(
             c.add_port(port=port)
 
     return c
-
-
-if __name__ == "__main__":
-    show_components(
-        resonator,
-        resonator_quarter_wave,
-        resonator_half_wave,
-        resonator_quarter_wave_bend_start,
-        resonator_quarter_wave_bend_both,
-        resonator_coupled,
-        partial(
-            resonator_coupled,
-            length=2000,
-            meanders=4,
-            open_start=False,
-            open_end=True,
-        ),
-    )

--- a/qpdk/cells/snspd.py
+++ b/qpdk/cells/snspd.py
@@ -116,12 +116,3 @@ def snspd(
     D.info["ysize"] = ysize
     D.flatten()
     return D
-
-
-if __name__ == "__main__":
-    from qpdk import PDK
-
-    PDK.activate()
-
-    c = snspd()
-    c.show()

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -17,7 +17,6 @@ from qpdk.cells.helpers import (
     transform_component,
 )
 from qpdk.cells.junction import squid_junction, squid_junction_long
-from qpdk.helper import show_components
 from qpdk.tech import LAYER
 
 
@@ -535,22 +534,3 @@ def xmon_transmon(
     c.info["qubit_type"] = "xmon"
 
     return c
-
-
-if __name__ == "__main__":
-    show_components(
-        double_pad_transmon,
-        partial(double_pad_transmon, junction_displacement=DCplxTrans(0, 150)),
-        double_pad_transmon_with_bbox,
-        flipmon,
-        flipmon_with_bbox,
-        xmon_transmon,
-    )
-
-    # Visualize flip-chip flipmon
-    # c = gf.Component()
-    # (c << flipmon_with_bbox()).move((0, 0))
-    # c << rectangle(size=(500, 500), layer=LAYER.SIM_AREA, centered=True)
-    # to_stl(c, "flipmon.stl", layer_stack=LAYER_STACK_FLIP_CHIP)
-    # scene = c.to_3d(layer_stack=LAYER_STACK_FLIP_CHIP)
-    # scene.show()

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -12,12 +12,12 @@ from kfactory import kdb
 from klayout.db import DCplxTrans, Region
 
 from qpdk.cells.bump import indium_bump
-from qpdk.cells.helpers import (
+from qpdk.cells.junction import squid_junction, squid_junction_long
+from qpdk.tech import LAYER
+from qpdk.utils import (
     subtract_draw_from_etch as _subtract_draw_from_etch,
     transform_component,
 )
-from qpdk.cells.junction import squid_junction, squid_junction_long
-from qpdk.tech import LAYER
 
 
 @gf.cell(check_instances=False, tags=("qubits", "transmons"))

--- a/qpdk/cells/tsv.py
+++ b/qpdk/cells/tsv.py
@@ -23,7 +23,7 @@ def tsv(diameter: float = 15.0) -> Component:
     c = Component()
     circle = gf.components.circle(radius=diameter / 2, layer=LAYER.TSV)
     ref = c.add_ref(circle)
-    ref.move((0, 0))
+    ref.move((0.0, 0.0))
     c.add_port(
         name="center",
         center=(
@@ -36,8 +36,3 @@ def tsv(diameter: float = 15.0) -> Component:
         port_type="placement",
     )
     return c
-
-
-if __name__ == "__main__":
-    c = tsv()
-    c.show()

--- a/qpdk/cells/unimon.py
+++ b/qpdk/cells/unimon.py
@@ -25,7 +25,6 @@ from qpdk.cells.capacitor import half_circle_coupler
 from qpdk.cells.junction import josephson_junction, squid_junction
 from qpdk.cells.resonator import resonator
 from qpdk.cells.waveguides import bend_circular, straight
-from qpdk.helper import show_components
 from qpdk.tech import LAYER, get_etch_section
 
 
@@ -37,7 +36,18 @@ def unimon_arm(
     cross_section: CrossSectionSpec = "cpw",
     junction_gap: float = 6.0,
 ) -> Component:
-    """Creates a quarter-wave resonator arm for the unimon qubit."""
+    """Creates a quarter-wave resonator arm for the unimon qubit.
+
+    Args:
+        arm_length: Length of the resonator arm in µm.
+        arm_meanders: Number of meanders in the arm.
+        bend_spec: Specification for the bend component.
+        cross_section: Cross-section specification for the arm.
+        junction_gap: Gap for the junction in µm.
+
+    Returns:
+        Component: The quarter-wave resonator arm component.
+    """
     c = Component()
     cross_section_obj = gf.get_cross_section(cross_section)
     bend = gf.get_component(
@@ -194,7 +204,7 @@ def unimon(
     junction_comp = gf.get_component(junction_spec)
     junction_ref = c.add_ref(junction_comp)
     junction_ref.dcplx_trans *= kdb.DCplxTrans(1, -45, False, 0, 0)
-    junction_ref.dcenter = (0, 0)
+    junction_ref.dcenter = (0.0, 0.0)
 
     gap_comp = gf.c.rectangle(
         size=(junction_gap, junction_etch_width),
@@ -205,7 +215,7 @@ def unimon(
     )
 
     gap_ref = c.add_ref(gap_comp)
-    gap_ref.dcenter = (0, 0)
+    gap_ref.dcenter = (0.0, 0.0)
     gap_ref.rotate(90)
 
     arm_top_ref = c.add_ref(arm)
@@ -376,11 +386,3 @@ def unimon_coupled(
     c.info["coupling_radius"] = coupling_radius
 
     return c
-
-
-if __name__ == "__main__":
-    show_components(
-        unimon,
-        partial(unimon, arm_length=2000, arm_meanders=4),
-        unimon_coupled,
-    )

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -8,7 +8,6 @@ from kfactory import VInstance
 from klayout.db import DCplxTrans
 
 from qpdk import tech
-from qpdk.helper import show_components
 from qpdk.logger import logger
 from qpdk.tech import get_etch_section
 
@@ -28,7 +27,7 @@ def rectangle(
     Args:
         size: (tuple) Width and height of rectangle.
         layer: Specific layer to put polygon geometry on.
-        centered: True sets center to (0, 0), False sets south-west to (0, 0).
+        centered: True sets center to (0.0, 0.0), False sets south-west to (0.0, 0.0).
         port_type: optical, electrical.
         port_orientations: list of port_orientations to add. None adds no ports.
     """
@@ -201,7 +200,7 @@ def tee(cross_section: CrossSectionSpec = "cpw") -> gf.Component:
     )
 
     # center
-    c.center = (0, 0)
+    c.center = (0.0, 0.0)
 
     return c
 
@@ -446,22 +445,3 @@ def add_etch_gap(
     )
     etch_ref.transform(port.dcplx_trans * DCplxTrans(etch_section.width / 2, 0))
     return etch_ref
-
-
-if __name__ == "__main__":
-    show_components(
-        taper_cross_section,
-        bend_euler,
-        bend_circular,
-        tee,
-        bend_s,
-        straight,
-        coupler_ring,
-        coupler_straight,
-        partial(straight_open, length=20),
-        partial(straight_double_open, length=20),
-        straight_all_angle,
-        partial(bend_euler_all_angle, angle=33),
-        rectangle,
-        spacing=50,
-    )

--- a/qpdk/samples/filled_resonator.py
+++ b/qpdk/samples/filled_resonator.py
@@ -16,9 +16,9 @@
 # %%
 import gdsfactory as gf
 
-from qpdk.cells.helpers import fill_magnetic_vortices
 from qpdk.cells.resonator import resonator_quarter_wave
 from qpdk.tech import LAYER
+from qpdk.utils import fill_magnetic_vortices
 
 # %% [markdown]
 # ## Filled Quarter Wave Resonator Function

--- a/qpdk/samples/filled_test_chip.py
+++ b/qpdk/samples/filled_test_chip.py
@@ -17,8 +17,8 @@ from gdsfactory.read import from_yaml
 
 from qpdk import PDK, tech
 from qpdk.cells.chip import chip_edge
-from qpdk.cells.helpers import apply_additive_metals, fill_magnetic_vortices
 from qpdk.helper import layerenum_to_tuple
+from qpdk.utils import apply_additive_metals, fill_magnetic_vortices
 
 # %% [markdown]
 # # Filled Qubit Test Chip Example

--- a/qpdk/samples/resonator_test_chip.py
+++ b/qpdk/samples/resonator_test_chip.py
@@ -21,7 +21,6 @@ import numpy as np
 
 from qpdk import tech
 from qpdk.cells.chip import chip_edge
-from qpdk.cells.helpers import fill_magnetic_vortices
 from qpdk.cells.launcher import launcher
 from qpdk.cells.resonator import resonator_coupled
 from qpdk.cells.waveguides import straight
@@ -31,6 +30,7 @@ from qpdk.tech import (
     route_bundle_cpw,
     route_bundle_sbend,
 )
+from qpdk.utils import fill_magnetic_vortices
 
 # %% [markdown]
 # ## Resonator Test Chip Function

--- a/qpdk/samples/sample_to_3d.py
+++ b/qpdk/samples/sample_to_3d.py
@@ -17,7 +17,7 @@
 import gdsfactory as gf
 
 from qpdk import PDK, cells, tech
-from qpdk.cells.helpers import apply_additive_metals, fill_magnetic_vortices
+from qpdk.utils import apply_additive_metals, fill_magnetic_vortices
 
 # %% [markdown]
 # ## 3D Sample Function

--- a/qpdk/simulation/aedt_base.py
+++ b/qpdk/simulation/aedt_base.py
@@ -17,13 +17,13 @@ import gdsfactory as gf
 from gdsfactory.technology.layer_stack import LayerLevel
 
 from qpdk import LAYER_STACK
-from qpdk.cells.helpers import (
+from qpdk.tech import LAYER, material_properties
+from qpdk.utils import (
     add_margin_to_layer,
     apply_additive_metals,
     invert_mask_polarity,
     remove_metadata_layers,
 )
-from qpdk.tech import LAYER, material_properties
 
 if TYPE_CHECKING:
     from ansys.aedt.core import Hfss, Q2d

--- a/qpdk/utils.py
+++ b/qpdk/utils.py
@@ -125,7 +125,7 @@ def fill_magnetic_vortices(
 
     Example:
         >>> from qpdk.cells.resonator import resonator_quarter_wave
-        >>> from qpdk.cells.helpers import fill_magnetic_vortices
+        >>> from qpdk.utils import fill_magnetic_vortices
         >>> resonator = resonator_quarter_wave()
         >>> filled_resonator = fill_magnetic_vortices(resonator)
         >>> # Or use with default component

--- a/tests/helper/test_apply_additive_metals.py
+++ b/tests/helper/test_apply_additive_metals.py
@@ -3,10 +3,10 @@
 from gdsfactory import Component
 
 from qpdk import PDK
-from qpdk.cells.helpers import apply_additive_metals
 from qpdk.cells.transmon import flipmon_with_bbox
 from qpdk.helper import layerenum_to_tuple
 from qpdk.tech import LAYER
+from qpdk.utils import apply_additive_metals
 
 ADDITIVE_LAYERS = {
     layerenum_to_tuple(layer_enum) for layer_enum in (LAYER.M1_DRAW, LAYER.M2_DRAW)

--- a/tests/helper/test_boolean_helpers.py
+++ b/tests/helper/test_boolean_helpers.py
@@ -4,7 +4,6 @@ import gdsfactory as gf
 from gdsfactory import Component
 
 from qpdk.cells.capacitor import interdigital_capacitor, plate_capacitor_single
-from qpdk.cells.helpers import merge_layers_with_etch, subtract_draw_from_etch
 from qpdk.cells.transmon import (
     double_pad_transmon_with_bbox,
     flipmon_with_bbox,
@@ -12,6 +11,7 @@ from qpdk.cells.transmon import (
 )
 from qpdk.helper import layerenum_to_tuple
 from qpdk.tech import LAYER
+from qpdk.utils import merge_layers_with_etch, subtract_draw_from_etch
 
 
 def test_merge_layers_with_etch_returns_component():

--- a/tests/helper/test_fill_vortices.py
+++ b/tests/helper/test_fill_vortices.py
@@ -3,9 +3,9 @@
 import gdsfactory as gf
 
 from qpdk import PDK
-from qpdk.cells.helpers import fill_magnetic_vortices
 from qpdk.cells.resonator import resonator_quarter_wave
 from qpdk.tech import LAYER
+from qpdk.utils import fill_magnetic_vortices
 
 
 def test_fill_magnetic_vortices():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,8 +3,8 @@
 import gdsfactory as gf
 import pytest
 
-from qpdk.cells.helpers import add_rect
 from qpdk.tech import LAYER
+from qpdk.utils import add_rect
 
 
 def test_add_rect_x0_x1() -> None:


### PR DESCRIPTION
This PR integrates centralized PDK validation hooks and standardizes development tooling across the repository.

Main changes:
- Added `doplaydo/pdk-ci-workflow` to pre-commit for unified PDK structural and content validation.
- Standardized `pyproject.toml` configurations for `pytest`, `mypy`, `towncrier`, and `tbump`.
- Added `dev` and `docs` optional dependency groups.
- Cleaned up cell definitions in `qpdk/cells/` by removing `if __name__ == "__main__":` blocks and switching to relative imports.
- Updated project version to 0.3.6 and initialized `CHANGELOG.md`.

## Summary by Sourcery

Centralize development tooling and PDK validation by updating configuration, housekeeping cell utilities, and aligning versioning and changelog metadata.

New Features:
- Introduce centralized PDK validation via shared pre-commit hooks.
- Add CHANGELOG.md and configure towncrier and tbump for managed releases.

Bug Fixes:
- Remove __main__ entry points from cell modules and adjust coordinates and centers to normalized float values for layout consistency.

Enhancements:
- Standardize project tooling configuration for mypy, ruff, setuptools package data, markdownlint, and related linters.
- Refactor cell and utility modules to use relative imports, a shared qpdk.utils module, and clearer docstrings.
- Align Makefile and just tasks for install, dev, test, and pre-commit hook installation.

CI:
- Add a centralized pdk-ci-workflow repository to pre-commit for structural, content, and workflow checks across the PDK.

Documentation:
- Initialize a Keep a Changelog–style CHANGELOG.md documenting recent versions.

Tests:
- Update tests to import helper utilities from the new qpdk.utils module path.