### PR TITLE
Add Static/Dynamic layout viewer tabs to cells page

### DIFF
--- a/.github/write_cells.py
+++ b/.github/write_cells.py
@@ -3,17 +3,26 @@
 # ruff: noqa: S701, T201
 
 import inspect
+import traceback
 from pathlib import Path
 
+import kwasm.embed
+import matplotlib as mpl
+import matplotlib.pyplot as plt
 from gdsfactory.serialization import clean_value_json
 from jinja2 import Environment, FileSystemLoader
 
 import qpdk
 from qpdk.config import PATH
 
+mpl.use("Agg")
+
 filepath_cells = PATH.docs / "cells.rst"
 filepath_samples = PATH.docs / "samples.rst"
 template_dir = PATH.docs / "templates"
+
+kwasm_dir = PATH.docs / "kwasm"
+gds_dir = kwasm_dir / "gds"
 
 skip = {}
 
@@ -27,6 +36,53 @@ samples = qpdk.get_sample_functions()
 # Set up Jinja2 environment
 # Note: autoescape is False because we're generating RST, not HTML
 env = Environment(loader=FileSystemLoader(template_dir), autoescape=False)
+
+
+def _setup_kwasm_viewer() -> None:
+    """Create the kwasm viewer HTML and GDS output directory."""
+    gds_dir.mkdir(parents=True, exist_ok=True)
+    viewer_path = kwasm_dir / "viewer.html"
+    if viewer_path.exists():
+        return
+    template = kwasm.embed._read_artifacts()
+    template = template.replace("KWASM_GDS_B64", "")
+    template = template.replace("KWASM_LYP_B64", "")
+    template = template.replace("KWASM_LYRDB_B64", "")
+    template = template.replace("KWASM_NETLIST_B64", "")
+    viewer_path.write_text(template)
+
+
+def _generate_artifacts(c, name: str) -> None:
+    """Generate GDS and PNG plot for the component."""
+    c.draw_ports()
+    c.write_gds(gds_dir / f"{name}.gds")
+    fig, ax = plt.subplots()
+    c.plot(ax=ax)
+    fig.savefig(gds_dir / f"{name}.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _write_gds(name: str) -> bool:
+    """Write GDS and PNG for a cell.
+
+    Returns:
+        True if files were written successfully, False otherwise.
+    """
+    sig = inspect.signature(cells[name])
+    kwargs = {
+        p: sig.parameters[p].default
+        for p in sig.parameters
+        if isinstance(sig.parameters[p].default, int | float | str | tuple)
+        and p not in skip_settings
+    }
+    try:
+        c = cells[name](**kwargs).copy()
+        _generate_artifacts(c, name)
+    except Exception:
+        traceback.print_exc()
+        return False
+    else:
+        return True
 
 
 def get_kwargs(sig: inspect.Signature) -> str:
@@ -43,6 +99,8 @@ def get_kwargs(sig: inspect.Signature) -> str:
     ])
 
 
+_setup_kwasm_viewer()
+
 # Generate cells.rst
 cells_items = []
 for name in sorted(cells.keys()):
@@ -51,7 +109,8 @@ for name in sorted(cells.keys()):
     print(name)
     sig = inspect.signature(cells[name])
     kwargs = get_kwargs(sig)
-    cells_items.append({"name": name, "kwargs": kwargs})
+    has_gds = name not in skip_plot and _write_gds(name)
+    cells_items.append({"name": name, "kwargs": kwargs, "has_gds": has_gds})
 
 template = env.get_template("cells.rst.j2")
 rendered = template.render(items=cells_items, skip_plot=skip_plot)

--- a/docs/templates/cells.rst.j2
+++ b/docs/templates/cells.rst.j2
@@ -36,6 +36,22 @@ API Reference
 
 .. autofunction:: qpdk.cells.{{ item.name }}
 {%     if item.name not in skip_plot %}
+{%         if item.has_gds %}
+
+.. tab-set::
+
+   .. tab-item:: Static
+
+      .. image:: kwasm/gds/{{ item.name }}.png
+         :alt: {{ item.name }}
+
+   .. tab-item:: Dynamic
+
+      .. raw:: html
+
+         <iframe src="kwasm/viewer.html?url=gds/{{ item.name }}.gds" loading="lazy" width="100%" height="400" style="border:none"></iframe>
+
+{%         else %}
 
 .. plot::
 
@@ -45,6 +61,7 @@ API Reference
    c = cells.{{ item.name }}({{ item.kwargs }}).copy()
    c.draw_ports()
    c.plot()
+{%         endif %}
 {%     endif %}
 {% endfor %}
 


### PR DESCRIPTION
Fixes #642

## Summary

- Each layout viewer in the API Reference docs now renders as two tabs: **Static** (PNG image, default) and **Dynamic** (interactive kwasm viewer)
- Gallery grid cards retain `.. plot::` for dynamic thumbnail rendering

## Test plan

- [ ] Run docs build and verify cells page renders with Static/Dynamic tabs
- [ ] Confirm tab switching works between Static and Dynamic views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add static PNG and dynamic kwasm-based viewers for cell layouts in the API reference cells page.

New Features:
- Generate GDS and PNG artifacts for cells to support static and dynamic documentation views.
- Render cells API reference entries with tabbed Static/Dynamic layout viewers when GDS generation succeeds.

Enhancements:
- Introduce a reusable kwasm viewer HTML artifact in the docs and ensure the required directory structure is created during docs generation.