### PR TITLE
fix [tool.elvis] config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ source = ["qpdk"]
 exclude_lines = ["if __name__ == .__main__.", "pragma: no cover"]
 
 [tool.elvis]
-short-layers = [[1, 0], [31, 0], [2, 0], [30, 0], [10, 0]]
+short-layers = [[1, 0], [25, 0], [31, 0], [2, 0], [30, 0], [10, 0]]
 connected-layers = [
   [[1, 0], [31, 0]],
   [[31, 0], [2, 0]],
@@ -143,6 +143,9 @@ connected-layers = [
   [[1, 0], [10, 0]],
   [[2, 0], [10, 0]],
 ]
+
+[tool.elvis.equivalent-ports]
+launcher = [["o1", "waveport"]]
 
 [tool.gdsfactoryplus]
 name = "qpdk"


### PR DESCRIPTION
Follow-up to #591.

- Add NbTiN (25,0) to short-layers. NbTiN is a superconducting conducting layer used in fluxonium inductors and SNSPD; it was present in the PDK stack but missing from the Elvis config.
- Add [tool.elvis.equivalent-ports] for the launcher cell: o1 (circuit-connection end) and waveport (probe/wirebond end) represent the same signal at different access points.

Closes the two review comments from Gemini on #591.