### PR TITLE
Fix for Variable defined multiple times

### DIFF
--- a/qpdk/utils.py
+++ b/qpdk/utils.py
@@ -362,8 +362,6 @@ def add_margin_to_layer(
 
     bbox = component.bbox()
 
-    bbox_region = Region(bbox.to_itype(component.kcl.dbu))
-
     # Identify layer indices for the specified margins
     layer_indices_margins = {
         component.kcl.layer(*layer): margin for layer, margin in layer_margins


### PR DESCRIPTION
The best fix is to remove the first, unused assignment to `bbox_region` and keep a single definition where it is actually needed (after `bbox_itype` is created). This eliminates the dead store without changing functionality.

In `qpdk/utils.py`, within `add_margin_to_layer`:
- Delete the line `bbox_region = Region(bbox.to_itype(component.kcl.dbu))` (currently line 365 in the snippet).
- Keep the existing later lines:
  - `bbox_itype = bbox.to_itype(component.kcl.dbu)`
  - `bbox_region = Region(bbox_itype)`

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Eliminate a redundant bbox_region assignment that caused the variable to be defined multiple times in add_margin_to_layer.