### PR TITLE
Update CODEOWNERS to remove a member

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt @das-dias
+* @joamatab @nikosavola @Alex-l-r @sheron-lian @thanojo @cdaunt @das-dias


### PR DESCRIPTION
Removed @ThomasPluck from CODEOWNERS list.

## Summary by Sourcery

Chores:
- Remove an outdated member from the CODEOWNERS list.