### PR TITLE
Fix broken gdsfactory Code of Conduct link

### DIFF
--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,4 +1,4 @@
 ## Code of Conduct
 
 We follow the [gdsfactory](https://github.com/gdsfactory/gdsfactory)
-[Code of Conduct](https://gdsfactory.github.io/gdsfactory/code_of_conduct.html).
+[Code of Conduct](https://gdsfactory.github.io/gdsfactory/code_of_conduct/).


### PR DESCRIPTION
Closes #682. The link in docs/code_of_conduct.md was updated to the correct rendered docs URL.

## Summary by Sourcery

Documentation:
- Fix the Code of Conduct link in docs to point to the correct rendered gdsfactory documentation page.