### PR TITLE
Clean cache directories in just clean recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -24,7 +24,8 @@ install-tech:
 [confirm]
 [group('setup')]
 clean:
-    @rm -rf dist build *.egg-info docs/_build docs/notebooks
+    @rm -rf dist build *.egg-info docs/_build docs/notebooks .hypothesis .pytest_cache .ruff_cache
+    @find . -path ./.venv -prune -o -path ./.git -prune -o -type d -name __pycache__ -exec rm -rf {} +
 
 # Update pre-commit hooks to the latest revisions
 [group('lint')]

--- a/justfile
+++ b/justfile
@@ -23,9 +23,21 @@ install-tech:
 # Clean up all build, test, coverage and Python artifacts
 [confirm]
 [group('setup')]
+[unix]
 clean:
     @rm -rf dist build *.egg-info docs/_build docs/notebooks .hypothesis .pytest_cache .ruff_cache
     @find . -path ./.venv -prune -o -path ./.git -prune -o -type d -name __pycache__ -exec rm -rf {} +
+
+# Clean up all build, test, coverage and Python artifacts
+[confirm]
+[group('setup')]
+[windows]
+[script('powershell.exe')]
+clean:
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue dist, build, *.egg-info, docs/_build, docs/notebooks, .hypothesis, .pytest_cache, .ruff_cache
+    Get-ChildItem -Recurse -Directory -Filter __pycache__ -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '\\\.venv\\' -and $_.FullName -notmatch '\\\.git\\' } |
+        Remove-Item -Recurse -Force
 
 # Update pre-commit hooks to the latest revisions
 [group('lint')]


### PR DESCRIPTION
- `just clean` now also removes `.hypothesis`, `.pytest_cache`, `.ruff_cache`, and nested `__pycache__` directories
- `.venv` and `.vscode` are left untouched since they aren't build/test artifacts

## Summary by Sourcery

Build:
- Extend the `just clean` task to delete Hypothesis, pytest, and Ruff cache directories and recursively remove `__pycache__` folders, while excluding `.venv` and `.git`.