### PR TITLE
Add SBOM generation to release workflow

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -20,7 +20,9 @@ exclude = [
   "\\$RESOLVED_VERSION",
   # pyansys broken parsed URLs
   "https://.*\\.pyansys\\.com.*/n",
-  "https://.*\\.pyansys\\.com.*//n"
+  "https://.*\\.pyansys\\.com.*//n",
+  # Persistent identifiers
+  "https://urn.fi/.*"
 ]
 
 # Set a timeout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Generate SBOM
+        run: |
+          uv run --all-extras --with cyclonedx-bom cyclonedx-py environment --pyproject pyproject.toml --output-format JSON --output-file sbom.json
       - name: Create Release
         run: |
           # Get the latest draft release tag if it exists
@@ -61,12 +65,14 @@ jobs:
             # Create release with draft body
             gh release create ${{ needs.check_and_tag.outputs.tag }} \
               --title "${{ needs.check_and_tag.outputs.tag }}" \
-              --notes "$DRAFT_BODY"
+              --notes "$DRAFT_BODY" \
+              sbom.json
           else
             # Create release with auto-generated notes
             gh release create ${{ needs.check_and_tag.outputs.tag }} \
               --title "${{ needs.check_and_tag.outputs.tag }}" \
-              --generate-notes
+              --generate-notes \
+              sbom.json
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,8 @@ scripts/
 # 3D
 *.glb
 *.stl
+
+# Software Bill of Materials
+sbom.json
+bom.json
+bom.xml


### PR DESCRIPTION
Integrates CycloneDX SBOM generation into the release GitHub Action and attaches the `sbom.json` artifact to GitHub releases. Updates `.gitignore` to ignore the local `sbom.json` file.

## Summary by Sourcery

Integrate SBOM generation into the release workflow and attach the generated artifact to GitHub releases.

Build:
- Add uv-based CycloneDX SBOM generation step to the release GitHub Action and upload the resulting sbom.json with each release.

Chores:
- Ignore the locally generated sbom.json file in version control.