### PR TITLE
Ignore jupyter-book in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       default-days: 7
     ignore:
       - dependency-name: "doplaydo/*"
+      - dependency-name: "jupyter-book"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary
- Add jupyter-book to dependabot ignore list to prevent unnecessary update PRs

## Summary by Sourcery

Build:
- Add jupyter-book to Dependabot's ignore list for version update checks.