### PR TITLE
Update zizmor configuration for Claude PR Review workflow

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,16 @@
+name: Claude PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+jobs:
+  review:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,13 @@
 rules:
   unpinned-uses:
-    disable: false
+    ignore:
+      - "claude-pr-review.yml"
+  excessive-permissions:
+    ignore:
+      - "claude-pr-review.yml"
+  secrets-inherit:
+    ignore:
+      - "claude-pr-review.yml"
   dangerous-triggers:
     ignore:
       - "pages.yml"


### PR DESCRIPTION
Adds Claude PR review from `doplaydo/pdk-ci-workflow` and ignore rules to `.github/zizmor.yml` for the Claude PR Review workflow to allow using `@main` and `secrets: inherit`.

## Summary by Sourcery

Configure a reusable Claude PR Review GitHub Actions workflow and adjust zizmor rules to allow its use.

Build:
- Add a Claude PR Review reusable workflow that runs on pull request and issue_comment events.
- Update zizmor configuration to ignore specific checks for the Claude PR Review workflow using the shared workflow on @main with inherited secrets.