### PR TITLE
chore: bump gdsfactory to ~=9.44.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
   "doroutes~=1.1.0",
-  "gdsfactory~=9.43.0",
+  "gdsfactory~=9.44.0",
   "typing-extensions>=4.12.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1055,7 +1055,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.43.0"
+version = "9.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -1091,9 +1091,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/fd/003bc9e4a99c88acf7edfeedc2fa27a9922be881a435266c6b96228ae715/gdsfactory-9.43.0.tar.gz", hash = "sha256:63c9e8af8167a0eb26501c58eb7bbddca8e754e22c3fa89133a945f50358465a", size = 551466, upload-time = "2026-05-16T23:32:48.855Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/6b1751eab32f1ec7c4506a2dadb59194878f729de84905756b1c3a438343/gdsfactory-9.44.0.tar.gz", hash = "sha256:f993d35df133110938a368a6a3de60c23672ec7e5877a37c17eb92c630077727", size = 555361, upload-time = "2026-06-12T15:33:26.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/41/96779e4bdcecdabb60bb20fd00b6deb9801912ba9a4dd85b0f0304f6a482/gdsfactory-9.43.0-py3-none-any.whl", hash = "sha256:b57f8fc898fa9c44d1adf827b34ffb354aa6aeef0726cd90b62a702ef6649843", size = 802406, upload-time = "2026-05-16T23:32:46.171Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c9/eb4b7a5c8b4c05cb9d2dbf348527f58029dd23f118bdf1919ee2f6dde5a5/gdsfactory-9.44.0-py3-none-any.whl", hash = "sha256:e07473acb91af16dd55c2964d13974e86ee7614dad70f70503543d9223c899d0", size = 806596, upload-time = "2026-06-12T15:33:23.765Z" },
 ]
 
 [[package]]
@@ -3860,7 +3860,7 @@ test = [
 requires-dist = [
     { name = "doroutes", specifier = "~=1.1.0" },
     { name = "flax", marker = "extra == 'netket'" },
-    { name = "gdsfactory", specifier = "~=9.43.0" },
+    { name = "gdsfactory", specifier = "~=9.44.0" },
     { name = "gdsfactoryplus", marker = "extra == 'gdsfactoryplus'" },
     { name = "gplugins", extras = ["meshwell"], marker = "extra == 'models'", specifier = "~=2.1.0" },
     { name = "httpx", marker = "extra == 'gdsfactoryplus'" },


### PR DESCRIPTION
Bump gdsfactory dependency to `~=9.44.0` across all pyproject.toml files.

## Summary by Sourcery

Build:
- Update gdsfactory dependency constraint from ~=9.43.0 to ~=9.44.0 in pyproject configuration