### PR TITLE
feat: enable sbend="bend_s" in route_bundle strategies

### DIFF
--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -480,6 +480,7 @@ route_bundle = route_bundle_cpw = partial(
     bend="bend_circular",
     collision_check_layers=[LAYER.WG],
     on_collision="error",
+    sbend="bend_s",
 )
 route_bundle_all_angle = route_bundle_all_angle_cpw = partial(
     gf.routing.route_bundle_all_angle,


### PR DESCRIPTION
## Summary

- Enable `sbend="bend_s"` in all `route_bundle` routing strategies
- This allows the router to use S-bends when needed to avoid collisions

## Test plan

- [ ] Verify routing still works correctly with sbend enabled

## Summary by Sourcery

New Features:
- Allow route_bundle-based microstrip routing to use S-bends via the bend_s component when needed to avoid collisions.