### PR TITLE
Remove .env and fix .gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-pdk="qpdk"
-RAY_ENABLE_UV_RUN_RUNTIME_ENV="0"

--- a/.gitignore
+++ b/.gitignore
@@ -113,7 +113,6 @@ celerybeat.pid
 
 # Environments
 .env
-!/.env
 .venv
 env/
 venv/


### PR DESCRIPTION
## Summary
- Remove committed `.env` file containing local dev settings (`pdk="qpdk"`, `RAY_ENABLE_UV_RUN_RUNTIME_ENV="0"`)
- Remove `!/.env` exception from `.gitignore` so `.env` is properly ignored
- No CI impact: the justfile already defaults `pdk` to `'qpdk'`, and notebooks set `RAY_ENABLE_UV_RUN_RUNTIME_ENV` inline

## Test plan
- [ ] CI passes (docs, notebooks, tests should all work without the .env)

## Summary by Sourcery

Remove the committed .env file from version control and ensure .env files are ignored by Git.

Enhancements:
- Clean up repository configuration by removing a tracked .env file containing local development settings.

Chores:
- Update .gitignore rules so .env files remain untracked in the repository.