### PR TITLE
Fix broken SAX documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ in minutes.
 - **Parametric & composable** — Combine Python functions (`@gf.cell`) into hierarchical designs or define full chips in
   YAML.
 - **Analytical circuit models** — Fast, differentiable S-parameter simulations powered by
-  [SAX](https://flaport.github.io/sax/) and [JAX](https://github.com/jax-ml/jax).
+  [SAX](https://gdsfactory.github.io/sax/) and [JAX](https://github.com/jax-ml/jax).
 - **Automated routing** — CPW-aware routing strategies with auto-tapers for complex layouts, and
   [DoRoutes](https://doplaydo.github.io/DoRoutes/).
 - **KLayout integration** — Layer definitions, technology files, and cross sections for immediate visual inspection.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "jax": ("https://docs.jax.dev/en/latest/", None),
     "gdsfactory": ("https://gdsfactory.github.io/gdsfactory/", None),
-    "sax": ("https://flaport.github.io/sax/", None),
+    "sax": ("https://gdsfactory.github.io/sax/", None),
 }
 
 # -- MyST configuration ------------------------------------------------------

--- a/docs/notebooks.rst
+++ b/docs/notebooks.rst
@@ -70,7 +70,7 @@ as follows. Each stage may loop back to earlier stages as the design is refined.
 S-parameter circuit models treat microwave components as linear, frequency-dependent
 networks described by their scattering matrices. In **qpdk** these models are
 implemented with `JAX <https://jax.readthedocs.io/>`_ and composed into circuits using
-`SAX <https://flaport.github.io/sax/>`_
+`SAX <https://gdsfactory.github.io/sax/>`_
 :cite:`blaisCircuitQuantumElectrodynamics2021,gopplCoplanarWaveguideResonators2008a`.
 
 **Typical use cases:**

--- a/notebooks/monte_carlo_fabrication_tolerance.ipynb
+++ b/notebooks/monte_carlo_fabrication_tolerance.ipynb
@@ -338,7 +338,7 @@
     "resonance frequencies of the on-chip resonators.\n",
     "\n",
     "This section performs a **Monte Carlo analysis** inspired by the\n",
-    "[SAX layout-aware Monte Carlo example](https://flaport.github.io/sax/nbs/examples/07_layout_aware/).\n",
+    "[SAX layout-aware Monte Carlo example](https://gdsfactory.github.io/sax/nbs/examples/07_layout_aware/).\n",
     "The approach is:\n",
     "\n",
     "1. Reuse the **standard QPDK model functions** (``straight``, ``bend_euler``,\n",
@@ -1295,7 +1295,7 @@
     "  targeting.\n",
     "- The Monte Carlo framework developed here can be extended to include spatial\n",
     "  correlation across the die (wafer-map approach, as in the\n",
-    "  [SAX layout-aware example](https://flaport.github.io/sax/nbs/examples/07_layout_aware/))\n",
+    "  [SAX layout-aware example](https://gdsfactory.github.io/sax/nbs/examples/07_layout_aware/))\n",
     "  or additional sources of variation (substrate permittivity, metal\n",
     "  thickness)."
    ]

--- a/notebooks/src/monte_carlo_fabrication_tolerance.py
+++ b/notebooks/src/monte_carlo_fabrication_tolerance.py
@@ -229,7 +229,7 @@ plt.show(block=False)
 # resonance frequencies of the on-chip resonators.
 #
 # This section performs a **Monte Carlo analysis** inspired by the
-# [SAX layout-aware Monte Carlo example](https://flaport.github.io/sax/nbs/examples/07_layout_aware/).
+# [SAX layout-aware Monte Carlo example](https://gdsfactory.github.io/sax/nbs/examples/07_layout_aware/).
 # The approach is:
 #
 # 1. Reuse the **standard QPDK model functions** (``straight``, ``bend_euler``,
@@ -941,6 +941,6 @@ plt.show(block=False)
 #   targeting.
 # - The Monte Carlo framework developed here can be extended to include spatial
 #   correlation across the die (wafer-map approach, as in the
-#   [SAX layout-aware example](https://flaport.github.io/sax/nbs/examples/07_layout_aware/))
+#   [SAX layout-aware example](https://gdsfactory.github.io/sax/nbs/examples/07_layout_aware/))
 #   or additional sources of variation (substrate permittivity, metal
 #   thickness).

--- a/qpdk/models/README.md
+++ b/qpdk/models/README.md
@@ -5,7 +5,7 @@ This directory houses the models for frequency-dependent SPICE-like circuit simu
 
 ## Libraries
 
-- [Sax](https://flaport.github.io/sax/) is used as the circuit simulator backend
+- [Sax](https://gdsfactory.github.io/sax/) is used as the circuit simulator backend
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Update SAX docs URL from `flaport.github.io/sax` to `gdsfactory.github.io/sax` across 6 files
- The old URL returns 404, causing lychee link-checker to fail in pre-commit on every PR (including #638)

## Files changed
- `README.md`
- `docs/conf.py` (intersphinx mapping)
- `docs/notebooks.rst`
- `notebooks/monte_carlo_fabrication_tolerance.ipynb`
- `notebooks/src/monte_carlo_fabrication_tolerance.py`
- `qpdk/models/README.md`

## Test plan
- [x] Verified new URLs return HTTP 200 (both base URL and subpaths)
- [x] All pre-commit hooks pass locally

## Summary by Sourcery

Bug Fixes:
- Replace outdated SAX documentation URLs that returned 404s with the current gdsfactory-hosted SAX URLs to restore working documentation and notebook links.