### PR TITLE
Add zensical docs support

### DIFF
--- a/.github/agents/component-designer.md
+++ b/.github/agents/component-designer.md
@@ -61,6 +61,7 @@ The key pattern is:
 
 ```python
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import gdsfactory as gf

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-
+.PHONY: install-doc-fonts build install dev test nbdocs docs-pdf docs docs-serve doc drc-sample drc
 
 # Makefile — compatibility shim for gdsfactory PDK CI tooling
 #
@@ -51,8 +51,8 @@ test:
 nbdocs:
 	rm -rf docs/notebooks/*.md
 	find notebooks -maxdepth 1 -mindepth 1 -name "*.ipynb" | sort | \
-		xargs -P4 -I{} uv run --extra docs jupyter nbconvert \
-			--execute --to markdown --embed-images {} --output-dir docs/notebooks
+	xargs -P4 -I{} uv run --extra docs jupyter nbconvert \
+	--execute --to markdown --embed-images {} --output-dir docs/notebooks
 	uv run python docs/hooks.py docs/notebooks/*.md
 
 docs-pdf: nbdocs
@@ -72,5 +72,3 @@ docs-serve: nbdocs
 	uv run python .github/write_models.py
 	cp CHANGELOG.md docs/changelog.md
 	uv run --extra docs zensical serve -a localhost:8080
-
-.PHONY: drc drc-sample doc docs docs-pdf build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-doc-fonts docs build install dev test
+
 
 # Makefile — compatibility shim for gdsfactory PDK CI tooling
 #
@@ -28,17 +28,6 @@ install-doc-fonts:
 		sudo fc-cache -f && rm -rf /tmp/qpdk-fonts; \
 	fi
 
-docs: install-doc-fonts
-	@$(JUST_CMD) docs
-	@if [ "$$GITHUB_ACTIONS" = "true" ]; then \
-		TOKEN=$${GH_TOKEN:-$${GITHUB_TOKEN:-$$(git config --get http.https://github.com/.extraheader | cut -d ' ' -f 3 | base64 -d | cut -d ':' -f 2 2>/dev/null)}}; \
-		if [ -n "$$TOKEN" ]; then \
-			GH_TOKEN=$$TOKEN gh run download $$GITHUB_RUN_ID -n pdf-docs -D docs/_build/html || echo "PDF artifact not found, skipping…"; \
-		else \
-			echo "GH_TOKEN not set and could not be extracted from git, skipping PDF download…"; \
-		fi; \
-	fi
-
 build:
 	@$(JUST_CMD) build
 
@@ -58,3 +47,30 @@ test:
 # Any target not explicitly defined above is forwarded to just.
 %:
 	@$(JUST_CMD) $@
+
+nbdocs:
+	rm -rf docs/notebooks/*.md
+	find notebooks -maxdepth 1 -mindepth 1 -name "*.ipynb" | sort | \
+		xargs -P4 -I{} uv run --extra docs jupyter nbconvert \
+			--execute --to markdown --embed-images {} --output-dir docs/notebooks
+	uv run python docs/hooks.py docs/notebooks/*.md
+
+docs-pdf: nbdocs
+	uv run python .github/write_cells.py
+	uv run python .github/write_models.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
+
+docs: nbdocs
+	uv run python .github/write_cells.py
+	uv run python .github/write_models.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
+
+docs-serve: nbdocs
+	uv run python .github/write_cells.py
+	uv run python .github/write_models.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,4 +1,3 @@
-# ruff: noqa: INP001
 """Post-process notebook markdown: convert MyST admonitions to Material style.
 
 Usage: python docs/hooks.py docs/notebooks/*.md
@@ -51,4 +50,4 @@ def _myst_to_material_admonitions(markdown: str) -> str:
 if __name__ == "__main__":
     for path in sys.argv[1:]:
         p = Path(path)
-        p.write_text(process(p.read_text()))
+        p.write_text(process(p.read_text(encoding="utf-8")), encoding="utf-8")

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,39 @@
+site_name: Generic Superconducting Quantum Process Design Kit
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+  - Tutorial:
+      - All Models: notebooks/all_models.md
+      - Circuit Simulation Demo: notebooks/circuit_simulation_demo.md
+      - Hfss Driven Capacitor: notebooks/hfss_driven_capacitor.md
+      - Hfss Eigenmode Resonator: notebooks/hfss_eigenmode_resonator.md
+      - Hfss Q2D Cpw Impedance: notebooks/hfss_q2d_cpw_impedance.md
+      - Jax Backend Comparison: notebooks/jax_backend_comparison.md
+      - Matlab Integration: notebooks/matlab_integration.md
+      - Model Comparison To Qucs: notebooks/model_comparison_to_qucs.md
+      - Monte Carlo Fabrication Tolerance: notebooks/monte_carlo_fabrication_tolerance.md
+      - Netket Transmon Design: notebooks/netket_transmon_design.md
+      - Optimize Capacitor Optuna: notebooks/optimize_capacitor_optuna.md
+      - Pymablock Dispersive Shift: notebooks/pymablock_dispersive_shift.md
+      - Qutip Qip Pulse Simulation: notebooks/qutip_qip_pulse_simulation.md
+      - Resonator Frequency Model: notebooks/resonator_frequency_model.md
+      - Scqubits Parameter Calculation: notebooks/scqubits_parameter_calculation.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,14 @@ pymablock = ["pymablock>=2.2.1"]
 qutip = ["qutip-jax>=0.1.1", "qutip-qip>=0.4.1"]
 ray = ["ray[default]", "tqdm"]
 scqubits = ["scqubits"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "mkdocstrings[python]>=0.27.0",
+  "nbconvert",
+  "zensical>=0.0.40,<0.1.0",
+]
 
 [dependency-groups]
 dev = [{ include-group = "lint" }, { include-group = "test" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,22 +68,12 @@ scqubits = ["scqubits"]
 [dependency-groups]
 dev = [{ include-group = "lint" }, { include-group = "test" }]
 docs = [
-  "jinja2",
-  "jupytext",
-  "linkify-it-py",
-  "matplotlib",
-  "myst-nb>=1.0",
-  "pydata-sphinx-theme",
-  "scipy",
-  "sphinx>=9.0",
-  "sphinx-copybutton",
-  "sphinx-design",
-  "sphinx-github-alerts>=1.0",
-  "sphinxcontrib-bibtex",
-  "sphinxcontrib-bibtex-urn",
-  "sphinxcontrib-mermaid>=2.0.1",
-  "sphinxcontrib-svgbob",
-  { include-group = "docs-models" },
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
 ]
 docs-models = [
   "flax",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,8 +71,8 @@ docs = [
   "jupyter",
   "mkdocs-material",
   "mkdocs-with-pdf",
-  "nbconvert",
   "mkdocstrings[python]>=0.27.0",
+  "nbconvert",
   "zensical>=0.0.40,<0.1.0"
 ]
 docs-models = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,43 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]},
+  {"Tutorial" = [
+    {"All Models" = "notebooks/all_models.md"},
+    {"Circuit Simulation Demo" = "notebooks/circuit_simulation_demo.md"},
+    {"Hfss Driven Capacitor" = "notebooks/hfss_driven_capacitor.md"},
+    {"Hfss Eigenmode Resonator" = "notebooks/hfss_eigenmode_resonator.md"},
+    {"Hfss Q2D Cpw Impedance" = "notebooks/hfss_q2d_cpw_impedance.md"},
+    {"Jax Backend Comparison" = "notebooks/jax_backend_comparison.md"},
+    {"Matlab Integration" = "notebooks/matlab_integration.md"},
+    {"Model Comparison To Qucs" = "notebooks/model_comparison_to_qucs.md"},
+    {"Monte Carlo Fabrication Tolerance" = "notebooks/monte_carlo_fabrication_tolerance.md"},
+    {"Netket Transmon Design" = "notebooks/netket_transmon_design.md"},
+    {"Optimize Capacitor Optuna" = "notebooks/optimize_capacitor_optuna.md"},
+    {"Pymablock Dispersive Shift" = "notebooks/pymablock_dispersive_shift.md"},
+    {"Qutip Qip Pulse Simulation" = "notebooks/qutip_qip_pulse_simulation.md"},
+    {"Resonator Frequency Model" = "notebooks/resonator_frequency_model.md"},
+    {"Scqubits Parameter Calculation" = "notebooks/scqubits_parameter_calculation.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "Generic Superconducting Quantum Process Design Kit"
+site_url = "https://gdsfactory.github.io/quantum-rf-pdk"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation from Sphinx/MyST to a zensical/MkDocs Material setup with notebook-based docs and PDF generation targets.

New Features:
- Add zensical-based MkDocs configuration for site navigation and theming.
- Introduce MkDocs PDF configuration to build a standalone PDF version of the docs.
- Add Makefile targets to serve docs locally and generate HTML and PDF outputs.
- Add a post-processing hook to convert MyST-style admonitions in notebook markdown to Material-style admonitions.

Enhancements:
- Replace Sphinx-oriented documentation dependencies with MkDocs/zensical-related dependencies in the docs dependency group.