### PR TITLE
test: check all ports have manhattan orientations

### DIFF
--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -280,6 +280,28 @@ def test_optical_port_positions(component_name: str) -> None:
             )
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 if __name__ == "__main__":
     component_type = "coupler_symmetric"
     c = cells[component_type]()

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -283,13 +283,14 @@ def test_optical_port_positions(component_name: str) -> None:
 MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
 
 skip_test_manhattan_ports: set[str] = set()
+manhattan_test_cell_names = [
+    name for name in cell_names if name not in skip_test_manhattan_ports
+]
 
 
-@pytest.mark.parametrize("component_name", cell_names)
+@pytest.mark.parametrize("component_name", manhattan_test_cell_names)
 def test_port_orientations_manhattan(component_name: str) -> None:
     """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
-    if component_name in skip_test_manhattan_ports:
-        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
     component = cells[component_name]()
     if isinstance(component, gf.ComponentAllAngle):
         pytest.skip(f"{component_name} is an all-angle component")


### PR DESCRIPTION
Closes #715

Adds `test_port_orientations_manhattan` to `tests/test_pdk.py`, parametrized over every PDK cell (`cell_names`). For each cell it builds the component and asserts every port's orientation is within 1e-3 of 0/90/180/270 degrees; all-angle components (`gf.ComponentAllAngle`) are skipped, and a `skip_test_manhattan_ports` set is available for known issues. This catches ports at e.g. 44.9 degrees at test time rather than later during routing.

This is a templated rollout of the same test we are adding across our PDKs; the pattern was already reviewed, approved and merged.

⚠️ AI-created PR: a human must review the actual code changes before merge.

## Test plan

- [ ] CI passes (`test_port_orientations_manhattan` across all cells)

## Summary by Sourcery

Tests:
- Add a parametrized test over all PDK cells that asserts each port orientation is within tolerance of 0, 90, 180, or 270 degrees, with skips for all-angle components and known problematic cells.