### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,7 +65,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.13
     hooks:
       - id: ruff
         priority: 10
@@ -74,7 +74,7 @@ repos:
         priority: 20
         args: [--config=pyproject.toml]
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.9.12
+    rev: v0.11.3
     hooks:
       - id: tombi-format
         priority: 10
@@ -110,17 +110,17 @@ repos:
       - id: actionlint
         priority: 10
   - repo: https://github.com/woodruffw/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.0
     hooks:
       - id: zizmor
         priority: 10
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.10.6
+    rev: 0.11.14
     hooks:
       - id: uv-lock
         priority: 10
   - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.58.0
+    rev: 1.0.0
     hooks:
       - id: pyrefly-check
         priority: 30
@@ -194,13 +194,13 @@ repos:
         priority: 10
         types_or: [css]
   - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-    rev: v17.6.0
+    rev: v17.11.0
     hooks:
       - id: stylelint
         priority: 20
         args: [--fix, --config=.github/.stylelintrc.yaml]
         additional_dependencies:
-          - stylelint@17.9.1
+          - stylelint@17.11.0
   - repo: https://github.com/sco1/pre-commit-matlab
     rev: v1.2.0
     hooks:
@@ -216,7 +216,7 @@ repos:
         pass_filenames: true
         exclude: '^(?:docs/_build/.*|qpdk(?:/.*)?/__init__[.]py|notebooks/.*|docs/notebooks/[^/]+|qpdk/samples/[^/]+[.]py|tests/.*)$'
   - repo: https://github.com/lycheeverse/lychee.git
-    rev: lychee-v0.24.1
+    rev: lychee-v0.24.2
     hooks:
       - id: lychee
         priority: 10


### PR DESCRIPTION
Updates multiple pre-commit hooks in .pre-commit-config.yaml to their latest versions, including Ruff, Tombi, Zizmor, uv, Pyrefly, Stylelint, and Lychee.

Most notably and the primary reason for the PR, pyrefly is now v1.0.0.

## Summary by Sourcery

Build:
- Bump versions of Ruff, Tombi, Zizmor, uv, Pyrefly, Stylelint, and Lychee pre-commit hooks in .pre-commit-config.yaml.