### PR TITLE
Add MATLAB language server pre-commit hooks and CI lint step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      SKIP: matlab-diagnostics,matlab-format,matlab-quickfix  # No license
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -175,6 +177,22 @@ jobs:
       - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
         with:
           cache: true
+      - name: Checkout MATLAB lint helper
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: nikosavola/MATLAB-language-server-pre-commit
+          ref: v0.1.0
+          sparse-checkout: matlab
+          sparse-checkout-cone-mode: false
+          path: matlab-lsp-hook
+      - name: Run MATLAB Code Analyzer lint
+        uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0
+        with:
+          command: |
+            diary('/tmp/matlab_lint.log'); diary on;
+            addpath('matlab-lsp-hook/matlab');
+            lintFiles();
+            diary off;
       - name: Sanity-check MATLAB ↔ Python bridge
         uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0
         with:
@@ -200,6 +218,8 @@ jobs:
       - name: Print MATLAB diary on failure
         if: failure()
         run: |
+          echo "=== /tmp/matlab_lint.log ==="
+          cat /tmp/matlab_lint.log 2>/dev/null || echo "(missing)"
           echo "=== /tmp/matlab_bridge.log ==="
           cat /tmp/matlab_bridge.log 2>/dev/null || echo "(missing)"
           echo "=== /tmp/matlab_script.log ==="
@@ -210,6 +230,7 @@ jobs:
           name: matlab-notebook-artifacts
           path: |
             /tmp/qpdk_matlab_demo/**
+            /tmp/matlab_lint.log
             /tmp/matlab_bridge.log
             /tmp/matlab_script.log
           if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,22 +177,7 @@ jobs:
       - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
         with:
           cache: true
-      - name: Checkout MATLAB lint helper
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: nikosavola/MATLAB-language-server-pre-commit
-          ref: v0.1.0
-          sparse-checkout: matlab
-          sparse-checkout-cone-mode: false
-          path: matlab-lsp-hook
-      - name: Run MATLAB Code Analyzer lint
-        uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0
-        with:
-          command: |
-            diary('/tmp/matlab_lint.log'); diary on;
-            addpath('matlab-lsp-hook/matlab');
-            lintFiles();
-            diary off;
+      - uses: nikosavola/MATLAB-language-server-pre-commit@v0.1.1 # zizmor: ignore[unpinned-uses]
       - name: Sanity-check MATLAB ↔ Python bridge
         uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0
         with:
@@ -218,8 +203,6 @@ jobs:
       - name: Print MATLAB diary on failure
         if: failure()
         run: |
-          echo "=== /tmp/matlab_lint.log ==="
-          cat /tmp/matlab_lint.log 2>/dev/null || echo "(missing)"
           echo "=== /tmp/matlab_bridge.log ==="
           cat /tmp/matlab_bridge.log 2>/dev/null || echo "(missing)"
           echo "=== /tmp/matlab_script.log ==="
@@ -230,7 +213,6 @@ jobs:
           name: matlab-notebook-artifacts
           path: |
             /tmp/qpdk_matlab_demo/**
-            /tmp/matlab_lint.log
             /tmp/matlab_bridge.log
             /tmp/matlab_script.log
           if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     env:
-      SKIP: matlab-diagnostics,matlab-format,matlab-quickfix  # No license
+      PREK_SKIP: matlab-diagnostics,matlab-format,matlab-quickfix  # No license
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
       - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
         with:
           cache: true
-      - uses: nikosavola/MATLAB-language-server-pre-commit@v0.1.1 # zizmor: ignore[unpinned-uses]
+      - uses: nikosavola/MATLAB-language-server-pre-commit@5966190480d0a77bf731bac19df84417aabc63b2 # v0.1.1
       - name: Sanity-check MATLAB ↔ Python bridge
         uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -215,7 +215,7 @@ repos:
         priority: 10
         args: [--line-length=100]
   - repo: https://github.com/nikosavola/MATLAB-language-server-pre-commit
-    rev: v0.1.0
+    rev: v0.1.1
     hooks:
       - id: matlab-format
         priority: 20

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -214,6 +214,15 @@ repos:
       - id: matlab-reflow-comments
         priority: 10
         args: [--line-length=100]
+  - repo: https://github.com/nikosavola/MATLAB-language-server-pre-commit
+    rev: v0.1.0
+    hooks:
+      - id: matlab-format
+        priority: 20
+      - id: matlab-diagnostics
+        priority: 30
+      - id: matlab-quickfix
+        priority: 30
   - repo: https://github.com/econchick/interrogate
     rev: 1.7.0
     hooks:


### PR DESCRIPTION
- Add `matlab-format`, `matlab-diagnostics`, `matlab-quickfix` hooks from [MATLAB-language-server-pre-commit](https://github.com/nikosavola/MATLAB-language-server-pre-commit)
- Skip those hooks in the generic `pre-commit` CI job (no MATLAB there, and the free public-project license doesn't cover the language server's own MATLAB process)
- Add the equivalent lint check to the `test-matlab` job via `nikosavola/MATLAB-language-server-pre-commit@v0.1.1`, which works under the free license

Note: depends on `v0.1.1` being published on the hook repo.

## Summary by Sourcery

Integrate MATLAB language server linting into the project while accommodating licensing constraints in CI.

New Features:
- Add MATLAB-language-server-based format, diagnostics, and quick-fix hooks to the pre-commit configuration.

CI:
- Skip MATLAB language server hooks in the generic pre-commit CI job via SKIP environment configuration.
- Add MATLAB language server lint step to the MATLAB CI job using the dedicated MATLAB-language-server-pre-commit action.