### PR TITLE
Update doroutes to ~=0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "doroutes>=0.2.0",
+  "doroutes~=0.6.0",
   "gdsfactory>=9.39.0,<9.41.0",
   "typing-extensions>=4.12.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -767,22 +767,23 @@ wheels = [
 
 [[package]]
 name = "doroutes"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "kfactory" },
+    { name = "kwasm" },
     { name = "numpy" },
     { name = "shapely" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/6258ac4731f48df531fd251b17166fa9710de1c8e6e735786353c158d780/doroutes-0.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83fa8c28a7b09a0170a0600950b1894e0a56702dad90103504e52945e57d3417", size = 3295877, upload-time = "2026-03-27T20:27:36.274Z" },
-    { url = "https://files.pythonhosted.org/packages/48/63/fe06b9fd3be1c61b1fa5f3e1f6e4384837d733767f6c4617465406b3b6b2/doroutes-0.5.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:23c2d1c046d4059b8ffc60b412c6c91c19537ec52151e002272f447f456f9626", size = 3453660, upload-time = "2026-03-27T20:27:37.995Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/5b/bb3e05fc51171fabc9ef9b4df042c467ea2428e171bb31266ed2516a8749/doroutes-0.5.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3f2f5b9b2d2cd4a2effeb52ea7288d394e151ff0f9f49bd022727f3a2383ef87", size = 3631342, upload-time = "2026-03-27T20:27:39.569Z" },
-    { url = "https://files.pythonhosted.org/packages/94/c0/28ecaace1467d50ab9e745ad67a4ccd8a9813c5af6c29fecb2f10bffe994/doroutes-0.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:0ca3e9eb90614d678d65ecd80befaf122d168e905f249e69e067e258558081c3", size = 3014142, upload-time = "2026-03-27T20:27:40.889Z" },
-    { url = "https://files.pythonhosted.org/packages/87/62/e2146c3d8b135428e6ecef0e98b89c04f0f99f92466f506e2fbee2ecc8cc/doroutes-0.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:92308e02349c6e77e3723c92d57147000aea8033bb9d33d82f45d75265f5b666", size = 3295930, upload-time = "2026-03-27T20:27:42.249Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/6e/da7d0a7d48b82e61efbe2f04c904a802f2d6e13bd9e8bf66260e1f98609b/doroutes-0.5.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:e42c971c37456c8f5a2c285a475b4d60b803dca64902d8c4f86e81742f4dd0dc", size = 3452142, upload-time = "2026-03-27T20:27:43.459Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/bd/9c4dfd993453128e3d7f10f640d5c24b6a6e327f4a5a0f4ecb4e69cf8add/doroutes-0.5.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b339e3355a8ec4aaa9e00c98ed92640ae4e195c145cea5788366a6b2f5390a5a", size = 3630873, upload-time = "2026-03-27T20:27:44.751Z" },
-    { url = "https://files.pythonhosted.org/packages/79/29/375ec680dbd16ac1167d97a10600096cf56499aa7b5ea61dbdbfafcc5e38/doroutes-0.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:3e8545ac77241f3c71458998b5beceaa57eb42dc0cf24f7c470acd2194d58f83", size = 3014094, upload-time = "2026-03-27T20:27:45.969Z" },
+    { url = "https://files.pythonhosted.org/packages/65/c7/1f92a80dc0fb481db056c04ab7ed8d8ee0ed5f36a8c139de8dce29b8b60f/doroutes-0.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c3925a12ae9b84d76d8fc600d5a1f81e09dcbe0e8d167c172dba4b830efa0007", size = 3324235, upload-time = "2026-05-08T09:14:43.464Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bb/334c74b39efdfb4f5c72f2885384d38fa215a1646eca970cc8b8b9d9f21e/doroutes-0.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e61b5e0a64eebd0dd028747e7fc222c36b1276619e45d7ef31e9bb4751bc53d1", size = 3491762, upload-time = "2026-05-08T09:14:44.734Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a8/3e05acdbef2d3a7c3e4ac83c9aac688db67d8fff1ffe5dd89165b42a0378/doroutes-0.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a77ebde363a4f96c66475992f32d4e8ef20827bcf4ebbda5b8ad1fdf0940ca68", size = 3658448, upload-time = "2026-05-08T09:14:46.035Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/90/0de7a4614fcac5a4fcad9cba0e700503957f3169560fed2d9f051c04ef45/doroutes-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:a48098e0c72a967c53dcbf9f19f174ac1912e328a8684cf2e41329c9e238bd28", size = 3044223, upload-time = "2026-05-08T09:14:47.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/32/a9716b9267bb2d6264b57a3dc6903e5513211092e42790908b879ea379c3/doroutes-0.6.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fdf97c1c1635e69e3f83e26b64c9cfee0ba5f9a8eade08281b95a848af45eda5", size = 3324069, upload-time = "2026-05-08T09:14:49.119Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d6/ab62eabfb90a27d82f297205e541b0a60dd2a47fe8961d9a81f94a91804e/doroutes-0.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c700f207c75c65d52f17ddb922ee71d00f1a189afd46d258d06bb61ab0b20fa1", size = 3491640, upload-time = "2026-05-08T09:14:50.76Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/10/8ed0b5dda15272e57c5fce069cadadd15c17b3d74527d9722188e8a8a034/doroutes-0.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:44960bcf7a2db3fb2c1029a4e3ab8a30137f5f3afda6736db6cf2a9b6588525f", size = 3658064, upload-time = "2026-05-08T09:14:52.249Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/fe/ac0393d14f8047e06d939c145f0b2a24d9e57a2d0c1d5b92232927a029ba/doroutes-0.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:cfd93ef7480be108d39af7c40795ca76d9a1b7d736f49af345921b70d60aa634", size = 3043704, upload-time = "2026-05-08T09:14:53.894Z" },
 ]
 
 [[package]]
