### PR TITLE
Fix PDK CI workflow link and update PR labeler trigger

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -11,6 +11,6 @@ permissions:
   id-token: write
 jobs:
   review:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/claude-pr-review.yml@main # zizmor: ignore[unpinned-uses]
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -9,6 +9,6 @@ permissions:
   pull-requests: write
 jobs:
   drc:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/drc.yml@main # zizmor: ignore[unpinned-uses]
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -22,4 +22,4 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/issue.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,6 @@
 name: Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 permissions:
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -74,7 +74,7 @@ jobs:
       actions: read
       pages: write
       id-token: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main # zizmor: ignore[unpinned-uses, secrets-inherit]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/pages.yml@main # zizmor: ignore[unpinned-uses, secrets-inherit]
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
       SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,4 +6,4 @@ on:
     branches: [main]
 jobs:
   draft:
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/release-drafter.yml@main # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,19 +112,19 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/test_coverage.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   model-coverage:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_coverage.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   model-regression:
     permissions:
       contents: write
       pull-requests: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/model_regression.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]
   test-matlab:
     runs-on: ubuntu-latest

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -10,5 +10,5 @@ jobs:
   badges:
     permissions:
       contents: write
-    uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main # zizmor: ignore[unpinned-uses]
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/update_badges.yml@main # zizmor: ignore[unpinned-uses]
     secrets: inherit # zizmor: ignore[secrets-inherit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: ^uv\.lock$
 # 50: Global whitespace cleanup.
 repos:
   - repo: https://github.com/doplaydo/pdk-ci-workflow-public
-    rev: f566e80e1525b5d53bb41a49e953d217b68d6453
+    rev: 268d1a04880a24771ff66b1a8b433b289e1ff7a8
     hooks:
       - id: check-required-files
         priority: 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ exclude: ^uv\.lock$
 # 40: Global structure checks (end-of-file-fixer).
 # 50: Global whitespace cleanup.
 repos:
-  - repo: https://github.com/doplaydo/pdk-ci-workflow
+  - repo: https://github.com/doplaydo/pdk-ci-workflow-public
     rev: f566e80e1525b5d53bb41a49e953d217b68d6453
     hooks:
       - id: check-required-files

--- a/docs/make_commands.md
+++ b/docs/make_commands.md
@@ -1,7 +1,7 @@
 ## Makefile Compatibility
 
 A `Makefile` is provided as a thin compatibility layer for the
-[gdsfactory PDK CI workflows](https://github.com/doplaydo/pdk-ci-workflow). **`just` remains the primary task runner**
+[gdsfactory PDK CI workflows](https://github.com/doplaydo/pdk-ci-workflow-public). **`just` remains the primary task runner**
 for day-to-day development; the Makefile exists so that `make install` and `make test` work out-of-the-box in CI
 environments that expect them.
 


### PR DESCRIPTION
## Summary
This PR addresses two critical CI issues:

1. **Fix lychee link checker failure:** Updates the broken link `https://github.com/doplaydo/pdk-ci-workflow` to `https://github.com/doplaydo/pdk-ci-workflow-public` in `docs/make_commands.md`.
2. **Fix PR labeler permission failure:** Changes the PR Labeler trigger event from `pull_request` to `pull_request_target` in `.github/workflows/labeler.yml` so that it runs with write permissions for pull requests from forks.

This PR replaces #647, which was opened from an external fork and could not successfully run the Labeler workflow.

## Summary by Sourcery

Switch CI and tooling integrations to the public PDK CI workflow and adjust PR labeling permissions.

Build:
- Point the pre-commit configuration at the public pdk-ci-workflow-public repository for shared hooks.

CI:
- Update all GitHub Actions workflows to reference the public pdk-ci reusable workflows instead of the private repository.
- Change the PR labeler workflow trigger to use pull_request_target so it can run with write permissions on forked pull requests.

Documentation:
- Update documentation to reference the public PDK CI workflow link in the Makefile compatibility section.