### PR TITLE
fix(docs): serve kwasm viewer so the Dynamic PCell tab works

### DIFF
--- a/.github/write_cells.py
+++ b/.github/write_cells.py
@@ -21,8 +21,17 @@ filepath_cells = PATH.docs / "cells.rst"
 filepath_samples = PATH.docs / "samples.rst"
 template_dir = PATH.docs / "templates"
 
-kwasm_dir = PATH.docs / "kwasm"
+# Lives under ``docs/_extra`` which is declared as ``html_extra_path`` in
+# ``docs/conf.py``, so its contents are copied verbatim to the HTML output root
+# as ``kwasm/``.  Sphinx only copies files it knows about (``.. image::``
+# targets and the like), so the viewer HTML and the GDS files it fetches would
+# otherwise never reach the built site and the Dynamic tab would 404.
+kwasm_dir = PATH.docs / "_extra" / "kwasm"
 gds_dir = kwasm_dir / "gds"
+# Static previews are referenced with ``.. image::`` so Sphinx copies them into
+# ``_images/`` itself; keeping them out of ``_extra`` avoids shipping a second
+# copy of every preview.
+png_dir = PATH.docs / "_generated" / "cells"
 
 skip = {}
 
@@ -41,6 +50,7 @@ env = Environment(loader=FileSystemLoader(template_dir), autoescape=False)
 def _setup_kwasm_viewer() -> None:
     """Create the kwasm viewer HTML and GDS output directory."""
     gds_dir.mkdir(parents=True, exist_ok=True)
+    png_dir.mkdir(parents=True, exist_ok=True)
     viewer_path = kwasm_dir / "viewer.html"
     if viewer_path.exists():
         return
@@ -58,7 +68,7 @@ def _generate_artifacts(c, name: str) -> None:
     c.write_gds(gds_dir / f"{name}.gds")
     fig, ax = plt.subplots()
     c.plot(ax=ax)
-    fig.savefig(gds_dir / f"{name}.png", dpi=150, bbox_inches="tight")
+    fig.savefig(png_dir / f"{name}.png", dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,8 @@ docs/cells.rst
 docs/models.rst
 docs/samples.rst
 docs/notebooks/
+docs/_extra/
+docs/_generated/
 docs/makefile_help.txt
 docs/justfile_help.txt
 !notebooks/*.ipynb

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ plot_apply_rcparams = True  # Ensure rcParams are applied even with :context:
 
 exclude_patterns = [
     "_build",
+    "_extra",
     "conf.py",
     "ipython_config.py",
     "*.mplstyle",
@@ -206,6 +207,11 @@ html_context = {
     "doc_path": "docs",
 }
 html_static_path = ["_static"]
+# Contents are copied verbatim to the output root, so ``docs/_extra/kwasm/``
+# becomes ``kwasm/`` on the built site.  This is what serves the interactive
+# viewer and the GDS files behind the "Dynamic" tab of each PCell; Sphinx does
+# not copy them on its own since they are only referenced from ``.. raw:: html``.
+html_extra_path = ["_extra"]
 html_css_files = [
     "css/custom.css",
 ]

--- a/docs/templates/cells.rst.j2
+++ b/docs/templates/cells.rst.j2
@@ -42,7 +42,7 @@ API Reference
 
    .. tab-item:: Static
 
-      .. image:: kwasm/gds/{{ item.name }}.png
+      .. image:: _generated/cells/{{ item.name }}.png
          :alt: {{ item.name }}
 
    .. tab-item:: Dynamic


### PR DESCRIPTION
Fixes #710

## Problem

Every PCell on the [cells page](https://gdsfactory.github.io/quantum-rf-pdk/cells.html) has a `Static` / `Dynamic` tab pair. The `Dynamic` tab is blank.

The template embeds the kwasm viewer from a `raw:: html` block:

```html
<iframe src="kwasm/viewer.html?url=gds/<cell>.gds" ...></iframe>
```

`write_cells.py` writes `viewer.html` and the per-cell `.gds` into `docs/kwasm/`, but Sphinx only copies files it knows about (`.. image::` targets, `html_static_path`, …). Nothing references those as Sphinx resources, so `docs/kwasm/` never reaches the build output:

```
GET /quantum-rf-pdk/cells.html        -> 200
GET /quantum-rf-pdk/kwasm/viewer.html -> 404
```

The `Static` tab works because its previews go through `.. image::`, which Sphinx does copy into `_images/`.

## Fix

- Generate `viewer.html` + `gds/*.gds` into `docs/_extra/kwasm/`, and declare `html_extra_path = ["_extra"]`. Sphinx copies the contents of an extra path verbatim to the output root, so they land at `kwasm/…` — exactly the URL the existing iframe already uses. No change to the iframe markup.
- Move the static previews to `docs/_generated/cells/`. They are referenced via `.. image::`, so Sphinx copies them into `_images/` on its own; keeping them out of `_extra` avoids shipping a second copy of all 62 previews (~9 MB).
- `_extra` added to `exclude_patterns` so Sphinx does not also treat it as source; both generated dirs added to `.gitignore` alongside the other generated docs artifacts.

## Verification

- Reproduced the 404 against the deployed site (above).
- Confirmed the kwasm bundled viewer does support the `?url=` query parameter it is being handed (`new URLSearchParams(window.location.search).get('url')` → `loadUrl(...)`), so the iframe URL itself was never the problem — only the missing files.
- Built a minimal Sphinx project with this exact layout and `-W`: clean build, and the output tree contains `kwasm/viewer.html` and `kwasm/gds/<cell>.gds` at the root with the image still resolving to `_images/`.
- `pre-commit` run on the changed files passes. (`pyrefly` and `lychee` fail in my sandbox for environment reasons — Python 3.11 vs the repo's 3.12 on pre-existing `tests/` files, and a glibc mismatch in the lychee binary — neither touches these changes.)

> [!NOTE]
> Please confirm the rendered `Dynamic` tab in the docs preview build before merging — I verified the files are now served and that the viewer reads `?url=`, but I could not render the real viewer end-to-end in my environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Serve kwasm viewer and GDS artifacts via Sphinx so Dynamic PCell tabs work in the built docs.

Enhancements:
- Generate kwasm viewer and GDS files under docs/_extra/kwasm and configure Sphinx html_extra_path to publish them at kwasm/.
- Write static preview PNGs to docs/_generated/cells and reference them via .. image:: to avoid duplicating assets in the built site.
- Exclude _extra from Sphinx source processing and add the generated docs directories to .gitignore.