@@ -1836,6 +1837,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/a0/fad4b1177f09ea9204613e0f18291c9ae0e4c03f6378642791e09916e8fb/klujax-0.4.8-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1873357da8bc59f02244491f69023503caef00b3035493292f84eb53270b3192", size = 2126159, upload-time = "2026-01-27T13:07:21.676Z" },
     { url = "https://files.pythonhosted.org/packages/41/cd/a8b6bf56510db5aae474117396eec0b4c9d3918a1a5965a6b622f19e3640/klujax-0.4.8-cp313-cp313-win_amd64.whl", hash = "sha256:d963a0d4658aaf3eb3410bdcc4e614bbd780de2a0767dbe72292b3b168e89ca7", size = 138588, upload-time = "2026-01-27T13:07:22.744Z" },
     { url = "https://files.pythonhosted.org/packages/36/cf/47b79353865a6196dfcff2ad75697332aef0e950004f3f43cffd02e7e57b/klujax-0.4.8-cp313-cp313-win_arm64.whl", hash = "sha256:e5dd6bae4a027f2272eb898c7dbfa45967c57fbc926264aee54f1097406fb865", size = 118315, upload-time = "2026-01-27T13:07:24.147Z" },
+]
+
+[[package]]
+name = "kwasm"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typer" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/8c/55817f8b5b01b98d9d62e77fd00f6781f07ceb8bb742454b58803904e55e/kwasm-0.2.13-py3-none-any.whl", hash = "sha256:585629e642625356d498944159d8c40538869c178caa0cc95f94332fb6382e88", size = 6866779, upload-time = "2026-05-07T21:47:40.004Z" },
 ]
 
 [[package]]
@@ -3825,7 +3837,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "doroutes", specifier = ">=0.2.0" },
+    { name = "doroutes", specifier = "~=0.6.0" },
     { name = "flax", marker = "extra == 'netket'" },
     { name = "gdsfactory", specifier = ">=9.39.0,<9.41.0" },
     { name = "gdsfactoryplus", marker = "extra == 'gdsfactoryplus'" },


### PR DESCRIPTION
## Summary
- Update `doroutes` dependency from `>=0.2.0` to `~=0.6.0`

## Test plan
- [ ] Verify the project installs correctly with `doroutes~=0.6.0`