### PR TITLE
Update CODEOWNERS: remove departed members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt @das-dias
+* @joamatab @nikosavola @thanojo @cdaunt @das-dias


### PR DESCRIPTION
Remove @ThomasPluck, @tvt173, @sheron-lian, @Alex-l-r from CODEOWNERS as requested. @nikosavola retained per request.

## Summary by Sourcery

Chores:
- Remove departed team members from the CODEOWNERS file while retaining the requested owner.