### PR TITLE
Upgrade download-artifact action to v8.0.1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Pages artifact
-        uses: actions/download-artifact@fa0b92f8cc0b10bb8e1454a060e9c7d0023c4a2e # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: github-pages
           path: combined_tmp
@@ -98,7 +98,7 @@ jobs:
           mkdir -p combined
           tar -xf combined_tmp/artifact.tar -C combined
       - name: Download PDF docs
-        uses: actions/download-artifact@fa0b92f8cc0b10bb8e1454a060e9c7d0023c4a2e # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pdf-docs
           path: combined


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update the GitHub Pages workflow to use actions/download-artifact v8.0.1 for both site and PDF docs artifacts.