### PR TITLE
Replace RST code directives with markdown code blocks

### DIFF
--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -340,10 +340,10 @@ def straight_all_angle(
         cross_section: Cross-section specification.
         width: Optional width override in μm.
 
-    .. code::
-
+    ```
         o1  ──────────────── o2
                 length
+    ```
     """
     return gf.c.straight_all_angle(
         length=length, npoints=npoints, cross_section=cross_section, width=width

--- a/qpdk/models/couplers.py
+++ b/qpdk/models/couplers.py
@@ -154,11 +154,11 @@ def coupler_straight(
     Returns:
         sax.SDict: S-parameters dictionary
 
-    .. code::
-
+    ```
         o2──────▲───────o3
                 │gap
         o1──────▼───────o4
+    ```
     """
     f = jnp.asarray(f)
     straight_settings = {"length": length / 2, "cross_section": cross_section}

--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -280,11 +280,11 @@ def xsection(func: Callable[..., CrossSection]) -> Callable[..., CrossSection]:
 
     Ensures that the cross-section name matches the name of the function that generated it when created using default parameters
 
-    .. code-block:: python
-
+    ```python
         @xsection
         def strip(width=TECH.width_strip, radius=TECH.radius_strip):
             return gf.cross_section.cross_section(width=width, radius=radius)
+    ```
     """
     default_cross_section = func()
     _cross_section_default_names[default_cross_section.name] = func.__name__


### PR DESCRIPTION
## Summary

- Replace `.. code::` and `.. code-block:: python` RST directives with markdown triple-backtick code blocks in docstrings
- ASCII art diagrams and code examples were not rendering correctly with the new docs theme because it expects markdown, not RST

## Test plan

- [ ] Verify docs build correctly
- [ ] Check ASCII art diagrams render properly in the docs

## Summary by Sourcery

Documentation:
- Replace RST code directives in docstrings with fenced Markdown code blocks for code examples and ASCII diagrams.