### PR TITLE
Switch CI workflows to pdk-ci-workflow-public

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,6 @@ permissions:
   id-token: write
 jobs:
   review:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/claude-pr-review.yml@main # zizmor: ignore[unpinned-uses]
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -9,6 +9,6 @@ permissions:
   pull-requests: write
 jobs:
   drc:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/drc.yml@main # zizmor: ignore[unpinned-uses]
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -22,4 +22,4 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/issue.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -74,7 +74,7 @@ jobs:
       actions: read
       pages: write
       id-token: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main # zizmor: ignore[unpinned-uses, secrets-inherit]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/pages.yml@main # zizmor: ignore[unpinned-uses, secrets-inherit]
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
       SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,4 +6,4 @@ on:
     branches: [main]
 jobs:
   draft:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/release-drafter.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,19 +112,19 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/test_coverage.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   model-coverage:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_coverage.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   model-regression:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_regression.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   test-matlab:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -10,5 +10,5 @@ jobs:
   badges:
     permissions:
       contents: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/update_badges.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: ^uv\.lock$
 # 40: Global structure checks (end-of-file-fixer).
 # 50: Global whitespace cleanup.
 repos:
-  - repo: https://github.com/doplaydo/pdk-ci-workflow
+  - repo: https://github.com/doplaydo/pdk-ci-workflow-public
     rev: f566e80e1525b5d53bb41a49e953d217b68d6453
     hooks:
       - id: check-required-files


### PR DESCRIPTION
## Summary
- Switches all reusable workflow references from `doplaydo/pdk-ci-workflow` to `doplaydo/pdk-ci-workflow-public`
- Updates `.pre-commit-config.yaml` to use the public repo for hooks

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch CI and local tooling to use the public pdk-ci reusable workflows and hooks repository.

Build:
- Update pre-commit configuration to pull hooks from doplaydo/pdk-ci-workflow-public.

CI:
- Update all GitHub Actions workflows to reference doplaydo/pdk-ci-workflow-public reusable workflows instead of the private repository.