### PR TITLE
ci: set artifact retention to 1 day

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
       - run: just build
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
+          retention-days: 1
           name: dist
           path: dist
           compression-level: 9

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,7 @@ jobs:
       - run: just docs
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
+          retention-days: 1
           name: html-docs-${{ matrix.python-version }}
           path: "./docs/_build/html/"
   build-docs-result:
@@ -111,6 +112,7 @@ jobs:
           args: -pdfxe -xelatex -interaction=nonstopmode -f -file-line-error
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
+          retention-days: 1
           name: pdf-docs
           path: "./docs/_build/latex/qpdk.pdf"
   deploy-docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
+          retention-days: 1
           name: coverage-report-${{ matrix.python-version }}
           path: htmlcov
   test-code-result:


### PR DESCRIPTION
Set retention-days: 1 on upload-artifact steps to reduce storage usage.

## Summary by Sourcery

CI:
- Configure all upload-artifact steps in CI workflows to retain artifacts for only one day.