### PR TITLE
Add schematic-symbol capability to cells

### DIFF
--- a/qpdk/cells/__init__.py
+++ b/qpdk/cells/__init__.py
@@ -2,6 +2,7 @@
 
 import gdsfactory as gf
 
+from ._schematic import *
 from .airbridge import *
 from .bump import *
 from .capacitor import *

--- a/qpdk/cells/_schematic.py
+++ b/qpdk/cells/_schematic.py
@@ -1,0 +1,191 @@
+"""Reusable schematic factory for qpdk cells, linked to SAX models.
+
+Mirrors gdsfactory's ``gpdk/_schematic.py`` port-pattern approach and
+IHP's ``s.info["models"]`` SPICE-link pattern, but carries SAX model
+references instead of SPICE.
+"""
+
+from __future__ import annotations
+
+from kfactory.schematic import DSchematic
+
+__all__ = [
+    "bend_circular_schematic",
+    "double_pad_transmon_schematic",
+    "meander_inductor_schematic",
+    "resonator_schematic",
+    "sax_model",
+    "schematic",
+    "straight_schematic",
+]
+
+# ---------------------------------------------------------------------------
+# Port patterns
+# ---------------------------------------------------------------------------
+
+# 2-port horizontal (straight, taper, transition, resonator)
+_2PORT = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+]
+
+# 1-port (shorted/open resonator end, etc.)
+_1PORT = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+]
+
+# 3-port (couplers, tees)
+_3PORT = [
+    {"name": "o1", "side": "left", "type": "photonic"},
+    {"name": "o2", "side": "right", "type": "photonic"},
+    {"name": "o3", "side": "top", "type": "photonic"},
+]
+
+# Transmon qubit
+_TRANSMON = [
+    {"name": "left_pad", "side": "left", "type": "photonic"},
+    {"name": "right_pad", "side": "right", "type": "photonic"},
+]
+
+# ---------------------------------------------------------------------------
+# Schematic builder
+# ---------------------------------------------------------------------------
+
+_SIDE_XY = {
+    "left": (-1, 0, 180),
+    "right": (1, 0, 0),
+    "top": (0, 1, 90),
+    "bottom": (0, -1, 270),
+}
+
+
+def _make_schematic(
+    symbol: str,
+    tags: list[str],
+    ports: list[dict],
+    models: list[dict] | None,
+) -> DSchematic:
+    """Build a DSchematic from port patterns.
+
+    Args:
+        symbol: Name of the symbol.
+        tags: List of tags for the symbol.
+        ports: List of port definitions.
+        models: List of model definitions.
+
+    Returns:
+        DSchematic: The built schematic.
+
+    Raises:
+        ValueError: If a port has an unknown side.
+    """
+    # Deep-copy ports and models: both are lists of dicts shared across all
+    # calls via module-level constants and closure variables.
+    s = DSchematic()
+    s.info["symbol"] = symbol
+    s.info["tags"] = list(tags)
+    s.info["ports"] = [dict(p) for p in ports]
+    s.info["models"] = [dict(m) for m in models or []]
+
+    side_counts: dict[str, int] = {}
+    for port in ports:
+        side_counts[port["side"]] = side_counts.get(port["side"], 0) + 1
+
+    seen_sides: dict[str, int] = {}
+    spacing = 0.5
+    for port in ports:
+        side = port["side"]
+        try:
+            bx, by, orientation = _SIDE_XY[side]
+        except KeyError as exc:
+            raise ValueError(
+                f"schematic {symbol!r} port {port['name']!r}: unknown side "
+                f"{side!r} (expected one of {sorted(_SIDE_XY)})"
+            ) from exc
+        idx = seen_sides.get(side, 0)
+        seen_sides[side] = idx + 1
+        total = side_counts[side]
+        offset = (idx - (total - 1) / 2) * spacing
+        if side in {"left", "right"}:
+            x, y = bx, by + offset
+        else:
+            x, y = bx + offset, by
+
+        port_type = port.get("type", "photonic")
+        xs = "metal_routing" if port_type in {"electric", "electrical"} else "strip"
+        s.create_port(
+            name=port["name"],
+            cross_section=xs,
+            x=x,
+            y=y,
+            orientation=orientation,
+        )
+
+    return s
+
+
+def schematic(
+    symbol: str,
+    tags: list[str],
+    ports: list[dict],
+    models: list[dict] | None = None,
+):
+    """Return a ``schematic_function`` closure for use with ``@gf.cell``."""
+
+    def _schematic_fn(**_kwargs) -> DSchematic:
+        return _make_schematic(symbol, tags, ports, models)
+
+    return _schematic_fn
+
+
+def sax_model(
+    name: str,
+    module: str,
+    port_order: list[str],
+    qualname: str | None = None,
+    params: dict[str, str] | None = None,
+) -> dict:
+    """Build a SAX model entry for ``s.info["models"]``."""
+    return {
+        "language": "sax",
+        "name": name,
+        "module": module,
+        "qualname": qualname or name,
+        "port_order": list(port_order),
+        "params": dict(params) if params else {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pre-defined schematic functions
+# ---------------------------------------------------------------------------
+
+straight_schematic = schematic(
+    symbol="straight",
+    tags=["waveguides"],
+    ports=_2PORT,
+)
+
+bend_circular_schematic = schematic(
+    symbol="bend_circular",
+    tags=["waveguides"],
+    ports=_2PORT,
+)
+
+resonator_schematic = schematic(
+    symbol="resonator",
+    tags=["resonators"],
+    ports=_2PORT,
+)
+
+double_pad_transmon_schematic = schematic(
+    symbol="double_pad_transmon",
+    tags=["qubits", "transmons"],
+    ports=_TRANSMON,
+)
+
+meander_inductor_schematic = schematic(
+    symbol="meander_inductor",
+    tags=["inductors"],
+    ports=_2PORT,
+)

--- a/qpdk/cells/_schematic_tracking.md
+++ b/qpdk/cells/_schematic_tracking.md
@@ -1,0 +1,23 @@
+# Schematic Symbol Tracking
+
+This file tracks the status of schematic symbols for PDK cells.
+
+| Symbol Name         | Status | Icon / Pattern                             |
+| ------------------- | ------ | ------------------------------------------ |
+| straight            | ✅     | straight_schematic (\_2PORT)               |
+| bend_circular       | ✅     | bend_circular_schematic (\_2PORT)          |
+| resonator           | ✅     | resonator_schematic (\_2PORT)              |
+| double_pad_transmon | ✅     | double_pad_transmon_schematic (\_TRANSMON) |
+| meander_inductor    | ✅     | meander_inductor_schematic (\_2PORT)       |
+| half_circle_coupler | ❌     | \_3PORT (needs icon)                       |
+| fluxonium           | ❌     | TBD                                        |
+| unimon              | ❌     | TBD                                        |
+| snspd               | ❌     | TBD                                        |
+| inductor            | ❌     | TBD                                        |
+| capacitor           | ❌     | TBD                                        |
+| junction            | ❌     | TBD                                        |
+| launcher            | ❌     | TBD                                        |
+| airbridge           | ❌     | TBD                                        |
+| bump                | ❌     | TBD                                        |
+| tsv                 | ❌     | TBD                                        |
+| chip                | ❌     | TBD                                        |

--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -8,6 +8,7 @@ import gdsfactory as gf
 from gdsfactory.component import Component
 from gdsfactory.typings import CrossSectionSpec, LayerSpec
 
+from qpdk.cells._schematic import meander_inductor_schematic
 from qpdk.cells.waveguides import straight
 from qpdk.tech import (
     get_etch_section,
@@ -15,7 +16,7 @@ from qpdk.tech import (
 )
 
 
-@gf.cell(tags=("inductors",))
+@gf.cell(tags=("inductors",), schematic_function=meander_inductor_schematic)
 def meander_inductor(
     n_turns: int = 5,
     turn_length: float = 200.0,
@@ -192,6 +193,9 @@ def meander_inductor(
     c.info["cross_section"] = xs.name
 
     return c
+
+
+meander_inductor.schematic_function = meander_inductor_schematic
 
 
 @gf.cell(tags=("resonators", "inductors", "capacitors"))

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -9,11 +9,12 @@ import numpy as np
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
+from qpdk.cells._schematic import resonator_schematic
 from qpdk.cells.waveguides import bend_circular, straight
 from qpdk.tech import get_etch_section
 
 
-@gf.cell(tags=("resonators",))
+@gf.cell(tags=("resonators",), schematic_function=resonator_schematic)
 def resonator(
     length: float = 4000.0,
     meanders: int = 6,
@@ -196,6 +197,9 @@ def resonator(
     # )  # GHz, rough estimate
 
     return c
+
+
+resonator.schematic_function = resonator_schematic
 
 
 # A quarter-wave resonator is shorted at one end and has maximum electric field

--- a/qpdk/cells/transmon.py
+++ b/qpdk/cells/transmon.py
@@ -11,6 +11,7 @@ from gdsfactory.typings import ComponentSpec, LayerSpec
 from kfactory import kdb
 from klayout.db import DCplxTrans, Region
 
+from qpdk.cells._schematic import double_pad_transmon_schematic
 from qpdk.cells.bump import indium_bump
 from qpdk.cells.junction import squid_junction, squid_junction_long
 from qpdk.tech import LAYER
@@ -20,7 +21,11 @@ from qpdk.utils import (
 )
 
 
-@gf.cell(check_instances=False, tags=("qubits", "transmons"))
+@gf.cell(
+    check_instances=False,
+    tags=("qubits", "transmons"),
+    schematic_function=double_pad_transmon_schematic,
+)
 def double_pad_transmon(
     pad_size: tuple[float, float] = (250.0, 400.0),
     pad_gap: float = 15.0,
@@ -126,6 +131,9 @@ def double_pad_transmon(
     c.info["qubit_type"] = "transmon"
 
     return c
+
+
+double_pad_transmon.schematic_function = double_pad_transmon_schematic
 
 
 @gf.cell(tags=("qubits", "transmons"))

--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -8,6 +8,10 @@ from kfactory import VInstance
 from klayout.db import DCplxTrans
 
 from qpdk import tech
+from qpdk.cells._schematic import (
+    bend_circular_schematic,
+    straight_schematic,
+)
 from qpdk.logger import logger
 from qpdk.tech import get_etch_section
 
@@ -50,7 +54,7 @@ taper_cross_section = partial(
 )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), schematic_function=straight_schematic)
 def straight(
     length: float = 10.0,
     cross_section: CrossSectionSpec = _DEFAULT_CROSS_SECTION,
@@ -70,6 +74,7 @@ def straight(
     )
 
 
+straight.schematic_function = straight_schematic
 straight_shorted = straight
 
 
@@ -240,7 +245,7 @@ def bend_euler(
     )
 
 
-@gf.cell(tags=("waveguides",))
+@gf.cell(tags=("waveguides",), schematic_function=bend_circular_schematic)
 def bend_circular(
     angle: float = 90.0,
     radius: float = 100.0,
@@ -283,6 +288,9 @@ def bend_circular(
         allow_min_radius_violation=allow_min_radius_violation,
         **kwargs,
     )
+
+
+bend_circular.schematic_function = bend_circular_schematic
 
 
 @gf.cell(tags=("waveguides",))

--- a/tests/test_schematic.py
+++ b/tests/test_schematic.py
@@ -1,0 +1,51 @@
+"""Tests for schematic symbols."""
+
+from kfactory.schematic import DSchematic
+
+from qpdk.cells import (
+    bend_circular,
+    double_pad_transmon,
+    meander_inductor,
+    resonator,
+    straight,
+)
+from qpdk.cells._schematic import (
+    double_pad_transmon_schematic,
+    straight_schematic,
+)
+
+
+def test_schematic_functions():
+    """Verify that schematic functions are attached to cells."""
+    cells = [
+        straight,
+        bend_circular,
+        resonator,
+        double_pad_transmon,
+        meander_inductor,
+    ]
+
+    for cell in cells:
+        # Check if schematic_function is attached to the cell
+        assert hasattr(cell, "schematic_function")
+        assert cell.schematic_function is not None
+
+        # Execute it and verify it returns a DSchematic
+        s = cell.schematic_function()
+        assert isinstance(s, DSchematic)
+        assert "symbol" in s.info
+
+
+def test_schematic_factory():
+    """Verify that schematic factory returns correct DSchematic objects."""
+    s = straight_schematic()
+    assert isinstance(s, DSchematic)
+    assert s.info["symbol"] == "straight"
+    assert "o1" in s.ports
+    assert "o2" in s.ports
+
+    s = double_pad_transmon_schematic()
+    assert isinstance(s, DSchematic)
+    assert s.info["symbol"] == "double_pad_transmon"
+    assert "left_pad" in s.ports
+    assert "right_pad" in s.ports


### PR DESCRIPTION
Closes #680. Added schematic factory and patterns in _schematic.py, and enabled it for several core cells.

## Summary by Sourcery

Introduce reusable schematic symbol factory and attach schematic functions to key PDK cells for waveguides, resonators, inductors, and transmons.

New Features:
- Add a generic schematic factory and SAX model descriptor utilities for defining DSchematic symbols for PDK cells.
- Provide predefined schematic-symbol functions for straight waveguides, circular bends, resonators, meander inductors, and double-pad transmons.
- Expose schematic utilities via the qpdk.cells package for external use.
- Document current schematic symbol coverage and planned symbols in a tracking Markdown file.

Tests:
- Add tests to ensure schematic functions are attached to core cells and that the schematic factory produces correct DSchematic objects.