### PR TITLE
add missing codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola @Alex-l-r
+* @joamatab @ThomasPluck @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt


### PR DESCRIPTION
## Summary
- Ensure all required reviewers are listed in CODEOWNERS
- Added missing people from: @joamatab @ThomasPluck @nikosavola @sheron-lian @thanojo @Alex-l-r @cdaunt

## Test plan
- [x] Verify CODEOWNERS file has all required users

## Summary by Sourcery

Chores:
- Revise CODEOWNERS to include all required owners and align with current reviewer responsibilities.