### PR TITLE
Add das-dias as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt
+* @joamatab @ThomasPluck @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt @das-dias


### PR DESCRIPTION
## Summary
- Add @das-dias to CODEOWNERS

## Summary by Sourcery

Chores:
- Update CODEOWNERS to include an additional maintainer for relevant paths.