### PR TITLE
Make lumped_element_resonator port types consistent with the rest of the PDK

### DIFF
--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -455,14 +455,14 @@ def lumped_element_resonator(
         name="o1",
         port=straight_left.ports["o1"],
         layer=layer,
-        port_type="electrical",
+        port_type="optical",
         cross_section=xs,
     )
     c.add_port(
         name="o2",
         port=straight_right.ports["o2"],
         layer=layer,
-        port_type="electrical",
+        port_type="optical",
         cross_section=xs,
     )
 

--- a/tests/test_pdk/test_settings_lumped_element_resonator_.yml
+++ b/tests/test_pdk/test_settings_lumped_element_resonator_.yml
@@ -12,7 +12,7 @@ ports:
     layer: M1_DRAW
     name: o1
     orientation: 180
-    port_type: electrical
+    port_type: optical
     width: 2
   o2:
     center:
@@ -21,7 +21,7 @@ ports:
     layer: M1_DRAW
     name: o2
     orientation: 0
-    port_type: electrical
+    port_type: optical
     width: 2
 settings:
   bus_bar_spacing: 4


### PR DESCRIPTION
Closes #713

## Problem

`lumped_element_resonator` declared its `o1`/`o2` ports as `port_type="electrical"` while every other CPW signal-routing cell in the PDK uses `port_type="optical"`. gdsfactory will not connect ports of differing `port_type`, so the cell could not be routed against any other CPW component.

## Audit

I instantiated all 63 cells in the PDK and grouped them by `port_type`. The convention is otherwise fully coherent:

| `port_type` | Used for | Examples |
|-------------|----------|----------|
| `optical` | CPW signal-routing ports | `straight`, `launcher`, `meander_inductor`, `interdigital_capacitor`, `resonator`, `bend_*` |
| `placement` | non-routable geometric anchors | open-etch ends, `junction`, pad centers, `indium_bump`, `tsv` |
| `electrical` | genuine DC terminals | `airbridge` (`e1`/`e2`), `snspd` (`e1`/`e2`), `rectangle` (`e1`-`e4`) |

Cross-checking port *name* against port *type* across every cell yields exactly two violations, both on this cell:

| Cell | File | Ports | Change |
|------|------|-------|--------|
| `lumped_element_resonator` | `qpdk/cells/inductor.py` | `o1`, `o2` | `electrical` → `optical` |

No other cell in the PDK mixes `optical` and `electrical` ports, so this is the complete change set.

## Why `optical` is correct here

- Both child cells (`meander_inductor`, `interdigital_capacitor`) already expose `o1`/`o2` as `optical`.
- The SAX model at `qpdk/models/inductor.py:216` keys off `o1`/`o2`.
- The ports derive from `straight(...)` on the `cpw` cross-section, which produces `optical` ports.
- The ports are named `o1`/`o2` — optical convention — not `e1`/`e2`.

## Changed tests

Per repo policy, noting the regression reference I regenerated and why:

- `tests/test_pdk/test_settings_lumped_element_resonator_.yml` — regenerated with `pytest -s tests/test_pdk.py -k lumped_element_resonator --force-regen`. The only delta is `port_type: electrical` → `port_type: optical` on `o1` and `o2`, which is exactly the intended change. No geometry changed, so no GDS references shifted.

## Test plan

- [x] `pytest tests/test_pdk.py` — 322 passed, 2 skipped
- [x] Full suite — 853 passed, 7 skipped, 12 failed
  - All 12 failures are in `tests/models/test_unimon.py` (Hamiltonian math) and are **pre-existing**: I confirmed the identical 12 failures on unmodified `main` via `git stash`. Unrelated to this change.
- [x] `uvx prek run --all-files` — 29 hooks pass. `lychee` fails to run in my container only (its prebuilt binary requires GLIBC 2.38+); this diff adds no URLs.
- [ ] Human review of the layout/physics intent

## Note

Opened from a fork — I only have read access to this repo. Left as a **draft** for review.

Reminder: AI-created PRs still require human review of the actual code changes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align lumped_element_resonator port types with the CPW routing convention so it can connect to other CPW components.

Bug Fixes:
- Change lumped_element_resonator ports o1 and o2 from electrical to optical to restore compatibility with other CPW signal-routing cells.

Tests:
- Update the lumped_element_resonator golden settings YAML to reflect the optical port types for o1 and o2.