### PR TITLE
ci: skip docs build and claude review for dependabot PRs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,8 +12,10 @@ on:
   workflow_dispatch:
 jobs:
   get-python-versions:
+    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/get-python-versions.yml
   build-docs:
+    if: github.actor != 'dependabot[bot]'
     needs: get-python-versions
     runs-on: ubuntu-latest
     name: Build HTML docs
@@ -68,6 +70,7 @@ jobs:
           echo "latest-python=$latest" >> "$GITHUB_OUTPUT"
           echo "Latest Python version: $latest"
   build-docs-pdf:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: Build PDF docs
     steps:


### PR DESCRIPTION
## Summary
- Skip Sphinx docs build on Dependabot PRs (saves CI minutes)
- Skip Claude PR review on Dependabot PRs
- Ignore `jupyter-book` in Dependabot updates (if applicable)

## Test plan
- [ ] Verify Dependabot PRs no longer trigger docs build or Claude review
- [ ] Verify regular PRs still trigger all jobs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add conditional checks to skip Sphinx HTML and PDF documentation build jobs when the workflow is triggered by dependabot[bot].