### PR TITLE
Preserve pre-calculated simulation outputs in notebooks documentation

### DIFF
--- a/docs/docs.just
+++ b/docs/docs.just
@@ -47,12 +47,17 @@ write-justfile-help:
 convert-notebooks:
     @./.github/convert-notebooks.sh notebooks/src/*.py
 
-# Copy all sample scripts to use as notebooks docs
+# Copy all sample scripts and notebooks to use as documentation
 [private]
 [group('docs')]
 copy-sample-notebooks:
     @mkdir -p docs/notebooks
+    # Copy all .py source files from notebooks/src
     @cp -p notebooks/src/*.py docs/notebooks/
+    # For HFSS/Q3D notebooks, copy the .ipynb files which contain pre-calculated outputs
+    @cp -p notebooks/hfss_*.ipynb docs/notebooks/
+    # Remove the .py versions of HFSS notebooks to ensure Myst-NB uses the .ipynb versions
+    @rm -f docs/notebooks/hfss_*.py
 
 # Temporarily setup IPython configuration for documentation build
 [private]


### PR DESCRIPTION
This PR fixes an issue where manually saved HFSS and Q3D simulation outputs were being stripped during the documentation build.

Changes:
- Updated docs/docs.just to copy .ipynb files for HFSS/Q3D notebooks and remove their .py counterparts in the temporary docs directory, ensuring myst-nb uses the version with saved outputs.
- Updated QUCS reference data and model regression test results.

## Summary by Sourcery

Ensure documentation build uses pre-calculated HFSS/Q3D notebook outputs by preferring .ipynb files over converted scripts.

Bug Fixes:
- Prevent pre-saved HFSS and Q3D simulation outputs in notebooks from being stripped during documentation generation.

Enhancements:
- Adjust docs build script to copy HFSS/Q3D .ipynb notebooks and remove their .py counterparts in the temporary docs directory.