### PR TITLE
Add llms.txt for docs site per llmstxt.org

### DIFF
--- a/docs/docs.just
+++ b/docs/docs.just
@@ -26,6 +26,13 @@ write-justfile-help:
 convert-notebooks:
     @./.github/convert-notebooks.sh notebooks/src/*.py
 
+# Copy llms.txt (https://llmstxt.org/) into the built site root
+[private]
+[group('docs')]
+write-llms-txt:
+    @mkdir -p docs/_extra
+    @cp docs/llms.txt docs/_extra/llms.txt
+
 # Notebooks that should be copied as .ipynb because they have precalculated outputs
 # (These will have their .py counterparts removed if they exist to force MyST-NB to use .ipynb)
 precalculated_notebooks := "hfss_*.ipynb matlab_integration.ipynb"
@@ -66,7 +73,7 @@ setup-ipython-config-temporary-after:
 [private]
 [parallel]
 [group('docs')]
-docs-prerequisites: write-cells write-models write-justfile-help copy-sample-notebooks
+docs-prerequisites: write-cells write-models write-justfile-help copy-sample-notebooks write-llms-txt
 
 # Build documentation with the given Sphinx builder into docs/_build/<builder>
 [private]

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,21 @@
+# QPDK
+
+> QPDK is an open-source process design kit (PDK) for superconducting quantum RF applications built on [gdsfactory](https://gdsfactory.github.io/gdsfactory/). It provides parametric quantum circuit components (transmon qubits, CPW resonators, Josephson junctions, etc.), analytical S-parameter models, routing utilities, and test-chip examples.
+
+QPDK gives researchers, engineers, and students a scriptable, version-controlled foundation to go from concept to GDSII in minutes. The source code lives at https://github.com/gdsfactory/quantum-rf-pdk and the package is published as `qpdk` on PyPI.
+
+## Docs
+
+- [Home](https://gdsfactory.github.io/quantum-rf-pdk/index.html): Overview, key features, installation, and notable components
+- [PCells](https://gdsfactory.github.io/quantum-rf-pdk/cells.html): Gallery and API reference for all layout components (qubits, resonators, couplers, routing, etc.)
+- [Models](https://gdsfactory.github.io/quantum-rf-pdk/models.html): S-parameter and circuit models for quantum RF components
+- [Samples](https://gdsfactory.github.io/quantum-rf-pdk/samples.html): Example scripts assembling components into full layouts
+- [Notebooks](https://gdsfactory.github.io/quantum-rf-pdk/notebooks.html): Jupyter notebooks demonstrating simulation approaches for superconducting quantum devices
+- [Contributing](https://gdsfactory.github.io/quantum-rf-pdk/contributing.html): Development setup, testing, and contribution guidelines
+- [Security](https://gdsfactory.github.io/quantum-rf-pdk/security.html): Security policy
+
+## Optional
+
+- [PDF documentation](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf): Full documentation as a single PDF
+- [Changelog](https://github.com/gdsfactory/quantum-rf-pdk/blob/main/docs/changelog.md): Release history
+- [Code of conduct](https://gdsfactory.github.io/quantum-rf-pdk/code_of_conduct.html)


### PR DESCRIPTION
Copied into docs/_extra at build time (like the kwasm viewer assets) so it lands at the site root as llms.txt.

## Summary by Sourcery

Publish an llms.txt file at the documentation site root in accordance with llmstxt.org.

New Features:
- Add an llms.txt file to the documentation site root for LLM-friendly documentation discovery.

Build:
- Include llms.txt in the documentation build prerequisites so it is copied into the generated site.