### PR TITLE
Update branding to QPDK across the codebase

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug or issue with the quantum-rf-pdk
+description: Report a bug or issue with QPDK
 type: "Bug"
 labels: ["bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: 📚 Documentation
     url: https://gdsfactory.github.io/quantum-rf-pdk/
-    about: Check the quantum-rf-pdk documentation for guides and API reference
+    about: Check the QPDK documentation for guides and API reference
   - name: 💬 Discussions
     url: https://github.com/gdsfactory/quantum-rf-pdk/discussions
     about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or enhancement for quantum-rf-pdk
+description: Suggest a new feature or enhancement for QPDK
 type: "Feature"
 labels: ["enhancement"]
 body:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,5 +1,5 @@
 name: Question or Help
-description: Ask a question or get help using quantum-rf-pdk
+description: Ask a question or get help using QPDK
 labels: ["question"]
 body:
   - type: markdown

--- a/.github/agents/dependency-update.md
+++ b/.github/agents/dependency-update.md
@@ -3,7 +3,7 @@ name: Dependency Update Agent
 description: Updates all pinned dependencies including GitHub Actions, Python packages in pyproject.toml, and pre-commit hooks
 ---
 
-You are a specialized agent for updating dependencies in the quantum-rf-pdk repository.
+You are a specialized agent for updating dependencies in the QPDK repository.
 
 ## Your Responsibilities
 

--- a/.github/agents/version-bump.md
+++ b/.github/agents/version-bump.md
@@ -3,7 +3,7 @@ name: Version Bump Agent
 description: Bumps the project version according to Semantic Versioning (SemVer)
 ---
 
-You are a specialized agent for bumping the version of the quantum-rf-pdk repository.
+You are a specialized agent for bumping the version of the QPDK repository.
 
 ## Your Responsibilities
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AI Agent Best Practices for Superconducting Quantum PDK
+# AI Agent Best Practices for QPDK
 
 This is a Python-based superconducting microwave Process Design Kit (PDK) built on gdsfactory for designing quantum
 devices and circuits. It provides components like transmons, resonators, couplers, and quantum layouts. Please follow

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/_static/qpdk_logo_dark.svg">
-  <img src="docs/_static/qpdk_logo.svg" alt="QPDK — Quantum RF PDK" width="410">
+  <img src="docs/_static/qpdk_logo.svg" alt="QPDK" width="410">
 </picture>
 
 <!-- BADGES:START -->
@@ -205,8 +205,8 @@ docs/                   Sphinx documentation (HTML + PDF)
 
 ## Documentation
 
-- [Quantum RF PDK documentation (HTML)](https://gdsfactory.github.io/quantum-rf-pdk/)
-- [Quantum RF PDK documentation (PDF)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf)
+- [QPDK documentation (HTML)](https://gdsfactory.github.io/quantum-rf-pdk/)
+- [QPDK documentation (PDF)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf)
 - [gdsfactory documentation](https://gdsfactory.github.io/gdsfactory/)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/_static/qpdk_logo_dark.svg">
-  <img src="docs/_static/qpdk_logo.svg" alt="QPDK" width="410">
+  <img src="docs/_static/qpdk_logo.svg" alt="QPDK — Quantum Process Design Kit" width="410">
 </picture>
 
 <!-- BADGES:START -->

--- a/docs/_static/qpdk_logo.svg
+++ b/docs/_static/qpdk_logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 100" width="410" height="100" role="img" aria-label="QPDK — Quantum RF PDK">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 100" width="410" height="100" role="img" aria-label="QPDK">
   <title>QPDK</title>
   <line x1="42" y1="22" x2="42" y2="78" stroke="#0E1116" stroke-width="8" stroke-linecap="round"></line>
   <line x1="58" y1="22" x2="58" y2="78" stroke="#0E1116" stroke-width="8" stroke-linecap="round"></line>

--- a/docs/_static/qpdk_logo_dark.svg
+++ b/docs/_static/qpdk_logo_dark.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 100" width="410" height="100" role="img" aria-label="QPDK — Quantum RF PDK">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 100" width="410" height="100" role="img" aria-label="QPDK">
   <title>QPDK</title>
   <line x1="42" y1="22" x2="42" y2="78" stroke="#E9E6DF" stroke-width="8" stroke-linecap="round"></line>
   <line x1="58" y1="22" x2="58" y2="78" stroke="#E9E6DF" stroke-width="8" stroke-linecap="round"></line>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ This file serves as the documentation homepage.
 It includes the README.md but skips SVG badges which cannot be rendered in LaTeX/PDF.
 -->
 
-# QPDK — Quantum Process Design Kit
+# QPDK — Superconducting Quantum Process Design Kit
 
 ```{only} html
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ This file serves as the documentation homepage.
 It includes the README.md but skips SVG badges which cannot be rendered in LaTeX/PDF.
 -->
 
-# QPDK — Superconducting Quantum RF Process Design Kit
+# QPDK
 
 ```{only} html
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ This file serves as the documentation homepage.
 It includes the README.md but skips SVG badges which cannot be rendered in LaTeX/PDF.
 -->
 
-# QPDK
+# QPDK — Quantum Process Design Kit
 
 ```{only} html
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)

--- a/docs/ipython_config.py
+++ b/docs/ipython_config.py
@@ -27,7 +27,7 @@ c.InteractiveShellApp.exec_lines = [  # noqa: F821
     # TrueType font embedding (Type 42) for PDF/PS - more compatible than Type 3
     "plt.rcParams['pdf.fonttype'] = 42",
     "plt.rcParams['ps.fonttype'] = 42",
-    # Load custom matplotlib style for quantum-rf-pdk documentation
+    # Load custom matplotlib style for QPDK documentation
     "plt.style.use('qpdk')",
     # Suppress harmless logging warnings that clutter notebook output.
     # fontTools and matplotlib emit warnings via Python's logging module (not

--- a/docs/qpdk.mplstyle
+++ b/docs/qpdk.mplstyle
@@ -1,5 +1,5 @@
-# Quantum RF PDK Matplotlib Style
-# Custom style for quantum-rf-pdk documentation
+# QPDK Matplotlib Style
+# Custom style for QPDK documentation
 
 font.family: serif
 font.serif: CMU Serif, cmr10, DejaVu Serif, Bitstream Vera Serif, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif

--- a/notebooks/all_models.ipynb
+++ b/notebooks/all_models.ipynb
@@ -33,7 +33,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/circuit_simulation_demo.ipynb
+++ b/notebooks/circuit_simulation_demo.ipynb
@@ -27,7 +27,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/hfss_driven_capacitor.ipynb
+++ b/notebooks/hfss_driven_capacitor.ipynb
@@ -55,7 +55,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/hfss_eigenmode_resonator.ipynb
+++ b/notebooks/hfss_eigenmode_resonator.ipynb
@@ -55,7 +55,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/hfss_q2d_cpw_impedance.ipynb
+++ b/notebooks/hfss_q2d_cpw_impedance.ipynb
@@ -58,7 +58,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/jax_backend_comparison.ipynb
+++ b/notebooks/jax_backend_comparison.ipynb
@@ -48,7 +48,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/model_comparison_to_qucs.ipynb
+++ b/notebooks/model_comparison_to_qucs.ipynb
@@ -33,7 +33,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/monte_carlo_fabrication_tolerance.ipynb
+++ b/notebooks/monte_carlo_fabrication_tolerance.ipynb
@@ -38,7 +38,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/netket_transmon_design.ipynb
+++ b/notebooks/netket_transmon_design.ipynb
@@ -74,7 +74,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/optimize_capacitor_optuna.ipynb
+++ b/notebooks/optimize_capacitor_optuna.ipynb
@@ -29,7 +29,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/pymablock_dispersive_shift.ipynb
+++ b/notebooks/pymablock_dispersive_shift.ipynb
@@ -56,7 +56,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/qutip_qip_pulse_simulation.ipynb
+++ b/notebooks/qutip_qip_pulse_simulation.ipynb
@@ -55,7 +55,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/resonator_frequency_model.ipynb
+++ b/notebooks/resonator_frequency_model.ipynb
@@ -27,7 +27,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/scqubits_parameter_calculation.ipynb
+++ b/notebooks/scqubits_parameter_calculation.ipynb
@@ -68,7 +68,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    import subprocess\n",
     "\n",
-    "    print(\"Running in Google Colab. Installing quantum-rf-pdk...\")\n",
+    "    print(\"Running in Google Colab. Installing QPDK...\")\n",
     "    subprocess.check_call([\n",
     "        sys.executable,\n",
     "        \"-m\",\n",

--- a/notebooks/src/all_models.py
+++ b/notebooks/src/all_models.py
@@ -20,7 +20,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/circuit_simulation_demo.py
+++ b/notebooks/src/circuit_simulation_demo.py
@@ -33,7 +33,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/hfss_driven_capacitor.py
+++ b/notebooks/src/hfss_driven_capacitor.py
@@ -36,7 +36,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/hfss_eigenmode_resonator.py
+++ b/notebooks/src/hfss_eigenmode_resonator.py
@@ -36,7 +36,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/hfss_q2d_cpw_impedance.py
+++ b/notebooks/src/hfss_q2d_cpw_impedance.py
@@ -39,7 +39,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/jax_backend_comparison.py
+++ b/notebooks/src/jax_backend_comparison.py
@@ -39,7 +39,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/model_comparison_to_qucs.py
+++ b/notebooks/src/model_comparison_to_qucs.py
@@ -25,7 +25,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/monte_carlo_fabrication_tolerance.py
+++ b/notebooks/src/monte_carlo_fabrication_tolerance.py
@@ -29,7 +29,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/netket_transmon_design.py
+++ b/notebooks/src/netket_transmon_design.py
@@ -58,7 +58,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/optimize_capacitor_optuna.py
+++ b/notebooks/src/optimize_capacitor_optuna.py
@@ -21,7 +21,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/pymablock_dispersive_shift.py
+++ b/notebooks/src/pymablock_dispersive_shift.py
@@ -48,7 +48,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/qutip_qip_pulse_simulation.py
+++ b/notebooks/src/qutip_qip_pulse_simulation.py
@@ -51,7 +51,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/resonator_frequency_model.py
+++ b/notebooks/src/resonator_frequency_model.py
@@ -19,7 +19,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/notebooks/src/scqubits_parameter_calculation.py
+++ b/notebooks/src/scqubits_parameter_calculation.py
@@ -60,7 +60,7 @@ import sys
 if "google.colab" in sys.modules:
     import subprocess
 
-    print("Running in Google Colab. Installing quantum-rf-pdk...")
+    print("Running in Google Colab. Installing QPDK...")
     subprocess.check_call([
         sys.executable,
         "-m",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "qpdk"
 version = "0.3.7"
-description = "Quantum-RF generic PDK"
+description = "Generic QPDK"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "qpdk"
 version = "0.3.7"
-description = "Generic QPDK"
+description = "Generic Superconducting Quantum Process Design Kit"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This PR updates the project branding from "Quantum RF PDK" (and variants) to "QPDK".

Main changes:
- Replaced "Quantum RF PDK" with "QPDK" in documentation, comments, and README.
- Updated issue templates and agent instructions to use the new branding.
- Renamed the package description in `pyproject.toml`.
- Updated notebook source files and regenerated the corresponding Jupyter notebooks to reflect the new name in Colab installation scripts.
- Maintained all repository URLs and package imports unaltered to prevent broken links.

## Summary by Sourcery

Standardize the project branding to QPDK across documentation, configuration, and notebook materials while keeping package imports and URLs unchanged.

Enhancements:
- Update package metadata description in pyproject.toml to use the QPDK branding.
- Align AI agent configuration text and internal comments with the QPDK name.

Documentation:
- Refresh README, documentation index, and links to reference QPDK instead of Quantum RF PDK.
- Update GitHub issue templates and contact links to use QPDK terminology and documentation naming.
- Adjust Colab installation messages and notebook sources to reference QPDK consistently across all tutorials and examples.

Chores:
- Revise logo alt text and related style assets to reflect the QPDK branding.