### PR TITLE
add type tags to all @cell components

### DIFF
--- a/notebooks/src/optimize_capacitor_optuna.py
+++ b/notebooks/src/optimize_capacitor_optuna.py
@@ -55,7 +55,7 @@ from qpdk.tech import LAYER, material_properties
 
 
 # %%
-@gf.cell
+@gf.cell(tags={"type": "optimize_capacitor_optuna"})
 def capacitor_simulation(
     finger_length: float = 20.0,
     finger_gap: float = 2.0,

--- a/qpdk/cells/airbridge.py
+++ b/qpdk/cells/airbridge.py
@@ -15,7 +15,7 @@ from qpdk import tech
 from qpdk.tech import LAYER
 
 
-@gf.cell(tags=("interconnects",))
+@gf.cell(tags=("interconnects",), tags={"type": "airbridge"})
 def airbridge(
     bridge_length: float = 30.0,
     bridge_width: float = 8.0,

--- a/qpdk/cells/bump.py
+++ b/qpdk/cells/bump.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from qpdk.tech import LAYER
 
 
-@gf.cell(tags=("interconnects", "flip-chip", "3d-integration"))
+@gf.cell(tags=("interconnects", "flip-chip", "3d-integration"), tags={"type": "bump"})
 def indium_bump(diameter: float = 15.0) -> Component:
     """Creates an indium bump component for 3D integration.
 

--- a/qpdk/cells/capacitor.py
+++ b/qpdk/cells/capacitor.py
@@ -16,7 +16,7 @@ from qpdk.helper import show_components
 from qpdk.tech import LAYER, get_etch_section, get_etch_sections
 
 
-@gf.cell(tags=("capacitors", "couplers"))
+@gf.cell(tags=("capacitors", "couplers"), tags={"type": "capacitor"})
 def half_circle_coupler(
     radius: float = 50.0,
     angle: float = 180.0,
@@ -139,7 +139,7 @@ def half_circle_coupler(
     return c
 
 
-@gf.cell(tags=("capacitors",))
+@gf.cell(tags=("capacitors",), tags={"type": "capacitor"})
 def interdigital_capacitor(
     fingers: int = 4,
     finger_length: float = 20.0,
@@ -313,7 +313,7 @@ def interdigital_capacitor(
     return c
 
 
-@gf.cell(tags=("capacitors",))
+@gf.cell(tags=("capacitors",), tags={"type": "capacitor"})
 def plate_capacitor(
     length: float = 26.0,
     width: float = 5.0,
@@ -390,7 +390,7 @@ def plate_capacitor(
     return c
 
 
-@gf.cell(tags=("capacitors", "couplers"))
+@gf.cell(tags=("capacitors", "couplers"), tags={"type": "capacitor"})
 def plate_capacitor_single(
     length: float = 26.0,
     width: float = 5.0,

--- a/qpdk/cells/chip.py
+++ b/qpdk/cells/chip.py
@@ -7,7 +7,7 @@ from qpdk.cells.waveguides import rectangle
 from qpdk.helper import show_components
 
 
-@gf.cell(tags=("chip",))
+@gf.cell(tags=("chip",), tags={"type": "chip"})
 def chip_edge(
     size: tuple[float, float] = (10000.0, 10000.0),
     width: float = 200.0,

--- a/qpdk/cells/derived/transmon_with_resonator_and_probeline.py
+++ b/qpdk/cells/derived/transmon_with_resonator_and_probeline.py
@@ -181,7 +181,7 @@ def _transmon_with_resonator_base(
     return c
 
 
-@gf.cell(tags=("qubits", "transmons", "resonators", "couplers"))
+@gf.cell(tags=("qubits", "transmons", "resonators", "couplers"), tags={"type": "transmon_with_resonator_and_probeline"})
 def transmon_with_resonator_and_probeline(
     qubit: ComponentSpec = "double_pad_transmon_with_bbox",
     resonator: ComponentSpec = partial(
@@ -249,7 +249,7 @@ def transmon_with_resonator_and_probeline(
     )
 
 
-@gf.cell(tags=("qubits", "transmons", "resonators"))
+@gf.cell(tags=("qubits", "transmons", "resonators"), tags={"type": "transmon_with_resonator_and_probeline"})
 def transmon_with_resonator(
     qubit: ComponentSpec = "double_pad_transmon_with_bbox",
     resonator: ComponentSpec = partial(

--- a/qpdk/cells/fluxonium.py
+++ b/qpdk/cells/fluxonium.py
@@ -22,7 +22,7 @@ from qpdk.tech import (
 __all__ = ["fluxonium", "fluxonium_with_bbox"]
 
 
-@gf.cell(check_instances=False, tags=("qubits", "inductors"))
+@gf.cell(check_instances=False, tags=("qubits", "inductors"), tags={"type": "fluxonium"})
 def fluxonium(
     pad_size: tuple[float, float] = (250.0, 400.0),
     pad_gap: float = 25.0,
@@ -287,7 +287,7 @@ def _snap_to_grid(value: float, grid: float = 0.002) -> float:
     return math.ceil(value / grid) * grid
 
 
-@gf.cell(tags=("qubits", "inductors"))
+@gf.cell(tags=("qubits", "inductors"), tags={"type": "fluxonium"})
 def fluxonium_with_bbox(
     bbox_extension: float = 200.0,
     pad_size: tuple[float, float] = (250.0, 400.0),

--- a/qpdk/cells/helpers.py
+++ b/qpdk/cells/helpers.py
@@ -86,7 +86,7 @@ _EXCLUDE_LAYERS_DEFAULT_M2 = [
 ]
 
 
-@gf.cell
+@gf.cell(tags={"type": "helpers"})
 def fill_magnetic_vortices(
     component: Component | None = None,
     rectangle_size: tuple[float, float] = (15.0, 15.0),
@@ -276,7 +276,7 @@ def apply_additive_metals(component: Component) -> Component:
     return component
 
 
-@gf.cell
+@gf.cell(tags={"type": "helpers"})
 def invert_mask_polarity(component: Component) -> Component:
     """Invert mask polarity of a component.
 

--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -15,7 +15,7 @@ from qpdk.tech import (
 )
 
 
-@gf.cell(tags=("inductors",))
+@gf.cell(tags=("inductors",), tags={"type": "inductor"})
 def meander_inductor(
     n_turns: int = 5,
     turn_length: float = 200.0,
@@ -194,7 +194,7 @@ def meander_inductor(
     return c
 
 
-@gf.cell(tags=("resonators", "inductors", "capacitors"))
+@gf.cell(tags=("resonators", "inductors", "capacitors"), tags={"type": "inductor"})
 def lumped_element_resonator(
     fingers: int = 20,
     finger_length: float = 20.0,

--- a/qpdk/cells/junction.py
+++ b/qpdk/cells/junction.py
@@ -16,7 +16,7 @@ from qpdk.tech import (
 )
 
 
-@gf.cell(tags=("junctions",))
+@gf.cell(tags=("junctions",), tags={"type": "junction"})
 def single_josephson_junction_wire(
     wide_straight_length: float = 8.3,
     narrow_straight_length: float = 0.5,
@@ -98,7 +98,7 @@ def single_josephson_junction_wire(
     return c
 
 
-@gf.cell(tags=("junctions",))
+@gf.cell(tags=("junctions",), tags={"type": "junction"})
 def josephson_junction(
     junction_overlap_displacement: float = 1.8,
     wide_straight_length: float = 8.3,
@@ -204,7 +204,7 @@ def josephson_junction(
     return c
 
 
-@gf.cell(tags=("junctions",))
+@gf.cell(tags=("junctions",), tags={"type": "junction"})
 def josephson_junction_long(**kwargs) -> Component:
     """Josephson junction with wide_straight_length=12.
 
@@ -214,7 +214,7 @@ def josephson_junction_long(**kwargs) -> Component:
     return josephson_junction(wide_straight_length=12, **kwargs)
 
 
-@gf.cell(tags=("junctions",))
+@gf.cell(tags=("junctions",), tags={"type": "junction"})
 def squid_junction_long(**kwargs) -> Component:
     """SQUID junction with josephson_junction_long.
 
@@ -224,7 +224,7 @@ def squid_junction_long(**kwargs) -> Component:
     return squid_junction(junction_spec=josephson_junction_long, **kwargs)
 
 
-@gf.cell(tags=("junctions",))
+@gf.cell(tags=("junctions",), tags={"type": "junction"})
 def squid_junction(
     junction_spec: ComponentSpec = josephson_junction,
     loop_area: float = 4,

--- a/qpdk/cells/launcher.py
+++ b/qpdk/cells/launcher.py
@@ -26,6 +26,7 @@ LAUNCHER_CROSS_SECTION_SMALL = partial(coplanar_waveguide, etch_layer=LAYER.M1_E
     tags=(
         "waveguides",
         "interconnects",
+    tags={"type": "launcher"},
     )
 )
 def launcher(

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -14,7 +14,7 @@ from qpdk.helper import show_components
 from qpdk.tech import get_etch_section
 
 
-@gf.cell(tags=("resonators",))
+@gf.cell(tags=("resonators",), tags={"type": "resonator"})
 def resonator(
     length: float = 4000.0,
     meanders: int = 6,
@@ -225,7 +225,7 @@ resonator_half_wave_bend_both = partial(
 )
 
 
-@gf.cell(tags=("resonators", "couplers"))
+@gf.cell(tags=("resonators", "couplers"), tags={"type": "resonator"})
 def resonator_coupled(
     length: float = 4000.0,
     meanders: int = 6,
@@ -323,7 +323,7 @@ def resonator_coupled(
     return c
 
 
-@gf.cell(tags=("resonators", "couplers"))
+@gf.cell(tags=("resonators", "couplers"), tags={"type": "resonator"})
 def quarter_wave_resonator_coupled(
     length: float = 4000.0,
     meanders: int = 6,

--- a/qpdk/cells/snspd.py
+++ b/qpdk/cells/snspd.py
@@ -10,7 +10,7 @@ from gdsfactory.typings import LayerSpec, Port, Size
 from qpdk.tech import LAYER
 
 
-@gf.cell(tags=("detectors",))
+@gf.cell(tags=("detectors",), tags={"type": "snspd"})
 def snspd(
     wire_width: float = 0.2,
     wire_pitch: float = 0.6,

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -21,7 +21,7 @@ from qpdk.helper import show_components
 from qpdk.tech import LAYER
 
 
-@gf.cell(check_instances=False, tags=("qubits", "transmons"))
+@gf.cell(check_instances=False, tags=("qubits", "transmons"), tags={"type": "transmon"})
 def double_pad_transmon(
     pad_size: tuple[float, float] = (250.0, 400.0),
     pad_gap: float = 15.0,
@@ -129,7 +129,7 @@ def double_pad_transmon(
     return c
 
 
-@gf.cell(tags=("qubits", "transmons"))
+@gf.cell(tags=("qubits", "transmons"), tags={"type": "transmon"})
 def double_pad_transmon_with_bbox(
     bbox_extension: float = 200.0,
     pad_size: tuple[float, float] = (250.0, 400.0),
@@ -192,7 +192,7 @@ def double_pad_transmon_with_bbox(
     return c
 
 
-@gf.cell(check_instances=False, tags=("qubits", "transmons", "flip-chip"))
+@gf.cell(check_instances=False, tags=("qubits", "transmons", "flip-chip"), tags={"type": "transmon"})
 def flipmon(
     inner_circle_radius: float = 60.0,
     outer_ring_radius: float = 110.0,
@@ -321,7 +321,7 @@ def flipmon(
     return c
 
 
-@gf.cell(tags=("qubits", "transmons", "flip-chip"))
+@gf.cell(tags=("qubits", "transmons", "flip-chip"), tags={"type": "transmon"})
 def flipmon_with_bbox(
     inner_circle_radius: float = 60.0,
     outer_ring_radius: float = 110.0,
@@ -389,7 +389,7 @@ def flipmon_with_bbox(
     return c
 
 
-@gf.cell(check_instances=False, tags=("qubits", "transmons"))
+@gf.cell(check_instances=False, tags=("qubits", "transmons"), tags={"type": "transmon"})
 def xmon_transmon(
     arm_width: tuple[float, float, float, float] = (30.0, 20.0, 30.0, 20.0),
     arm_lengths: tuple[float, float, float, float] = (160.0, 120.0, 160.0, 120.0),

--- a/qpdk/cells/tsv.py
+++ b/qpdk/cells/tsv.py
@@ -8,7 +8,7 @@ from gdsfactory.component import Component
 from qpdk.tech import LAYER
 
 
-@gf.cell(tags=("interconnects", "3d-integration"))
+@gf.cell(tags=("interconnects", "3d-integration"), tags={"type": "tsv"})
 def tsv(diameter: float = 15.0) -> Component:
     """Creates a Through-silicon via (TSV) component for 3D integration.
 

--- a/qpdk/cells/unimon.py
+++ b/qpdk/cells/unimon.py
@@ -29,7 +29,7 @@ from qpdk.helper import show_components
 from qpdk.tech import LAYER, get_etch_section
 
 
-@gf.cell(tags=("qubits", "resonators"))
+@gf.cell(tags=("qubits", "resonators"), tags={"type": "unimon"})
 def unimon_arm(
     arm_length: float = 3000.0,
     arm_meanders: int = 6,
@@ -118,7 +118,7 @@ def unimon_arm(
     return c
 
 
-@gf.cell(check_instances=False, tags=("qubits",))
+@gf.cell(check_instances=False, tags=("qubits",), tags={"type": "unimon"})
 def unimon(
     arm_length: float = 3000.0,
     arm_meanders: int = 6,
@@ -253,7 +253,7 @@ def unimon(
     return c
 
 
-@gf.cell(tags=("qubits", "couplers"))
+@gf.cell(tags=("qubits", "couplers"), tags={"type": "unimon"})
 def unimon_coupled(
     arm_length: float = 3000.0,
     arm_meanders: int = 6,

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -15,7 +15,7 @@ from qpdk.tech import get_etch_section
 _DEFAULT_CROSS_SECTION = tech.cpw
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def rectangle(
     size: Size = (4.0, 2.0),
     layer: LayerSpec = "M1_DRAW",
@@ -51,7 +51,7 @@ taper_cross_section = partial(
 )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def straight(
     length: float = 10.0,
     cross_section: CrossSectionSpec = _DEFAULT_CROSS_SECTION,
@@ -74,7 +74,7 @@ def straight(
 straight_shorted = straight
 
 
-@gf.cell(tags=("waveguides", "resonators"))
+@gf.cell(tags=("waveguides", "resonators"), tags={"type": "waveguides"})
 def straight_open(
     length: float = 10.0,
     cross_section: CrossSectionSpec = _DEFAULT_CROSS_SECTION,
@@ -99,7 +99,7 @@ def straight_open(
     return c
 
 
-@gf.cell(tags=("waveguides", "resonators"))
+@gf.cell(tags=("waveguides", "resonators"), tags={"type": "waveguides"})
 def straight_double_open(
     length: float = 10.0,
     cross_section: CrossSectionSpec = _DEFAULT_CROSS_SECTION,
@@ -127,7 +127,7 @@ def straight_double_open(
     return c
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def nxn(
     xsize: float = 10.0,
     ysize: float = 10.0,
@@ -168,7 +168,7 @@ def nxn(
     )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def tee(cross_section: CrossSectionSpec = "cpw") -> gf.Component:
     """Returns a three-way tee waveguide.
 
@@ -206,7 +206,7 @@ def tee(cross_section: CrossSectionSpec = "cpw") -> gf.Component:
     return c
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def bend_euler(
     angle: float = 90.0,
     p: float = 0.5,
@@ -241,7 +241,7 @@ def bend_euler(
     )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def bend_circular(
     angle: float = 90.0,
     radius: float = 100.0,
@@ -286,7 +286,7 @@ def bend_circular(
     )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), tags={"type": "waveguides"})
 def bend_s(
     size: Size = (20.0, 3.0),
     cross_section: CrossSectionSpec = _DEFAULT_CROSS_SECTION,


### PR DESCRIPTION
## Summary
- Adds `tags={"type": "<filename>"}` to all `@gf.cell` and `@gf.cell_with_module_name` decorators
- Type is derived from the source filename (e.g., `waveguides.py` → `"waveguides"`, `couplers.py` → `"couplers"`)
- Enables filtering and categorization of components by type

Mirrors the change in gdsfactory: https://github.com/gdsfactory/gdsfactory/commit/4c216c5ef

## Test plan
- [ ] Verify all cells still instantiate correctly via `make test`
- [ ] Check that tags appear in cell metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add type-based metadata tags to all gdsfactory cell components for consistent categorization and filtering across the library.

Enhancements:
- Annotate all @gf.cell components with a type tag derived from their defining module (e.g., capacitor, waveguides, junction, transmon).
- Extend helper, notebook, and derived cells with consistent type tags to support metadata-driven discovery and organization of components.