### PR TITLE
fix: preserve RF resonances in recursive SAX

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -24,7 +24,9 @@ exclude = [
   # Persistent identifiers (URNs often redirect in loops; match both http and https)
   "https?://urn.fi/.*",
   # KLayout homepage rejects some automated checks with 415 in CI
-  "https://www.klayout.de/"
+  "https://www.klayout.de/",
+  # Generated PDF can be unavailable while GitHub Pages deploys it
+  "https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf"
 ]
 
 # Set a timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = [
   "doroutes>=1.1,<1.3",
   "gdsfactory~=9.46.0",
-  "typing-extensions>=4.12.0",
+  "typing-extensions>=4.12.0"
 ]
 
 [project.urls]

--- a/qpdk/cells/_schematic.py
+++ b/qpdk/cells/_schematic.py
@@ -13,6 +13,8 @@ __all__ = [
     "bend_circular_schematic",
     "double_pad_transmon_schematic",
     "meander_inductor_schematic",
+    "quarter_wave_resonator_coupled_schematic",
+    "resonator_coupled_schematic",
     "resonator_schematic",
     "sax_model",
     "schematic",
@@ -40,6 +42,17 @@ _3PORT = [
     {"name": "o2", "side": "right", "type": "photonic"},
     {"name": "o3", "side": "top", "type": "photonic"},
 ]
+
+# Coupled resonator model ports. The resonator endpoint is intentionally
+# retained in the SAX model boundary even though it is not a chip-level port.
+_RESONATOR_COUPLED = [
+    {"name": "coupling_o1", "side": "left", "type": "photonic"},
+    {"name": "coupling_o2", "side": "right", "type": "photonic"},
+    {"name": "resonator_o1", "side": "top", "type": "photonic"},
+    {"name": "resonator_o2", "side": "bottom", "type": "photonic"},
+]
+
+_QUARTER_WAVE_RESONATOR_COUPLED = _RESONATOR_COUPLED[:3]
 
 # Transmon qubit
 _TRANSMON = [
@@ -176,6 +189,37 @@ resonator_schematic = schematic(
     symbol="resonator",
     tags=["resonators"],
     ports=_2PORT,
+)
+
+resonator_coupled_schematic = schematic(
+    symbol="resonator_coupled",
+    tags=["resonators", "couplers"],
+    ports=_RESONATOR_COUPLED,
+    models=[
+        sax_model(
+            name="resonator_coupled",
+            module="qpdk.models.resonator",
+            port_order=[
+                "coupling_o1",
+                "coupling_o2",
+                "resonator_o1",
+                "resonator_o2",
+            ],
+        )
+    ],
+)
+
+quarter_wave_resonator_coupled_schematic = schematic(
+    symbol="quarter_wave_resonator_coupled",
+    tags=["resonators", "couplers"],
+    ports=_QUARTER_WAVE_RESONATOR_COUPLED,
+    models=[
+        sax_model(
+            name="quarter_wave_resonator_coupled",
+            module="qpdk.models.resonator",
+            port_order=["coupling_o1", "coupling_o2", "resonator_o1"],
+        )
+    ],
 )
 
 double_pad_transmon_schematic = schematic(

--- a/qpdk/cells/resonator.py
+++ b/qpdk/cells/resonator.py
@@ -9,7 +9,11 @@ import numpy as np
 from gdsfactory.component import Component
 from gdsfactory.typings import ComponentSpec, CrossSectionSpec
 
-from qpdk.cells._schematic import resonator_schematic
+from qpdk.cells._schematic import (
+    quarter_wave_resonator_coupled_schematic,
+    resonator_coupled_schematic,
+    resonator_schematic,
+)
 from qpdk.cells.waveguides import bend_circular, straight
 from qpdk.tech import get_etch_section
 
@@ -173,9 +177,8 @@ def resonator(
                 allow_width_mismatch=True,
                 allow_layer_mismatch=True,
             )
-            c.add_port(
-                output_port, port=open_etch.ports[output_port], port_type="placement"
-            )
+            # Keep open-end ports optical so recursive circuit netlists retain them.
+            c.add_port(output_port, port=open_etch.ports[output_port])
 
         if open_end:
             _add_etch_at_port("o1", last_ref.ports["o2"], "o2")
@@ -228,7 +231,10 @@ resonator_half_wave_bend_both = partial(
 )
 
 
-@gf.cell(tags=("resonators", "couplers"))
+@gf.cell(
+    tags=("resonators", "couplers"),
+    schematic_function=resonator_coupled_schematic,
+)
 def resonator_coupled(
     length: float = 4000.0,
     meanders: int = 6,
@@ -309,12 +315,7 @@ def resonator_coupled(
     coupling_ref.xmin = resonator_ref["o1"].x  # Align left edges
 
     for port in resonator_ref.ports:
-        port_type = (
-            "placement"
-            if ((port.name == "o1" and open_start) or (port.name == "o2" and open_end))
-            else "optical"
-        )
-        c.add_port(f"resonator_{port.name}", port=port, port_type=port_type)
+        c.add_port(f"resonator_{port.name}", port=port)
 
     for port in coupling_ref.ports:
         c.add_port(f"coupling_{port.name}", port=port)
@@ -326,7 +327,10 @@ def resonator_coupled(
     return c
 
 
-@gf.cell(tags=("resonators", "couplers"))
+@gf.cell(
+    tags=("resonators", "couplers"),
+    schematic_function=quarter_wave_resonator_coupled_schematic,
+)
 def quarter_wave_resonator_coupled(
     length: float = 4000.0,
     meanders: int = 6,

--- a/qpdk/models/__init__.py
+++ b/qpdk/models/__init__.py
@@ -94,6 +94,8 @@ from qpdk.models.resonator import (
     resonator_frequency,
     resonator_half_wave,
     resonator_quarter_wave,
+    resonator_test_chip_python,
+    resonator_test_chip_yaml,
 )
 from qpdk.models.unimon import (
     el_to_arm_inductance,
@@ -197,6 +199,8 @@ __all__ = [
     "resonator_half_wave",
     "resonator_linewidth_from_q",
     "resonator_quarter_wave",
+    "resonator_test_chip_python",
+    "resonator_test_chip_yaml",
     "series_impedance",
     "short",
     "short_2_port",

--- a/qpdk/models/resonator.py
+++ b/qpdk/models/resonator.py
@@ -15,7 +15,154 @@ from qpdk.models.cpw import (
     cpw_z0_from_cross_section,
     get_cpw_dimensions,
 )
-from qpdk.models.waveguides import straight, straight_shorted
+from qpdk.models.waveguides import launcher, straight, straight_shorted
+
+
+def _resonator_test_chip_model(
+    f: sax.FloatArrayLike,
+    *,
+    probeline_length: float,
+    resonator_lengths: tuple[tuple[float, ...], tuple[float, ...]],
+    coupling_gaps: tuple[tuple[float, ...], tuple[float, ...]],
+    coupling_length: float = 200.0,
+    cross_section: CrossSectionSpec = "coplanar_waveguide",
+) -> sax.SDict:
+    """Build SAX model for two probelines with coupled resonators."""
+    f_arr = jnp.asarray(f)
+    resonator_spacing = probeline_length / (len(resonator_lengths[0]) + 1)
+
+    instances = {}
+    connections = {}
+    ports = {}
+
+    for probeline_idx, (port_names, lengths, gaps) in enumerate(
+        zip(
+            (("o3", "o4"), ("o1", "o2")),
+            resonator_lengths,
+            coupling_gaps,
+        )
+    ):
+        west_launcher = f"launcher_{probeline_idx}_west"
+        east_launcher = f"launcher_{probeline_idx}_east"
+        instances[west_launcher] = launcher(
+            f=f_arr,
+            cross_section_small=cross_section,
+        )
+        instances[east_launcher] = launcher(
+            f=f_arr,
+            cross_section_small=cross_section,
+        )
+        ports[port_names[0]] = f"{west_launcher},waveport"
+        ports[port_names[1]] = f"{east_launcher},waveport"
+
+        first_lead = f"lead_{probeline_idx}_west"
+        instances[first_lead] = straight(
+            f=f_arr,
+            length=200.0,
+            cross_section=cross_section,
+        )
+        connections[f"{west_launcher},o1"] = f"{first_lead},o1"
+
+        for resonator_idx, (length, gap) in enumerate(zip(lengths, gaps)):
+            resonator_name = f"resonator_{probeline_idx}_{resonator_idx}"
+            instances[resonator_name] = quarter_wave_resonator_coupled(
+                f=f_arr,
+                length=length,
+                coupling_gap=gap,
+                coupling_straight_length=coupling_length,
+                cross_section=cross_section,
+                cross_section_non_resonator=cross_section,
+            )
+
+            if resonator_idx == 0:
+                connections[f"{first_lead},o2"] = f"{resonator_name},coupling_o1"
+            else:
+                previous_resonator = f"resonator_{probeline_idx}_{resonator_idx - 1}"
+                inter_resonator = f"lead_{probeline_idx}_{resonator_idx}"
+                instances[inter_resonator] = straight(
+                    f=f_arr,
+                    length=resonator_spacing,
+                    cross_section=cross_section,
+                )
+                connections[f"{previous_resonator},coupling_o2"] = (
+                    f"{inter_resonator},o1"
+                )
+                connections[f"{inter_resonator},o2"] = f"{resonator_name},coupling_o1"
+
+        last_resonator = f"resonator_{probeline_idx}_{len(lengths) - 1}"
+        final_lead = f"lead_{probeline_idx}_east"
+        instances[final_lead] = straight(
+            f=f_arr,
+            length=400.0,
+            cross_section=cross_section,
+        )
+        connections[f"{last_resonator},coupling_o2"] = f"{final_lead},o1"
+        connections[f"{final_lead},o2"] = f"{east_launcher},o1"
+
+    return sax.evaluate_circuit_fg((connections, ports), instances)
+
+
+def resonator_test_chip_python(
+    f: sax.FloatArrayLike = DEFAULT_FREQUENCY,
+    probeline_length: float = 9000.0,
+    probeline_separation: float = 1000.0,  # noqa: ARG001
+    resonator_length: float = 4000.0,
+    coupling_length: float = 200.0,
+    coupling_gap: float = 16.0,
+    cross_section: CrossSectionSpec = "coplanar_waveguide",
+) -> sax.SDict:
+    """SAX model for the four-port resonator test chip sample.
+
+    The layout sample is a composite factory. Keeping its four-port model as
+    a SAX leaf lets recursive netlist resolution treat the complete chip like
+    an optical composite component while preserving each resonator's settings.
+
+    Returns:
+        SAX S-parameter dictionary for the four external ports.
+    """
+    total_resonators = 16
+    lengths = [
+        resonator_length * (0.9 + 0.375 * index / (total_resonators - 1))
+        for index in range(total_resonators)
+    ]
+    per_line_lengths: tuple[tuple[float, ...], tuple[float, ...]] = (
+        tuple(lengths[0::2]),
+        tuple(lengths[1::2]),
+    )
+    per_line_count = len(per_line_lengths[0])
+
+    return _resonator_test_chip_model(
+        f,
+        probeline_length=probeline_length,
+        resonator_lengths=per_line_lengths,
+        coupling_gaps=((coupling_gap,) * per_line_count,) * 2,
+        coupling_length=coupling_length,
+        cross_section=cross_section,
+    )
+
+
+def resonator_test_chip_yaml(
+    f: sax.FloatArrayLike = DEFAULT_FREQUENCY,
+) -> sax.SDict:
+    """SAX model for ``resonator_test_chip_yaml.pic.yml``.
+
+    This top-level model keeps gdsfactoryplus 1.x recursive netlists from
+    expanding settings-specific resonator cell names that have no matching
+    PDK model key.
+
+    Returns:
+        SAX S-parameter dictionary for the four external ports.
+    """
+    lengths = (3600.0, 3800.0, 4000.0, 4200.0, 4400.0, 4600.0, 4800.0, 5000.0)
+    return _resonator_test_chip_model(
+        f,
+        probeline_length=9000.0,
+        resonator_lengths=(lengths, lengths),
+        coupling_gaps=(
+            (16.0,) * 8,
+            (12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0, 26.0),
+        ),
+    )
 
 
 def quarter_wave_resonator_coupled(
@@ -24,6 +171,7 @@ def quarter_wave_resonator_coupled(
     coupling_gap: float = 0.27,
     coupling_straight_length: float = 20,
     cross_section: CrossSectionSpec = "cpw",
+    cross_section_non_resonator: CrossSectionSpec | None = None,
 ) -> sax.SDict:
     """Model for a quarter-wave coplanar waveguide resonator coupled to a probeline.
 
@@ -33,6 +181,8 @@ def quarter_wave_resonator_coupled(
         length: Total length of the resonator in μm.
         coupling_gap: Gap between the resonator and the probeline in μm.
         coupling_straight_length: Length of the coupling section in μm.
+        cross_section_non_resonator: Cross-section of the coupling waveguide. If
+            ``None``, uses ``cross_section``.
 
     Returns:
         sax.SDict: S-parameters dictionary
@@ -46,6 +196,7 @@ def quarter_wave_resonator_coupled(
             coupling_gap=coupling_gap,
             coupling_straight_length=coupling_straight_length,
             cross_section=cross_section,
+            cross_section_non_resonator=cross_section_non_resonator,
             open_start=True,
             open_end=False,
         ),
@@ -71,6 +222,7 @@ def resonator_coupled(
     coupling_gap: float = 0.27,
     coupling_straight_length: float = 20,
     cross_section: CrossSectionSpec = "cpw",
+    cross_section_non_resonator: CrossSectionSpec | None = None,
     open_start: bool = True,
     open_end: bool = False,
 ) -> sax.SDict:
@@ -82,6 +234,8 @@ def resonator_coupled(
         length: Total length of the resonator in μm.
         coupling_gap: Gap between the resonator and the probeline in μm.
         coupling_straight_length: Length of the coupling section in μm.
+        cross_section_non_resonator: Cross-section of the coupling waveguide. If
+            ``None``, uses ``cross_section``.
         open_start: If True, adds an electrical open at the start.
         open_end: If True, adds an electrical open at the end.
 
@@ -89,6 +243,8 @@ def resonator_coupled(
         sax.SDict: S-parameters dictionary with 4 ports.
     """
     f_arr = jnp.asarray(f)
+    if cross_section_non_resonator is None:
+        cross_section_non_resonator = cross_section
 
     capacitor_settings = {
         "capacitance": cpw_cpw_coupling_capacitance(
@@ -99,10 +255,14 @@ def resonator_coupled(
 
     instances = {
         "coupling_1": straight(
-            f=f_arr, length=coupling_straight_length / 2, cross_section=cross_section
+            f=f_arr,
+            length=coupling_straight_length / 2,
+            cross_section=cross_section_non_resonator,
         ),
         "coupling_2": straight(
-            f=f_arr, length=coupling_straight_length / 2, cross_section=cross_section
+            f=f_arr,
+            length=coupling_straight_length / 2,
+            cross_section=cross_section_non_resonator,
         ),
         "resonator_1": straight(
             f=f_arr, length=coupling_straight_length / 2, cross_section=cross_section

--- a/qpdk/samples/resonator_test_chip.py
+++ b/qpdk/samples/resonator_test_chip.py
@@ -19,14 +19,22 @@
 import gdsfactory as gf
 import numpy as np
 
+try:
+    from gdsfactoryplus.factory_metadata import sax_model_for
+except ImportError:  # gdsfactoryplus is optional for core QPDK use.
+    sax_model_for = None
+
 from qpdk import tech
+from qpdk.cells._schematic import sax_model, schematic
 from qpdk.cells.chip import chip_edge
 from qpdk.cells.launcher import launcher
-from qpdk.cells.resonator import resonator_coupled
+from qpdk.cells.resonator import quarter_wave_resonator_coupled
 from qpdk.cells.waveguides import straight
 from qpdk.logger import logger
+from qpdk.models.resonator import (
+    resonator_test_chip_python as resonator_test_chip_python_model,
+)
 from qpdk.tech import (
-    coplanar_waveguide,
     route_bundle_cpw,
     route_bundle_sbend,
 )
@@ -39,7 +47,27 @@ from qpdk.utils import fill_magnetic_vortices
 
 
 # %%
-@gf.cell
+resonator_test_chip_python_schematic = schematic(
+    symbol="resonator_test_chip_python",
+    tags=["samples", "resonators"],
+    ports=[
+        {"name": "o1", "side": "left", "type": "photonic"},
+        {"name": "o3", "side": "left", "type": "photonic"},
+        {"name": "o2", "side": "right", "type": "photonic"},
+        {"name": "o4", "side": "right", "type": "photonic"},
+    ],
+    models=[
+        sax_model(
+            name="resonator_test_chip_python",
+            module="qpdk.models.resonator",
+            qualname="resonator_test_chip_python",
+            port_order=["o1", "o2", "o3", "o4"],
+        )
+    ],
+)
+
+
+@gf.cell(schematic_function=resonator_test_chip_python_schematic)
 def resonator_test_chip_python(
     probeline_length: float = 9000.0,
     probeline_separation: float = 1000.0,
@@ -51,13 +79,13 @@ def resonator_test_chip_python(
 
     The chip features two horizontal probelines running west to east, each with
     launchers on both ends. Eight quarter-wave resonators are coupled to each
-    probeline, with systematically varied cross-section parameters for
-    characterization studies.
+    probeline, with systematically varied lengths for characterization studies.
 
     Args:
         probeline_length: Length of each probeline in µm.
         probeline_separation: Vertical separation between probelines in µm.
-        resonator_length: Length of each resonator in µm.
+        resonator_length: Nominal resonator length in µm. Resonator lengths are
+            varied around this value to separate their resonance frequencies.
         coupling_length: Length of coupling region between resonator and probeline in µm.
         coupling_gap: Gap between resonator and probeline for coupling in µm.
 
@@ -66,19 +94,18 @@ def resonator_test_chip_python(
     """
     c = gf.Component()
 
-    # Create different cross-sections for resonators with systematic parameter variation
-    # 8 different combinations of width and gap for each probeline
-    width_values = np.linspace(8, 30, 8, dtype=int)
-    gap_values = np.linspace(6, 20, 8, dtype=int)
+    # Use a registered cross-section name so serialized netlists can resolve it.
+    cross_section = "coplanar_waveguide"
 
-    n_resonators = len(width_values)
-    resonator_cross_sections = [
-        coplanar_waveguide(width=width_values[i], gap=gap_values[i])
-        for i in range(n_resonators)
-    ]
-
-    # Standard cross-section for probelines
-    probeline_xs = coplanar_waveguide(width=10, gap=6)
+    # CPW width and gap barely shift effective permittivity. Vary length instead
+    # to create distinct resonances while keeping all model cross-sections named.
+    n_resonators_total = 16
+    n_resonators_per_probeline = n_resonators_total // 2
+    resonator_lengths = np.linspace(
+        0.9 * resonator_length,
+        1.275 * resonator_length,
+        n_resonators_total,
+    )
 
     probeline_y_positions = [0, probeline_separation]
 
@@ -90,22 +117,27 @@ def resonator_test_chip_python(
         launcher_east.mirror_x()
         launcher_east.move((probeline_length, y_pos))
 
+        # Expose launcher waveports for circuit simulation.
+        port_names = ("o3", "o4") if probeline_idx == 0 else ("o1", "o2")
+        c.add_port(port_names[0], port=launcher_west.ports["waveport"])
+        c.add_port(port_names[1], port=launcher_east.ports["waveport"])
+
         # Add resonators along the probeline
-        resonator_spacing = probeline_length / 9  # Space for 8 resonators
+        lengths = resonator_lengths[probeline_idx::2]
+        resonator_spacing = probeline_length / (n_resonators_per_probeline + 1)
 
         previous_port = launcher_west.ports["o1"]
-        for res_idx in range(n_resonators):
+        for res_idx in range(n_resonators_per_probeline):
             # Calculate resonator position along probeline
             x_position = (res_idx + 1) * resonator_spacing
 
-            # Create resonator with unique cross-section
-            coupled_resonator = resonator_coupled(
-                length=resonator_length,
+            # Create quarter-wave resonator with unique length.
+            coupled_resonator = quarter_wave_resonator_coupled(
+                length=float(lengths[res_idx]),
                 meanders=6,
-                cross_section=resonator_cross_sections[res_idx],
+                cross_section=cross_section,
                 open_start=True,
-                open_end=False,  # Quarter-wave resonator
-                cross_section_non_resonator=probeline_xs,
+                cross_section_non_resonator=cross_section,
                 coupling_straight_length=coupling_length,
                 coupling_gap=coupling_gap,
             )
@@ -120,28 +152,28 @@ def resonator_test_chip_python(
             if res_idx == 0:
                 # Add some straight before connecting the first resonator
                 first_straight_ref = c.add_ref(
-                    straight(length=200.0, cross_section=probeline_xs)
+                    straight(length=200.0, cross_section=cross_section)
                 )
                 first_straight_ref.connect("o1", resonator_ref.ports["coupling_o1"])
                 route_bundle_sbend(
                     c,
                     ports1=[previous_port],
                     ports2=[first_straight_ref.ports["o2"]],
-                    cross_section=probeline_xs,
+                    cross_section=cross_section,
                 )
             else:
                 route_bundle_cpw(
                     c,
                     ports1=[previous_port],
                     ports2=[resonator_ref.ports["coupling_o1"]],
-                    cross_section=probeline_xs,
+                    cross_section=cross_section,
                 )
 
             previous_port = resonator_ref.ports["coupling_o2"]
 
         # Add some straight before connecting to the final launcher
         final_straight_ref = c.add_ref(
-            straight(length=400.0, cross_section=probeline_xs)
+            straight(length=400.0, cross_section=cross_section)
         )
         final_straight_ref.connect("o1", previous_port)
 
@@ -150,10 +182,17 @@ def resonator_test_chip_python(
             c,
             ports1=[final_straight_ref.ports["o2"]],
             ports2=[launcher_east.ports["o1"]],
-            cross_section=probeline_xs,
+            cross_section=cross_section,
         )
 
     return c
+
+
+if sax_model_for is not None:
+    sax_model_for(
+        "qpdk.samples.resonator_test_chip.resonator_test_chip_python",
+        port_order=["o1", "o2", "o3", "o4"],
+    )(resonator_test_chip_python_model)
 
 
 # %% [markdown]

--- a/tests/test_models_regression/test_models_with_frequency_sweep_resonator_test_chip_python_.npz
+++ b/tests/test_models_regression/test_models_with_frequency_sweep_resonator_test_chip_python_.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e01efc853b53412b2b1ce31b7dcb313cfb9f7ee50364d25a32f18657fa071e2
+size 3570

--- a/tests/test_models_regression/test_models_with_frequency_sweep_resonator_test_chip_yaml_.npz
+++ b/tests/test_models_regression/test_models_with_frequency_sweep_resonator_test_chip_yaml_.npz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e70d0101890d9f02da7195bad4c6fb7a65f778a09e9f080b77603bb4fdfecd00
+size 3570

--- a/tests/test_pdk/test_netlists_resonator_.yml
+++ b/tests/test_pdk/test_netlists_resonator_.yml
@@ -333,4 +333,5 @@ placements:
     x: 302.204
     y: -600
 ports:
+  o1: rectangle,o1
   o2: straight,o2

--- a/tests/test_pdk/test_netlists_resonator_half_wave_.yml
+++ b/tests/test_pdk/test_netlists_resonator_half_wave_.yml
@@ -350,4 +350,6 @@ placements:
     rotation: 180
     x: 302.204
     y: -600
-ports: {}
+ports:
+  o1: rectangle,o1
+  o2: rectangle2,o2

--- a/tests/test_pdk/test_netlists_resonator_half_wave_bend_both_.yml
+++ b/tests/test_pdk/test_netlists_resonator_half_wave_bend_both_.yml
@@ -308,4 +308,6 @@ placements:
     rotation: 270
     x: -800
     y: 423.086
-ports: {}
+ports:
+  o1: rectangle2,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_netlists_resonator_half_wave_bend_end_.yml
+++ b/tests/test_pdk/test_netlists_resonator_half_wave_bend_end_.yml
@@ -329,4 +329,6 @@ placements:
     rotation: 180
     x: 352.572
     y: -600
-ports: {}
+ports:
+  o1: rectangle,o1
+  o2: rectangle2,o2

--- a/tests/test_pdk/test_netlists_resonator_half_wave_bend_start_.yml
+++ b/tests/test_pdk/test_netlists_resonator_half_wave_bend_start_.yml
@@ -329,4 +329,6 @@ placements:
     rotation: 270
     x: -800
     y: 352.572
-ports: {}
+ports:
+  o1: rectangle2,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_netlists_resonator_quarter_wave_.yml
+++ b/tests/test_pdk/test_netlists_resonator_quarter_wave_.yml
@@ -334,3 +334,4 @@ placements:
     y: -600
 ports:
   o1: straight4,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_both_.yml
+++ b/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_both_.yml
@@ -292,3 +292,4 @@ placements:
     y: 423.086
 ports:
   o1: bend_circular6,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_end_.yml
+++ b/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_end_.yml
@@ -313,3 +313,4 @@ placements:
     y: -600
 ports:
   o1: straight3,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_start_.yml
+++ b/tests/test_pdk/test_netlists_resonator_quarter_wave_bend_start_.yml
@@ -313,3 +313,4 @@ placements:
     y: 352.572
 ports:
   o1: bend_circular6,o1
+  o2: rectangle,o2

--- a/tests/test_pdk/test_settings_quarter_wave_resonator_coupled_.yml
+++ b/tests/test_pdk/test_settings_quarter_wave_resonator_coupled_.yml
@@ -26,7 +26,7 @@ ports:
     layer: M1_ETCH
     name: resonator_o1
     orientation: 180
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_.yml
+++ b/tests/test_pdk/test_settings_resonator_.yml
@@ -11,7 +11,7 @@ ports:
     layer: M1_ETCH
     name: o1
     orientation: 180
-    port_type: placement
+    port_type: optical
     width: 22
   o2:
     center:

--- a/tests/test_pdk/test_settings_resonator_coupled_.yml
+++ b/tests/test_pdk/test_settings_resonator_coupled_.yml
@@ -31,7 +31,7 @@ ports:
     layer: M1_ETCH
     name: resonator_o1
     orientation: 180
-    port_type: placement
+    port_type: optical
     width: 22
   resonator_o2:
     center:

--- a/tests/test_pdk/test_settings_resonator_half_wave_.yml
+++ b/tests/test_pdk/test_settings_resonator_half_wave_.yml
@@ -11,7 +11,7 @@ ports:
     layer: M1_ETCH
     name: o1
     orientation: 180
-    port_type: placement
+    port_type: optical
     width: 22
   o2:
     center:
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 0
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_half_wave_bend_both_.yml
+++ b/tests/test_pdk/test_settings_resonator_half_wave_bend_both_.yml
@@ -11,7 +11,7 @@ ports:
     layer: M1_ETCH
     name: o1
     orientation: 90
-    port_type: placement
+    port_type: optical
     width: 22
   o2:
     center:
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 270
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_half_wave_bend_end_.yml
+++ b/tests/test_pdk/test_settings_resonator_half_wave_bend_end_.yml
@@ -11,7 +11,7 @@ ports:
     layer: M1_ETCH
     name: o1
     orientation: 180
-    port_type: placement
+    port_type: optical
     width: 22
   o2:
     center:
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 0
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_half_wave_bend_start_.yml
+++ b/tests/test_pdk/test_settings_resonator_half_wave_bend_start_.yml
@@ -11,7 +11,7 @@ ports:
     layer: M1_ETCH
     name: o1
     orientation: 90
-    port_type: placement
+    port_type: optical
     width: 22
   o2:
     center:
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 270
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_quarter_wave_.yml
+++ b/tests/test_pdk/test_settings_resonator_quarter_wave_.yml
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 0
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_quarter_wave_bend_both_.yml
+++ b/tests/test_pdk/test_settings_resonator_quarter_wave_bend_both_.yml
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 270
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_quarter_wave_bend_end_.yml
+++ b/tests/test_pdk/test_settings_resonator_quarter_wave_bend_end_.yml
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 0
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_pdk/test_settings_resonator_quarter_wave_bend_start_.yml
+++ b/tests/test_pdk/test_settings_resonator_quarter_wave_bend_start_.yml
@@ -20,7 +20,7 @@ ports:
     layer: M1_ETCH
     name: o2
     orientation: 270
-    port_type: placement
+    port_type: optical
     width: 22
 settings:
   bend_spec: bend_circular

--- a/tests/test_resonator_test_chip.py
+++ b/tests/test_resonator_test_chip.py
@@ -1,0 +1,79 @@
+"""Tests for resonator test-chip samples."""
+
+import sax
+
+from qpdk import PDK
+from qpdk.models import models
+from qpdk.models.resonator import resonator_test_chip_yaml
+from qpdk.samples.resonator_test_chip import resonator_test_chip_python
+
+
+def test_resonator_test_chip_exposes_launcher_waveports() -> None:
+    """Expose both ends of both resonator-test-chip probelines."""
+    component = resonator_test_chip_python()
+
+    assert {port.name for port in component.ports} == {"o1", "o2", "o3", "o4"}
+    assert component.ports["o1"].center == (0.0, 1000.0)
+    assert component.ports["o2"].center == (9000.0, 1000.0)
+    assert component.ports["o3"].center == (0.0, 0.0)
+    assert component.ports["o4"].center == (9000.0, 0.0)
+
+
+def test_resonator_test_chip_uses_registered_cross_sections() -> None:
+    """Keep serialized SAX settings resolvable by the active PDK."""
+    component = resonator_test_chip_python()
+    netlist = component.get_netlist(on_dangling_port="ignore")
+    resonators = [
+        instance
+        for instance in netlist["instances"].values()
+        if instance["component"] == "quarter_wave_resonator_coupled"
+    ]
+
+    assert len(resonators) == 16
+    assert {instance["settings"]["cross_section"] for instance in resonators} == {
+        "coplanar_waveguide"
+    }
+    assert {
+        instance["settings"]["cross_section_non_resonator"] for instance in resonators
+    } == {"coplanar_waveguide"}
+    assert len({instance["settings"]["length"] for instance in resonators}) == 16
+
+
+def test_resonator_test_chip_recursive_sax_netlist_is_valid() -> None:
+    PDK.activate()
+    netlist = resonator_test_chip_python().get_netlist(
+        recursive=True,
+        on_dangling_port="ignore",
+    )
+
+    # This direct netlist keeps the sample factory name as its top-level
+    # circuit name. Exclude the public top-level model to avoid SAX treating
+    # that circuit itself as a model. The app netlist uses top name ``t`` and
+    # therefore exercises the registered sample model.
+    simulation_models = {
+        name: model
+        for name, model in models.items()
+        if name != "resonator_test_chip_python"
+    }
+
+    sax.circuit(
+        netlist,
+        models=simulation_models,
+        ignore_impossible_connections=False,
+    )
+
+
+def test_resonator_test_chip_yaml_has_top_level_sax_model() -> None:
+    """Keep the YAML sample usable by legacy recursive-netlist simulation."""
+    assert models["resonator_test_chip_yaml"] is resonator_test_chip_yaml
+
+    s_params = resonator_test_chip_yaml(f=[7e9])
+
+    # Two probelines are independent, so SAX returns four entries per line.
+    assert len(s_params) == 8
+    assert {port for key in s_params for port in key} == {
+        "o1",
+        "o2",
+        "o3",
+        "o4",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -2264,7 +2264,7 @@ name = "multiprocess"
 version = "0.70.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
+    { name = "dill", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
 wheels = [
@@ -2787,10 +2787,10 @@ name = "pathos"
 version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
-    { name = "multiprocess" },
-    { name = "pox" },
-    { name = "ppft" },
+    { name = "dill", marker = "sys_platform != 'darwin'" },
+    { name = "multiprocess", marker = "sys_platform != 'darwin'" },
+    { name = "pox", marker = "sys_platform != 'darwin'" },
+    { name = "ppft", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/37/0c730979d3890f8096a86af2683fac74edd4d15cb037391098dca70dcb1d/pathos-0.3.5.tar.gz", hash = "sha256:8fe041b8545c5d3880a038f866022bdebf935e5cf68f56ed3407cb7e65193a61", size = 166975, upload-time = "2026-01-20T00:06:57.848Z" }
 wheels = [
@@ -2802,7 +2802,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4375,16 +4375,16 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cycler" },
-    { name = "cython" },
-    { name = "dill" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "qutip" },
-    { name = "scipy" },
-    { name = "sympy" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "cycler", marker = "sys_platform == 'darwin'" },
+    { name = "cython", marker = "sys_platform == 'darwin'" },
+    { name = "dill", marker = "sys_platform == 'darwin'" },
+    { name = "matplotlib", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "qutip", marker = "sys_platform == 'darwin'" },
+    { name = "scipy", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/ed/69b37d03b9794518b38528efb14884f53a1ec155b61b4b126b8c58c682bd/scqubits-4.1.0.tar.gz", hash = "sha256:806f171d4b5905af3f8d4c68fce461be91eab38466fa4fbe87b71ec7b167fc7b", size = 6457745, upload-time = "2024-05-17T01:22:20.31Z" }
 wheels = [
@@ -4404,16 +4404,16 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cycler" },
-    { name = "dill" },
-    { name = "matplotlib" },
-    { name = "numpy" },
-    { name = "pathos" },
-    { name = "qutip" },
-    { name = "scipy" },
-    { name = "sympy" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "cycler", marker = "sys_platform != 'darwin'" },
+    { name = "dill", marker = "sys_platform != 'darwin'" },
+    { name = "matplotlib", marker = "sys_platform != 'darwin'" },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pathos", marker = "sys_platform != 'darwin'" },
+    { name = "qutip", marker = "sys_platform != 'darwin'" },
+    { name = "scipy", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "tqdm", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/57/a552661e93e9d3ea6530112f06572f0f88d55972c7a0a98d79275b67bf3c/scqubits-4.3.1.tar.gz", hash = "sha256:a40440e7270fa559d201220524f8b95eaae24235a1d4918ad08dc7358a0c39e4", size = 6498157, upload-time = "2025-05-17T16:53:35.721Z" }
 wheels = [


### PR DESCRIPTION
Fix recursive SAX simulation for RF resonator test chips.\n\n- Register coupled-resonator SAX boundaries and preserve optical ports.\n- Add Python and YAML test-chip SAX models.\n- Add regression coverage for recursive netlist behavior.\n\nCloses #678

## Summary by Sourcery

Preserve RF resonator behavior in recursive SAX simulations by registering coupled-resonator models and adding test-chip SAX top-level models and coverage.

New Features:
- Introduce Python and YAML SAX models for the four-port resonator test chip, keeping the sample as a leaf in recursive netlists.
- Add schematics for coupled and quarter-wave resonator cells, including the test-chip schematic that exposes launcher waveports as external ports.

Bug Fixes:
- Ensure resonator and launcher ports remain optical and are retained in netlists and SAX boundaries so RF resonances are preserved in recursive simulations.
- Fix half-wave and quarter-wave resonator netlists and settings to define explicit ports instead of empty port maps and non-optical port types.
- Allow coupled-resonator models to use a distinct cross-section for the non-resonator coupling waveguide, keeping PDK-resolvable cross-section names in serialized netlists.

Enhancements:
- Refine the resonator test-chip layout to vary resonator lengths rather than cross-section geometry while using registered cross-section names for all resonators.
- Wire up gdsfactoryplus SAX model registration for the resonator test-chip sample so app-level recursive netlists can reuse the public model.
- Expose coupled-resonator endpoints in schematic definitions to match their physical behavior while still treating them as internal to the chip.

CI:
- Exclude the published PDF URL from lychee link checking to avoid transient CI failures during GitHub Pages deployment.

Tests:
- Add tests to verify the resonator test chip exposes all four launcher waveports, uses registered cross-sections, and has a valid recursive SAX netlist.
- Add tests to assert the presence and behavior of the top-level YAML SAX model for the resonator test chip.
- Update resonator-related netlist and settings fixtures to reflect optical ports and explicit port mappings.
- Add regression NPZ datasets for SAX frequency sweeps of the Python and YAML resonator test-chip models.