### PR TITLE
Run MATLAB setup and docs deps install in parallel with step-level background/wait

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,14 @@
 paths:
+  # actionlint v1.7.12 predates step-level parallelism (background steps and wait,
+  # shipped 2026-06-25), so it rejects both new step keys. Scoped to the two
+  # workflows that use them so the rest keep full syntax checking.
+  # Drop this once rhysd/actionlint#693 ships.
   .github/workflows/test.yml:
     ignore:
       - 'unknown permission scope "code-quality"'
+      - 'unexpected key "background" for step'
+      - 'step must run script with "run" section or run action with "uses" section'
+  .github/workflows/pages.yml:
+    ignore:
+      - 'unexpected key "background" for step'
+      - 'step must run script with "run" section or run action with "uses" section'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,7 +20,10 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      - run: just install
+      - name: Install Python dependencies
+        id: install-deps
+        run: just install
+        background: true # runs alongside the ImageMagick/font setup below, which docs-latex also needs
       - name: Cache ImageMagick
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -48,6 +51,8 @@ jobs:
           if [ -f /etc/ImageMagick-6/policy.xml ]; then
             sudo sed -i 's/rights="none" pattern="SVG"/rights="read|write" pattern="SVG"/' /etc/ImageMagick-6/policy.xml
           fi
+      - name: Wait for Python dependency installation
+        wait: install-deps
       - name: Generate LaTeX files
         run: just docs-latex || echo "LaTeX build completed with warnings, continuing…"
       - name: Compile LaTeX document

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,12 @@ jobs:
         with:
           lfs: true
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Set up MATLAB
+        id: matlab-setup
+        uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
+        with:
+          cache: true
+        background: true # runs alongside the Python setup below, MATLAB install is the slower branch
       - name: Install qpdk with models extra
         run: uv sync --extra models
       - name: Export QPDK_PYTHON and Python library paths
@@ -174,9 +180,8 @@ jobs:
           echo "LIBDIR: ${PY_LIBDIR}"
       - name: Sanity-check qpdk import (Python side)
         run: uv run python -c "import qpdk; qpdk.PDK.activate(); print('qpdk activated:', qpdk.PDK.name)"
-      - uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1
-        with:
-          cache: true
+      - name: Wait for MATLAB setup
+        wait: matlab-setup
       - uses: nikosavola/MATLAB-language-server-pre-commit@5966190480d0a77bf731bac19df84417aabc63b2 # v0.1.1
       - name: Sanity-check MATLAB ↔ Python bridge
         uses: matlab-actions/run-command@bcd446a219949c24051c1d04a4b4e0274c42f23b # v3.2.0


### PR DESCRIPTION
Uses the new GitHub Actions step-level parallelism (`background`/`wait`) to overlap independent, slow setup steps:

- **`test.yml` (`test-matlab`)**: MATLAB install now backgrounds while the unrelated Python env setup (`uv sync --extra models` + sanity checks) runs, joined by `wait: matlab-setup` before the MATLAB language-server step.
- **`pages.yml` (`build-docs-pdf`)**: `just install` now backgrounds while ImageMagick/fonts are installed, joined by `wait: install-deps` before `docs-latex`.

`actionlint` v1.7.12 predates this syntax and rejects the new step keys, so `.github/actionlint.yaml` now scopes ignores for the two affected workflows (drop once [rhysd/actionlint#693](https://github.com/rhysd/actionlint/issues/693) ships).

Verified with `uvx prek run --all-files` (actionlint, zizmor, check-jsonschema all pass).

## Summary by Sourcery

Run slow MATLAB and documentation dependency setup steps in parallel within CI workflows to reduce end-to-end job time while keeping dependent steps correctly ordered.

CI:
- Parallelize MATLAB setup with Python environment preparation in test workflow using step-level background/wait.
- Parallelize docs Python dependency installation with ImageMagick/font setup in pages workflow.
- Relax actionlint checks for new step-level parallelism keys in the affected workflows until upstream support is available.