### PR TITLE
fix: convert tuple S-param keys to string labels in all_models notebook

### DIFF
--- a/notebooks/all_models.ipynb
+++ b/notebooks/all_models.ipynb
@@ -264,7 +264,7 @@
     "f = jnp.linspace(1e9, 25e9, 201)\n",
     "S = gamma_0_load(f=f, gamma_0=0.5 + 0.5j, n_ports=2)\n",
     "for key in S:\n",
-    "    plt.plot(f / 1e9, abs(S[key]) ** 2, label=key)\n",
+    "    plt.plot(f / 1e9, abs(S[key]) ** 2, label=str(key))\n",
     "plt.ylim(-0.05, 1.05)\n",
     "plt.xlabel(\"Frequency [GHz]\")\n",
     "plt.ylabel(\"S\")\n",

--- a/notebooks/src/all_models.py
+++ b/notebooks/src/all_models.py
@@ -121,7 +121,7 @@ josephson_junction(f=TEST_FREQUENCY)
 f = jnp.linspace(1e9, 25e9, 201)
 S = gamma_0_load(f=f, gamma_0=0.5 + 0.5j, n_ports=2)
 for key in S:
-    plt.plot(f / 1e9, abs(S[key]) ** 2, label=key)
+    plt.plot(f / 1e9, abs(S[key]) ** 2, label=str(key))
 plt.ylim(-0.05, 1.05)
 plt.xlabel("Frequency [GHz]")
 plt.ylabel("S")


### PR DESCRIPTION
## Summary
- Fixes `ValueError: label must be scalar or have the same length as the input data` in `notebooks/all_models.ipynb`
- Newer matplotlib rejects tuple labels; wrapping with `str()` produces a readable label like `"('o1', 'o2')"`

Closes #648

## Test plan
- [ ] Run `all_models.ipynb` end-to-end without errors

## Summary by Sourcery

Bug Fixes:
- Convert tuple S-parameter dictionary keys to string labels when plotting to avoid label shape ValueError in the all_models notebook and script.