### PR TITLE
Add sample resonator schematic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,9 @@ cells_no_model_expected = [
   "unimon_arm",  # sub-component of unimon; model lives on parent
 ]
 
+[tool.gdsfactoryplus.sidebar]
+default_libraries = ["qpdk"]
+
 [tool.interrogate]
 docstring-style = "google"
 exclude = [

--- a/qpdk/sample_resonator.gsch
+++ b/qpdk/sample_resonator.gsch
@@ -1,0 +1,322 @@
+{
+  "sample_resonator:X1": {
+    "y": 3,
+    "bbox_xmin": -104.939,
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    "bbox_ymin": -1241,
+    "name": "X1",
+    "type": "ckt",
+    "bbox_width": 809.797,
+    "irl_x": -50,
+    "bbox_height": 1252,
+    "nets": {
+      "coupling_o1": "P2",
+      "resonator_o1": "P1",
+      "coupling_o2": "W3"
+    },
+    "ports": [
+      {
+        "name": "resonator_o1",
+        "irl_rx": -299.95950000000005,
+        "irl_ry": -585,
+        "orientation": 180,
+        "bendRadii": [
+          5
+        ],
+        "port_type": "optical",
+        "width": 22,
+        "layer": [
+          1,
+          1
+        ],
+        "layer_name": "M1_ETCH"
+      },
+      {
+        "name": "coupling_o1",
+        "irl_rx": -299.95950000000005,
+        "irl_ry": -615,
+        "orientation": 180,
+        "bendRadii": [
+          100
+        ],
+        "port_type": "optical",
+        "width": 10,
+        "cross_section": "coplanar_waveguide",
+        "layer": [
+          1,
+          0
+        ],
+        "layer_name": "M1_DRAW"
+      },
+      {
+        "name": "coupling_o2",
+        "irl_rx": -99.95949999999999,
+        "irl_ry": -615,
+        "orientation": 0,
+        "bendRadii": [
+          100
+        ],
+        "port_type": "optical",
+        "width": 10,
+        "cross_section": "coplanar_waveguide",
+        "layer": [
+          1,
+          0
+        ],
+        "layer_name": "M1_DRAW"
+      }
+    ],
+    "x": -1,
+    "texture_key": "qpdk.cells.resonator.quarter_wave_resonator_coupled_077cf40a",
+    "irl_y": 77.96546792915309,
+    "model": "qpdk.cells.resonator.quarter_wave_resonator_coupled",
+    "props": {
+      "cross_section_non_resonator": "cpw",
+      "meanders": 6,
+      "start_with_bend": false,
+      "end_with_bend": false,
+      "coupling_gap": 20,
+      "cross_section": "cpw",
+      "open_end": false,
+      "open_start": true,
+      "length": "6000",
+      "coupling_straight_length": 200
+    }
+  },
+  "sample_resonator:P1": {
+    "type": "port",
+    "x": 0,
+    "y": 1,
+    "transform": [
+      0,
+      1,
+      -1,
+      0,
+      0,
+      0
+    ],
+    "name": "P1",
+    "nets": {
+      "P": "P1"
+    },
+    "nature": "photonic"
+  },
+  "sample_resonator:W1": {
+    "type": "wire",
+    "x": 0,
+    "y": 3,
+    "rx": 0,
+    "ry": -2,
+    "variant": "d",
+    "name": "W1",
+    "net": "P1"
+  },
+  "sample_resonator:P2": {
+    "type": "port",
+    "x": -3,
+    "y": 4,
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    "name": "P2",
+    "nets": {
+      "P": "P2"
+    },
+    "nature": "photonic"
+  },
+  "sample_resonator:W2": {
+    "type": "wire",
+    "x": -1,
+    "y": 4,
+    "rx": -2,
+    "ry": 0,
+    "variant": "d",
+    "name": "W2",
+    "net": "P2"
+  },
+  "sample_resonator:X2": {
+    "y": 3,
+    "bbox_xmin": -104.939,
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0
+    ],
+    "bbox_ymin": -1241,
+    "name": "X2",
+    "type": "ckt",
+    "bbox_width": 666.939,
+    "irl_x": 1831.72325874826,
+    "bbox_height": 1252,
+    "nets": {
+      "coupling_o1": "W3",
+      "resonator_o1": "P4",
+      "coupling_o2": "P3"
+    },
+    "ports": [
+      {
+        "name": "resonator_o1",
+        "irl_rx": -228.5305,
+        "irl_ry": -585,
+        "orientation": 180,
+        "bendRadii": [
+          5
+        ],
+        "port_type": "optical",
+        "width": 22,
+        "layer": [
+          1,
+          1
+        ],
+        "layer_name": "M1_ETCH"
+      },
+      {
+        "name": "coupling_o1",
+        "irl_rx": -228.5305,
+        "irl_ry": -615,
+        "orientation": 180,
+        "bendRadii": [
+          100
+        ],
+        "port_type": "optical",
+        "width": 10,
+        "cross_section": "coplanar_waveguide",
+        "layer": [
+          1,
+          0
+        ],
+        "layer_name": "M1_DRAW"
+      },
+      {
+        "name": "coupling_o2",
+        "irl_rx": -28.53049999999996,
+        "irl_ry": -615,
+        "orientation": 0,
+        "bendRadii": [
+          100
+        ],
+        "port_type": "optical",
+        "width": 10,
+        "cross_section": "coplanar_waveguide",
+        "layer": [
+          1,
+          0
+        ],
+        "layer_name": "M1_DRAW"
+      }
+    ],
+    "x": 3,
+    "texture_key": "qpdk.cells.resonator.quarter_wave_resonator_coupled_26c03269",
+    "irl_y": 77.96546792915309,
+    "model": "qpdk.cells.resonator.quarter_wave_resonator_coupled",
+    "props": {
+      "cross_section_non_resonator": "cpw",
+      "meanders": 6,
+      "start_with_bend": false,
+      "end_with_bend": false,
+      "coupling_gap": 20,
+      "cross_section": "cpw",
+      "open_end": false,
+      "open_start": true,
+      "length": "5000",
+      "coupling_straight_length": 200
+    }
+  },
+  "sample_resonator:W3": {
+    "type": "wire",
+    "x": 1,
+    "y": 4,
+    "rx": 2,
+    "ry": 0,
+    "variant": "d",
+    "name": "W3",
+    "net": "W3"
+  },
+  "sample_resonator:P3": {
+    "transform": [
+      -1,
+      0,
+      0,
+      -1,
+      0,
+      0
+    ],
+    "type": "port",
+    "x": 5,
+    "y": 4,
+    "name": "P3",
+    "nets": {
+      "P": "P3"
+    },
+    "nature": "photonic"
+  },
+  "sample_resonator:P4": {
+    "transform": [
+      0,
+      1,
+      -1,
+      0,
+      0,
+      0
+    ],
+    "type": "port",
+    "x": 4,
+    "y": 3,
+    "name": "P4",
+    "nets": {
+      "P": "P4"
+    },
+    "nature": "photonic"
+  },
+  "poly_1": {
+    "name": "poly_1",
+    "type": "polyline",
+    "terminals": {
+      "start": {
+        "component_id": "sample_resonator:X1",
+        "port_name": "coupling_o2"
+      },
+      "finish": {
+        "component_id": "sample_resonator:X2",
+        "port_name": "coupling_o1"
+      }
+    },
+    "vertices": [
+      [
+        -149.95950317382812,
+        -537.0345458984375
+      ],
+      [
+        551.9680786132812,
+        -537.0345458984375
+      ],
+      [
+        901.2651977539062,
+        -537.0345458984375
+      ],
+      [
+        1603.1927490234375,
+        -537.0345458984375
+      ]
+    ],
+    "cross_section": "coplanar_waveguide",
+    "layer": null,
+    "width": 10,
+    "radius": 100
+  }
+}

--- a/qpdk/sample_resonator.gsch.svg
+++ b/qpdk/sample_resonator.gsch.svg
@@ -1,0 +1,369 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100%" xmlns="http://www.w3.org/2000/svg" viewBox="-68.32717215749561,-50.54494981135013,535.0604022593345,535.0604022593345" height="100%" class="gsch-symbol"><style>:root { color-scheme: light dark; }
+@layer vscode-default {
+  html { scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background); }
+  body { overscroll-behavior-x: none; background-color: transparent; color: var(--vscode-editor-foreground); font-family: var(--vscode-font-family); font-weight: var(--vscode-font-weight); font-size: var(--vscode-font-size); margin: 0px; padding: 0px 20px; }
+  img, video { max-width: 100%; max-height: 100%; }
+  a, a code { color: var(--vscode-textLink-foreground); }
+  p &gt; a { text-decoration: var(--text-link-decoration); }
+  a:hover { color: var(--vscode-textLink-activeForeground); }
+  a:focus, input:focus, select:focus, textarea:focus { outline: -webkit-focus-ring-color solid 1px; outline-offset: -1px; }
+  code { font-family: var(--monaco-monospace-font); color: var(--vscode-textPreformat-foreground); background-color: var(--vscode-textPreformat-background); padding: 1px 3px; border-radius: 4px; }
+  pre code { padding: 0px; }
+  blockquote { background: var(--vscode-textBlockQuote-background); border-color: var(--vscode-textBlockQuote-border); }
+  kbd { background-color: var(--vscode-keybindingLabel-background); color: var(--vscode-keybindingLabel-foreground); border-style: solid; border-width: 1px; border-radius: 3px; border-top-color: ; border-right-color: ; border-left-color: ; border-bottom-color: var(--vscode-keybindingLabel-bottomBorder); box-shadow: inset 0 -1px 0 var(--vscode-widget-shadow); vertical-align: middle; padding: 1px 3px; }
+  ::-webkit-scrollbar { width: 10px; height: 10px; }
+  ::-webkit-scrollbar-corner { background-color: var(--vscode-editor-background); }
+  ::-webkit-scrollbar-thumb { background-color: var(--vscode-scrollbarSlider-background); }
+  ::-webkit-scrollbar-thumb:hover { background-color: var(--vscode-scrollbarSlider-hoverBackground); }
+  ::-webkit-scrollbar-thumb:active { background-color: var(--vscode-scrollbarSlider-activeBackground); }
+  ::highlight(find-highlight) { background-color: var(--vscode-editor-findMatchHighlightBackground); }
+  ::highlight(current-find-highlight) { background-color: var(--vscode-editor-findMatchBackground); }
+}
+body, html { padding: 0px; margin: 0px; }
+:root { color-scheme: light dark; --color-bg: var(--vscode-editor-background, light-dark(#f9f9f9, #1e1e2e)); --color-surface: var(--vscode-sideBar-background, light-dark(white, #313244)); --color-surface-alt: var(--vscode-sideBarSectionHeader-background, light-dark(#f8f8f8, #45475a)); --color-text: var(--vscode-foreground, light-dark(#222222a5, #cdd6f4a5)); --color-text-strong: var(--vscode-editor-foreground, light-dark(#222222, #cdd6f4)); --color-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #a6adc8)); --color-border: var(--vscode-sideBarSectionHeader-border, light-dark(lightgray, #585b70)); --color-border-light: var(--vscode-sideBar-border, light-dark(#e7e7e7, #313244)); --color-shadow: light-dark(#00000033, #00000066); --color-accent: var(--vscode-button-background, light-dark(#0e1a32, #89b4fa)); --color-accent-text: var(--vscode-button-foreground, light-dark(white, #1e1e2e)); --color-badge: var(--vscode-badge-background, light-dark(#4a9eff, #89b4fa)); --color-badge-text: var(--vscode-badge-foreground, light-dark(white, #1e1e2e)); --color-input-bg: var(--vscode-input-background, light-dark(#00000008, #1e1e2e)); --color-input-border: var(--vscode-input-border, light-dark(#2222220d, #585b70)); --color-hover: var(--vscode-list-hoverBackground, light-dark(#00000007, #45475a)); --canvas-bg: var(--vscode-editor-background, light-dark(#f9f9f9, #1e1e2e)); --canvas-grid: var(--vscode-panel-border, light-dark(lightgray, #313244)); --canvas-stroke: var(--vscode-editor-foreground, light-dark(black, #cdd6f4)); --canvas-wire-stroke: var(--vscode-editor-foreground, light-dark(black, #89b4fa)); --canvas-wire-photonic: var(--vscode-editor-foreground, light-dark(black, #94e2d5)); --canvas-text: var(--vscode-editor-foreground, light-dark(#444, #cdd6f4)); --canvas-text-muted: var(--vscode-descriptionForeground, light-dark(#666, #a6adc8)); --canvas-select: light-dark(rgb(229, 216, 243), #45365e); --canvas-nc: light-dark(red, #f38ba8); --canvas-error: light-dark(red, #f38ba8); --canvas-warning: light-dark(orange, #fab387); --canvas-placeholder: var(--vscode-descriptionForeground, light-dark(#888, #6c7086)); --canvas-port-electric-fill: light-dark(rgb(145, 0, 0), #f38ba8); --canvas-port-electric-stroke: light-dark(rgb(53, 0, 0), #f38ba8); --canvas-port-photonic-fill: light-dark(rgb(0, 80, 160), #89b4fa); --canvas-port-photonic-stroke: light-dark(rgb(0, 20, 60), #89b4fa); --device-bg: light-dark(rgb(238, 238, 238), #313244); --device-bg-nchan: light-dark(rgb(216, 236, 243), #18304a); --device-bg-pchan: light-dark(rgb(243, 231, 216), #4a3018); --device-bg-passive: light-dark(rgb(216, 243, 226), #184a28); --device-bg-source: light-dark(rgb(243, 243, 216), #4a4518); --device-bg-photonic: light-dark(rgb(216, 243, 240), #183e46); --device-bg-photonic-active: light-dark(rgb(243, 224, 216), #4a2418); --device-bg-amp: light-dark(rgb(243, 238, 216), #4a4518); }
+.mosaic-app { font: 400 16px / 18px Roboto, sans-serif; color: var(--color-text); }
+.mosaic-app input, .mosaic-app textarea, .mosaic-app select { background: var(--color-input-bg) 0% 0% no-repeat padding-box; border: 2px solid var(--color-input-border); border-radius: 5px; padding: 5px 10px; color: var(--color-text); }
+.mosaic-app .combobox-group { display: flex; align-items: stretch; border-radius: 5px; overflow: hidden; }
+.mosaic-app .combobox-group .combobox-input { border-radius: 5px 0px 0px 5px; border-right-width: medium; border-right-style: none; border-right-color: currentcolor; flex: 1 1 0%; margin: 0px; }
+.mosaic-app .combobox-group .combobox-select { border-radius: 0px 5px 5px 0px; margin: 0px; padding: 5px 8px; width: 30px; cursor: pointer; border: 2px solid var(--color-input-border); }
+.mosaic-app .combobox-group .combobox-select:focus, .mosaic-app .combobox-group .combobox-input:focus { outline: none; border-color: selecteditem; }
+.mosaic-app .combobox-group:focus-within .combobox-input, .mosaic-app .combobox-group:focus-within .combobox-select { border-color: selecteditem; }
+.mosaic-app button, .mosaic-app input[type="submit"] { background: var(--color-surface-alt) 0% 0% no-repeat padding-box; box-shadow: 0px 1px 4px var(--color-shadow); border-radius: 7px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; padding: 10px 15px; cursor: pointer; color: var(--color-text); }
+.mosaic-app button:active { box-shadow: 0px 0px 4px var(--color-shadow); }
+.mosaic-app button.primary, .mosaic-app input[type="submit"] { background-color: var(--color-accent); color: var(--color-accent-text); }
+.mosaic-app .buttongroup { background: var(--color-surface-alt) 0% 0% no-repeat padding-box; box-shadow: 0px 1px 4px var(--color-shadow); border-radius: 7px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; padding: 0px; display: flex; flex-direction: row; align-items: center; position: relative; }
+.mosaic-app .buttongroup.primary { background-color: var(--color-accent); color: var(--color-accent-text); }
+.mosaic-app .buttongroup.primary &gt; button, .mosaic-app .buttongroup summary::after { color: var(--color-accent-text); border-color: var(--color-accent-text); }
+.mosaic-app .buttongroup.primary &gt; button:disabled { color: grey; }
+.mosaic-app .buttongroup summary { padding: 10px 15px; border-left: 1px solid var(--color-border); }
+.mosaic-app .buttongroup summary::after { transform: rotate(45deg); top: -5px; left: 0px; }
+.mosaic-app .buttongroup details &gt; button { position: absolute; left: 0px; bottom: -100%; width: 100%; }
+.mosaic-app .buttongroup &gt; button { background: none; box-shadow: none; }
+.mosaic-app details summary { list-style-type: none; cursor: pointer; }
+.mosaic-app details summary::after { content: ""; border-top-color: ; border-top-style: ; border-right-color: ; border-right-style: ; border-bottom-color: ; border-bottom-style: ; border-left-color: ; border-left-style: ; border-image-source: ; border-image-slice: ; border-image-width: ; border-image-outset: ; border-image-repeat: ; border-width: 0px 1px 1px 0px; padding: 3px; transform: rotate(-45deg); float: right; position: relative; top: 4px; left: -4px; transition: transform 100ms; }
+.mosaic-app details[open] &gt; summary::after { transform: rotate(45deg); }
+.mosaic-app .cellsel details[open] &gt; summary::after { border-color: var(--color-accent-text); }
+.mosaic-app .window { background: var(--color-surface); box-shadow: 0px 0px 10px var(--color-shadow); border-radius: 7px; border: 1px solid var(--color-border); padding: 20px; }
+.mosaic-app .window.hidden { display: none; }
+.mosaic-app .modal { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); z-index: 1000; }
+.mosaic-app .modal input[type="text"] { margin: 1em 0px; }
+.mosaic-app .modal input:not(:first-child) { margin-left: 1em; }
+.mosaic-app .contextmenu { position: fixed; z-index: 1000; margin: 0px; }
+.mosaic-app .contextmenu ul { padding: 0px; margin: 0px; list-style-type: none; }
+.mosaic-app .selection-anchor { position: fixed; z-index: 999; pointer-events: none; anchor-name: --selection; }
+.mosaic-app .selection-toolbar { position: absolute; left: 50%; top: 0px; transform: translate(-50%, calc(-100% - 8px)); pointer-events: auto; display: flex; align-items: center; padding: 0px 0.25em; border-radius: 7px; white-space: nowrap; }
+@supports (position-area: block-start) {
+  .mosaic-app .selection-toolbar { position: fixed; left: auto; top: auto; transform: none; position-anchor: --selection; position-area: block-start; justify-self: anchor-center; position-try-fallbacks: flip-block; margin: 8px; }
+}
+.mosaic-app .selection-toolbar .toolbar-group { display: flex; align-items: center; }
+.mosaic-app .selection-toolbar .toolbar-group + .toolbar-group { border-left: 1px solid var(--color-border); margin-left: 0.25em; padding-left: 0.25em; }
+.mosaic-app .model-selector-popup { min-width: 500px; max-width: 700px; }
+.mosaic-app .model-selector-popup h3 { margin-top: 0px; font: 500 20px / 25px Roboto, sans-serif; color: var(--color-text-strong); }
+.mosaic-app .model-selector-popup .model-search { width: 100%; box-sizing: border-box; margin-bottom: 10px; }
+.mosaic-app .model-popup-content { display: flex; gap: 10px; max-height: 400px; overflow: hidden; }
+.mosaic-app .model-popup-content .model-categories { flex: 0 0 200px; overflow-y: auto; border-right: 1px solid var(--color-border); padding-right: 10px; }
+.mosaic-app .model-popup-content .model-list { flex: 1 1 0%; overflow-y: auto; }
+.mosaic-app .model-popup-buttons { display: flex; justify-content: flex-end; gap: 10px; margin-top: 15px; padding-top: 15px; border-top: 1px solid var(--color-border); }
+.mosaic-app .field-with-unit { display: flex; gap: 4px; align-items: center; }
+.mosaic-app .field-with-unit &gt; :first-child { flex: 1 1 0%; min-width: 0px; }
+.mosaic-app .unit-suffix { flex-shrink: 0; font-size: 0.85em; opacity: 0.7; }
+.mosaic-app .field-with-extra { display: flex; gap: 5px; }
+.mosaic-app .field-with-extra &gt; :first-child { flex: 1 1 0%; min-width: 0px; }
+.mosaic-app .field-with-extra button { flex-shrink: 0; padding: 5px 10px; display: flex; align-items: center; }
+.mosaic-app button:disabled { opacity: 0.3; cursor: default; }
+.mosaic-libman h1 { font: 500 25px / 25px Roboto, sans-serif; letter-spacing: 0.85px; color: var(--color-text-strong); text-transform: uppercase; }
+.mosaic-libman h2 { font: 500 25px / 25px Roboto, sans-serif; letter-spacing: 0.72px; color: var(--color-text-strong); }
+.mosaic-libman h3 { font: 500 20px / 25px Roboto, sans-serif; letter-spacing: 0.72px; color: var(--color-text-strong); }
+.mosaic-libman button:has(svg) { display: flex; align-items: center; gap: 0.5em; }
+.mosaic-libman button svg { font-size: 20px; }
+.mosaic-libman .libhead { display: flex; flex-direction: row; justify-content: space-between; align-items: baseline; }
+.syncstatus.active svg { animation: 1.5s linear 0s infinite normal none running spinner; }
+.syncstatus.done { animation: 1.5s linear 0s 1 normal none running fadeout; opacity: 0; }
+@keyframes spinner {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+@keyframes fadeout {
+  0% { opacity: 1; }
+  100% { opacity: 0; }
+}
+.mosaic-libman .addbuttons { display: flex; flex-direction: row; justify-content: right; gap: 20px; padding: 20px; border-bottom: 1px solid var(--color-border-light); }
+.mosaic-libman .schsel { display: flex; flex-direction: column; overflow: hidden; }
+.mosaic-libman .models-header { display: flex; justify-content: space-between; align-items: center; gap: 15px; padding: 0px 20px; }
+.mosaic-libman .schsel .schematics { padding: 0px 20px; overflow: auto; }
+.mosaic-libman .libraries { grid-area: libraries; display: flex; flex-direction: column; border-right: 1px solid var(--color-border-light); overflow: hidden; }
+.mosaic-libman .libraries &gt; * { padding: 1em; }
+.mosaic-libman .libraries .dbsel { flex-grow: 1; }
+.mosaic-libman .schematics { grid-area: schematics; display: flex; flex-direction: column; }
+.mosaic-libman .cellsel { flex-grow: 1; overflow: auto; }
+.mosaic-libman .cellsel details { margin: 0.5em 0px; }
+.mosaic-libman .dbprops { padding: 1em; background-color: var(--color-hover); border-bottom: 1px solid var(--color-border-light); }
+.mosaic-libman .dbprops .properties { padding: 0px; }
+.mosaic-libman .dbprops .properties select { grid-column: controls; width: 100%; padding: 0.5em; }
+.mosaic-libman .workspace-actions { grid-column: controls; display: flex; gap: 0.5em; }
+.mosaic-libman .workspace-actions button { flex: 1 1 0%; }
+.mosaic-libman .proppane { grid-area: properties; border-left: 1px solid var(--color-border-light); padding: 20px; overflow: auto; }
+.mosaic-libman .proppane .preview { aspect-ratio: 1 / 1; margin-bottom: 1em; background-color: var(--color-surface-alt); border: 1px solid var(--color-border); position: relative; display: flex; align-items: center; justify-content: center; }
+.mosaic-libman .proppane .preview &gt; button { position: absolute; top: 10px; right: 10px; z-index: 1; }
+.mosaic-libman .proppane .preview object { width: 100%; height: 100%; }
+.mosaic-libman .proppane .preview .empty { padding: 1em; text-align: center; color: var(--color-text-muted); }
+.mosaic-libman .properties { display: grid; grid-template-columns: [labels] auto [controls] auto; grid-auto-flow: row; row-gap: 1em; align-items: center; }
+.mosaic-libman .properties label { grid-area: auto / labels; max-width: 10ch; overflow: hidden; text-overflow: ellipsis; }
+.mosaic-libman .properties input, .mosaic-libman .properties select, .mosaic-libman .properties textarea { grid-area: auto / controls; box-sizing: border-box; width: 100%; }
+.mosaic-libman .properties input[type="checkbox"] { width: auto; justify-self: start; }
+.mosaic-app .properties h4 { grid-column: 1 / -1; margin: 0.5em 0px 0px; }
+.mosaic-libman .properties &gt; button { grid-column: 1 / -1; justify-self: start; }
+.mosaic-libman input[type="radio"] { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+.mosaic-libman input[type="radio"]:focus-visible + label { outline: selecteditem solid 2px; outline-offset: 1px; }
+.mosaic-libman input[type="radio"] + label, .mosaic-libman .remote-model, .model-selector-popup .model-row { display: block; padding: 10px 15px; margin-top: 5px; cursor: pointer; }
+.mosaic-libman input[type="radio"]:checked + label, .mosaic-libman .remote-model:active, .model-selector-popup .model-row.active, .model-selector-popup .model-row:hover { background-color: rgba(0, 0, 0, 0.04); border-radius: 7px; }
+.mosaic-libman .section-header-with-button { display: flex; justify-content: space-between; align-items: center; padding-right: 10px; }
+.mosaic-libman .available-section .download-btn { background: none; padding: 2px 4px; margin: 0px; box-shadow: none; float: right; }
+.mosaic-libman .schematics label svg, .model-selector-popup .model-row svg { font-size: 1.5em; vertical-align: middle; margin-right: 0.2em; }
+.mosaic-libman .schematics label form { display: inline; }
+.mosaic-libman details .detailbody, .model-selector-popup details .detailbody { max-height: 0px; transition: max-height 1s; overflow: hidden; margin-left: 7px; }
+.mosaic-libman details[open] .detailbody, .model-selector-popup details[open] .detailbody { max-height: 10000px; }
+.mosaic-libman details summary { list-style-type: none; }
+.mosaic-libman .cellsel details summary, .model-selector-popup details summary { padding: 10px 15px; border-radius: 7px; cursor: pointer; }
+.mosaic-libman .dbprops details summary { padding: 1em; cursor: pointer; }
+.mosaic-libman .dbprops details form { margin: 0px 1em 1em; }
+.mosaic-libman .cellsel details[open] &gt; summary, .model-selector-popup details[open] &gt; summary { background: var(--color-accent) 0% 0% no-repeat padding-box; color: var(--color-accent-text); }
+.mosaic-libman { display: grid; grid-template: "libraries schematics properties" 1fr / 1fr 2fr 2fr; }
+.mosaic-libman .empty { margin: 1em 0px; }
+.mosaic-editor * { margin: 0px; padding: 0px; }
+.mosaic-editor h1, .mosaic-editor h2, .mosaic-editor h3, .mosaic-editor h4, .mosaic-editor h5, .mosaic-editor h6 { font-size: 1.1em; margin: 0.5em 0px; }
+.mosaic-editor p { margin: 0.5em 0px; }
+.mosaic-editor, .mosaic-container, .mosaic-libman { width: 100%; height: 100%; overflow: hidden; }
+.mosaic-container { display: flex; flex-direction: column; }
+.mosaic-container .chrome-float { background: var(--color-surface); box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 8px; border: 0.5px solid var(--color-border-light); }
+.mosaic-container .menu { grid-row: 1; z-index: 2; display: table; table-layout: auto; border-spacing: 0px; width: 100%; box-sizing: border-box; }
+.mosaic-container .menu .primary { display: contents; }
+.mosaic-container .menu .secondary { display: table-cell; vertical-align: middle; padding: 0.375em; text-align: right; }
+.mosaic-container .menu .toolbar-group { display: table-cell; vertical-align: middle; padding: 0.375em; }
+.mosaic-container .menu .toolbar-group &gt; *, .mosaic-container .menu .secondary &gt; * { display: inline-block; vertical-align: middle; margin: 0.375em; }
+.mosaic-container .menu .toolbar-group + .toolbar-group { padding-left: 0.5em; position: relative; }
+.mosaic-container .menu .toolbar-group + .toolbar-group::before { content: ""; position: absolute; left: 0px; top: 0.5em; bottom: 0.5em; }
+.mosaic-container .menu .status { display: table-cell; vertical-align: middle; white-space: nowrap; text-align: center; }
+.mosaic-container .content-wrapper { display: flex; flex: 1 1 0%; overflow: hidden; }
+.mosaic-container .content { position: relative; flex: 1 1 0%; overflow: hidden; z-index: 1; }
+.mosaic-container .devicetray-anchor { position: absolute; bottom: 25px; left: 0px; right: 0px; width: fit-content; margin: 0px auto; max-width: calc(100% - 50px); display: flex; flex-direction: row; }
+.mosaic-container .devicetray-anchor &gt; .tray-filler { visibility: hidden; }
+.mosaic-container .devicetray { border-radius: 15px; display: flex; flex-flow: wrap; padding: 0.5em; user-select: none; }
+.mosaic-container .sidebar { position: absolute; top: 25px; right: 25px; background: var(--color-surface) 0% 0% no-repeat padding-box; box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 8px; border: 0.5px solid var(--color-border); border-radius: 10px; width: 300px; max-height: calc(100% - 50px); overflow: hidden auto; box-sizing: border-box; }
+.mosaic-container .sidebar h1, .mosaic-app .device-props h1 { background-color: var(--color-accent); color: var(--color-accent-text); margin: 0px; border-radius: 10px 10px 0px 0px; padding: 15px 20px; font: 500 18px / 20px Roboto, sans-serif; letter-spacing: 0.7px; }
+.mosaic-container .sidebar .properties, .mosaic-app .device-props .properties { padding: 20px; }
+.mosaic-app .contextmenu.window:has(.device-props) { padding: 0px; overflow: hidden; }
+.mosaic-app .device-props { width: 300px; max-height: calc(-50px + 100vh); overflow: hidden auto; }
+.mosaic-container .chrome a, .mosaic-container .chrome button, .mosaic-container .chrome label, .mosaic-container .devicetray-anchor &gt; .tray-filler { font-size: inherit; padding: 0.5em; margin: 0.75em 0.5em; background-color: var(--color-surface); box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 8px; border-radius: 5px; width: 1em; height: 1em; color: var(--color-text); border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; box-sizing: content-box; cursor: pointer; }
+.mosaic-container .chrome svg, .mosaic-app .onboarding svg { fill: var(--color-text); }
+.mosaic-container .chrome [aria-disabled="true"] { cursor: not-allowed; opacity: 0.45; pointer-events: none; }
+.mosaic-container .chrome a:hover, .mosaic-container .chrome button:hover, .mosaic-container .chrome label:hover { background-color: var(--color-hover); }
+.mosaic-container .chrome a:active, .mosaic-container .chrome a.active, .mosaic-container .chrome button.active, .mosaic-container .chrome input[type="radio"]:checked + label { background-color: var(--color-accent); color: var(--color-accent-text); }
+.mosaic-container .chrome a:active svg, .mosaic-container .chrome a.active svg, .mosaic-container .chrome button.active svg, .mosaic-container .chrome input[type="radio"]:checked + label svg { fill: var(--color-accent-text); }
+.mosaic-container .chrome input[type="radio"] { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+.mosaic-container .chrome input[type="radio"]:focus-visible + label { outline: selecteditem solid 2px; outline-offset: 1px; }
+.mosaic-container .devicetray button, .mosaic-container .devicetray-anchor &gt; .tray-filler { padding: 0.6em; margin: 0.6em 0.4em; width: 25px; height: 25px; display: inline-block; }
+.mosaic-container .devicetray svg { width: 25px; height: 25px; }
+.mosaic-container .devicetray .domain-switch { display: flex; flex-direction: row; align-items: center; border-left: 0.5px solid var(--color-border-light); padding-left: 0.5em; }
+.mosaic-container .devicetray .domain-switch label { width: 16px; height: 16px; padding: 0.3em; margin: 0.6em 0.2em; }
+.mosaic-container .devicetray .domain-switch svg { width: 16px; height: 16px; }
+.mosaic-container .devicetray .split-tray { position: relative; display: inline-block; align-self: flex-start; margin: 0.6em 0.4em; }
+.mosaic-container .devicetray .split-tray &gt; button:first-child { margin: 0px; }
+.mosaic-container .devicetray .split-tray &gt; button.slit { position: absolute; left: 0px; right: 0px; top: -1.1em; height: 1.1em; width: auto; margin: 0px; padding: 0px; background: transparent; box-shadow: none; border-radius: 5px; }
+.mosaic-container .devicetray .split-tray &gt; button.slit::after { content: ""; position: absolute; top: 50%; left: 50%; padding: 3px; border-top-color: ; border-top-style: ; border-right-color: ; border-right-style: ; border-bottom-color: ; border-bottom-style: ; border-left-color: ; border-left-style: ; border-image-source: ; border-image-slice: ; border-image-width: ; border-image-outset: ; border-image-repeat: ; border-width: 0px 1px 1px 0px; transform: translate(-50%, -50%) rotate(-135deg); }
+.mosaic-container .devicetray .split-tray &gt; button.slit.open::after { transform: translate(-50%, -50%) rotate(45deg); }
+.mosaic-container .devicetray .split-tray &gt; button.slit:hover { background: var(--color-hover); }
+.mosaic-container .devicetray .tray-backdrop { position: fixed; inset: 0px; z-index: 20; }
+.mosaic-container .devicetray .split-tray .tray { position: absolute; left: -0.4em; bottom: calc(100% + 1.1em + 14px); display: flex; flex-direction: column-reverse; background: var(--color-surface) 0% 0% no-repeat padding-box; border: 0.5px solid var(--color-border-light); border-radius: 5px; z-index: 21; }
+.mosaic-container .devicetray .split-tray .tray::before { content: ""; position: absolute; z-index: -1; left: calc(50% - 10px); bottom: -10px; transform: rotate(45deg); width: 20px; height: 20px; background: var(--color-surface); border-bottom: 0.5px solid var(--color-border-light); border-right: 0.5px solid var(--color-border-light); }
+.mosaic-editor .properties { display: grid; grid-template-columns: [labels] auto [controls] 1fr; grid-auto-flow: row; gap: 0.8em; }
+.mosaic-editor .properties label { grid-area: auto / labels; max-width: 10ch; overflow: hidden; text-overflow: ellipsis; }
+.mosaic-editor .properties input, .mosaic-editor .properties select, .mosaic-editor .properties textarea { grid-area: auto / controls; box-sizing: border-box; width: 100%; }
+.mosaic-editor .properties .template-header { grid-column: 1 / -1; display: flex; align-items: center; justify-content: space-between; }
+.mosaic-editor .properties .field-with-extra { grid-column: controls; }
+.mosaic-editor svg { overflow: visible; stroke-linecap: round; touch-action: none; }
+.mosaic-editor g.staging, .mosaic-editor g.toolstaging { opacity: 0.5; }
+g.device { transform-box: view-box; transform-origin: center center; user-select: none; }
+@media (hover: none) {
+  .device g.toolstaging { display: none; }
+}
+polyline.wirebb { stroke: transparent; transition: stroke 200ms; stroke-width: 25px; fill: none; pointer-events: stroke; stroke-linejoin: round; }
+g.wire:hover polyline.wirebb { stroke: rgba(0, 0, 0, 0.03); }
+g.wire.photonic polyline.wirebb { stroke: light-dark(rgba(216, 243, 240, 0.2), transparent); }
+text { user-select: none; white-space: pre; fill: var(--canvas-stroke); }
+text.identifier { font-size: 0.7em; }
+g.text text { font-size: 0.7em; }
+rect.select { fill: rgba(0, 0, 0, 0.1); }
+.mosaic-canvas { background-color: var(--canvas-bg); overflow: hidden; }
+.mosaic-canvas.pan { cursor: url("icons/arrows-move.svg") 6 0, grab; }
+.mosaic-canvas.wire { cursor: url("icons/pencil.svg") 0 16, crosshair; }
+.mosaic-canvas.probe { cursor: url("icons/search.svg") 5 5, crosshair; }
+.mosaic-canvas.eraser .wire:hover, .mosaic-canvas.eraser .device { cursor: url("icons/eraser.svg") 6 14, crosshair; }
+.mosaic-canvas.cursor circle.port, .mosaic-canvas.cursor circle.nc { cursor: url("icons/pencil.svg") 0 16, crosshair; }
+:root:has(body.vscode-dark) { color-scheme: dark; }
+:root:has(body.vscode-light) { color-scheme: light; }
+:root:has(.mosaic-container.dark-cursors) { color-scheme: dark; }
+:root:has(.mosaic-container.light-cursors) { color-scheme: light; }
+:root:has(.mosaic-container.eyesore) { color-scheme: light; }
+@media (prefers-color-scheme: dark) {
+  .mosaic-canvas.pan { cursor: url("icons/arrows-move-light.svg") 6 0, grab; }
+  .mosaic-canvas.wire { cursor: url("icons/pencil-light.svg") 0 16, crosshair; }
+  .mosaic-canvas.probe { cursor: url("icons/search-light.svg") 5 5, crosshair; }
+  .mosaic-canvas.eraser .wire:hover, .mosaic-canvas.eraser .device { cursor: url("icons/eraser-light.svg") 6 14, crosshair; }
+  .mosaic-canvas.cursor circle.port, .mosaic-canvas.cursor circle.nc { cursor: url("icons/pencil-light.svg") 0 16, crosshair; }
+}
+.dark-cursors .mosaic-canvas.pan, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.pan { cursor: url("icons/arrows-move-light.svg") 6 0, grab; }
+.dark-cursors .mosaic-canvas.wire, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.wire { cursor: url("icons/pencil-light.svg") 0 16, crosshair; }
+.dark-cursors .mosaic-canvas.probe, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.probe { cursor: url("icons/search-light.svg") 5 5, crosshair; }
+.dark-cursors .mosaic-canvas.eraser .wire:hover, .dark-cursors .mosaic-canvas.eraser .device, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .wire:hover, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.eraser .device { cursor: url("icons/eraser-light.svg") 6 14, crosshair; }
+.dark-cursors .mosaic-canvas.cursor circle.port, .dark-cursors .mosaic-canvas.cursor circle.nc, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.cursor circle.port, .vscode-dark .mosaic-container:not(.light-cursors) .mosaic-canvas.cursor circle.nc { cursor: url("icons/pencil-light.svg") 0 16, crosshair; }
+body.vscode-dark, body.vscode-light { --canvas-select: color-mix(in srgb, var(--vscode-focusBorder) 25%, var(--canvas-bg)); }
+body.vscode-dark .mosaic-container .menu .status, body.vscode-light .mosaic-container .menu .status { display: none; }
+line.grid { stroke: var(--canvas-grid); stroke-width: 0.5px; fill: none; }
+rect.tetris { fill: var(--device-bg); stroke: var(--device-bg); stroke-width: calc(8.28427px); rx: 10px; }
+g.device.selected rect.tetris, rect.tetris.selected { fill: var(--canvas-select) !important; stroke: var(--canvas-select) !important; }
+.port.selected polyline { fill: var(--canvas-select) !important; }
+g.device.nchan rect.tetris { fill: var(--device-bg-nchan); stroke: var(--device-bg-nchan); }
+g.device.pchan rect.tetris { fill: var(--device-bg-pchan); stroke: var(--device-bg-pchan); }
+g.device.passive rect.tetris { fill: var(--device-bg-passive); stroke: var(--device-bg-passive); }
+g.device.source rect.tetris { fill: var(--device-bg-source); stroke: var(--device-bg-source); }
+g.device.photonic rect.tetris { fill: var(--device-bg-photonic); stroke: var(--device-bg-photonic); }
+g.device.photonic-active rect.tetris { fill: var(--device-bg-photonic-active); stroke: var(--device-bg-photonic-active); }
+g.device.port polyline { fill: var(--device-bg-source); }
+circle.port { fill: var(--canvas-port-electric-fill); stroke: var(--canvas-port-electric-stroke); }
+circle.port.photonic { fill: var(--canvas-port-photonic-fill); stroke: var(--canvas-port-photonic-stroke); }
+g.device circle.port { display: none; }
+g.device.selected circle.port { display: inherit; }
+g.device polyline, g.device circle.outline, g.device rect.outline, g.device polygon.outline, g.device path { stroke: var(--canvas-stroke); stroke-width: 2px; fill: none; }
+g.device polygon.arrow { fill: var(--canvas-stroke); stroke: none; }
+polyline.wire { stroke: var(--canvas-wire-stroke); stroke-width: 2px; fill: none; stroke-linejoin: round; }
+circle.wire { fill: var(--canvas-wire-stroke); }
+g.wire.photonic polyline.wire { stroke: var(--canvas-wire-photonic); }
+g.wire.photonic circle.wire { fill: var(--canvas-wire-photonic); }
+g.wire.selected polyline.wire { stroke-dasharray: 10px, 3px; }
+g.device.selected polyline, g.device.selected circle.outline, g.device.selected rect.outline, g.device.selected polygon.outline, g.device.selected path { stroke-dasharray: 10px, 3px; }
+circle.nc { fill: transparent; stroke: var(--canvas-nc); stroke-dasharray: 1, 4; }
+circle.nc.photonic { stroke: var(--canvas-port-photonic-fill); }
+.wire-error { color: var(--canvas-error); pointer-events: all; cursor: help; }
+.wire-error.fork-error { color: var(--canvas-warning); }
+g.airwire { pointer-events: stroke; cursor: help; }
+g.airwire path { fill: none; stroke: rgb(220, 38, 38); stroke-width: 1.5; stroke-dasharray: 4, 4; opacity: 0.7; pointer-events: stroke; }
+g.device.ckt rect.tetris, g.device.amp rect.tetris { fill: var(--device-bg-source); stroke: var(--device-bg-source); }
+g.device.ckt .outline.placeholder, g.device.amp .outline.placeholder { stroke-dasharray: 5, 5; stroke: var(--canvas-placeholder); }
+g.device.ckt text.model-name, g.device.amp text.model-name { font-size: 0.5em; fill: var(--canvas-text); }
+g.device text.port-label { font-size: 0.35em; fill: var(--canvas-text-muted); pointer-events: none; user-select: none; }
+g.device.amp polygon.outline { fill: var(--device-bg-amp); }
+.eyesore { --canvas-bg: black; --canvas-grid: lightgray; --canvas-stroke: #00cc66; --canvas-wire-stroke: #39bfff; --canvas-wire-photonic: #39bfff; --canvas-text: #00cc66; --canvas-text-muted: #00cc66; --canvas-select: transparent; --canvas-nc: red; --canvas-error: red; --canvas-warning: orange; --canvas-placeholder: #00cc66; --canvas-port-electric-fill: red; --canvas-port-electric-stroke: transparent; --canvas-port-photonic-fill: red; --canvas-port-photonic-stroke: transparent; --device-bg: transparent; --device-bg-nchan: transparent; --device-bg-pchan: transparent; --device-bg-passive: transparent; --device-bg-source: transparent; --device-bg-photonic: transparent; --device-bg-photonic-active: transparent; --device-bg-amp: transparent; }
+svg.eyesore { shape-rendering: crispedges; }
+.eyesore g.wire.photonic polyline.wirebb { stroke: transparent; }
+.eyesore g.device circle.port { display: inherit; }
+.eyesore line.grid { stroke-dasharray: 1, 99999; stroke-linecap: butt; vector-effect: non-scaling-stroke; stroke-width: 1px; }
+.eyesore g.device polyline, .eyesore g.device path, .eyesore g.device circle.outline, .eyesore g.device rect.outline, .eyesore g.device polygon.outline { stroke-width: 1px; vector-effect: non-scaling-stroke; }
+.eyesore g.device text { stroke: var(--canvas-stroke); fill: var(--canvas-stroke); vector-effect: non-scaling-stroke; }
+.eyesore g.device.port polyline { fill: red; stroke: none; }
+.eyesore g.device.port circle.port { fill: none; }
+.eyesore g.device.port.supply polyline, .eyesore g.device.port.ground polyline, .eyesore g.device.port.emitter polyline, .eyesore g.device.port.detector polyline { stroke: var(--canvas-stroke); fill: transparent; }
+.eyesore g.device.port.selected polyline { stroke: white; fill: transparent; }
+.eyesore g.device.selected polyline, .eyesore g.device.selected path, .eyesore g.device.selected circle.outline, .eyesore g.device.selected rect.outline, .eyesore g.device.selected polygon.outline, .eyesore g.device.selected polygon.arrow { stroke: white; fill: none; stroke-dasharray: none; }
+.eyesore g.device.selected polygon.arrow { fill: white; }
+.eyesore g.device.selected text { stroke: white; fill: white; }
+.eyesore g.wire.selected polyline.wire { stroke: white; stroke-dasharray: none; }
+.eyesore polyline.wire { stroke-width: 1px; vector-effect: non-scaling-stroke; }
+.eyesore text { fill: red; }
+#mosaic_notebook_wrapper { display: flex; flex-direction: column; height: 100%; background: var(--color-surface); border-left: 1px solid var(--color-border); z-index: 2; width: min(800px, 45%); min-width: 300px; max-width: 80%; position: relative; }
+#mosaic_notebook { flex: 1 1 0%; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; width: 100%; height: 100%; min-height: 0px; }
+#mosaic_notebook_wrapper .resize-handle { position: absolute; left: 0px; top: 0px; width: 6px; height: 100%; cursor: ew-resize; background: transparent; z-index: 10; }
+#mosaic_notebook_wrapper .resize-handle:hover { background: rgba(0, 0, 0, 0.1); }
+#mosaic_notebook_wrapper.resizing #mosaic_notebook { pointer-events: none; }
+.notebook-chevron { position: absolute; top: 50%; left: -18px; transform: translateY(-50%); background: var(--color-surface); border-top-color: ; border-top-style: ; border-top-width: ; border-bottom-color: ; border-bottom-style: ; border-bottom-width: ; border-left-color: ; border-left-style: ; border-left-width: ; border-image-source: ; border-image-slice: ; border-image-width: ; border-image-outset: ; border-image-repeat: ; border-right-width: medium; border-right-style: none; border-right-color: currentcolor; border-radius: 6px 0px 0px 6px; cursor: pointer; padding: 16px 4px; color: var(--color-text); font-size: 10px; line-height: 1; opacity: 0; transition: opacity 0.15s; z-index: 11; }
+#mosaic_notebook_wrapper:hover .notebook-chevron { opacity: 0.6; }
+.notebook-chevron:hover { background: var(--color-border); opacity: 1 !important; }
+#mosaic_notebook_collapsed { display: flex; align-items: center; justify-content: center; width: 18px; height: 100%; background: var(--color-surface); border-left: 1px solid var(--color-border); cursor: pointer; color: var(--color-text); font-size: 8px; }
+#mosaic_notebook_collapsed:hover { background: var(--color-border); }
+.mosaic-auth { background: var(--color-bg); width: 100%; height: 100vh; margin: 0px; padding: 0px; }
+.mosaic-auth .auth-container, .mosaic-auth .account-container { display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 20px; }
+.mosaic-auth .auth-card, .mosaic-auth .account-card { background: var(--color-surface); box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 8px; border: 0.5px solid var(--color-border-light); border-radius: 7px; padding: 40px; width: 100%; max-width: 400px; }
+.mosaic-auth .account-card { max-width: 500px; }
+.mosaic-auth .auth-card h1 { font: 500 25px / 25px Roboto, sans-serif; letter-spacing: 0.85px; color: var(--color-text-strong); text-align: center; margin-bottom: 30px; }
+.mosaic-auth .form-group { margin-bottom: 20px; }
+.mosaic-auth .form-group label { display: block; margin-bottom: 8px; color: var(--color-text); font-weight: 500; }
+.mosaic-auth .form-group input { width: 100%; padding: 12px; box-sizing: border-box; }
+.mosaic-auth .form-group input:focus { outline: none; border-color: var(--color-accent); }
+.mosaic-auth button.primary, .mosaic-auth input[type="submit"] { width: 100%; padding: 12px; margin: 20px 0px; }
+.mosaic-auth button.primary:disabled { background: var(--color-border); cursor: not-allowed; }
+.mosaic-auth button.secondary { display: inline-block; background: var(--color-surface-alt); color: var(--color-text); text-decoration: none; text-align: center; }
+.mosaic-auth button.secondary:hover { background-color: var(--color-border); }
+.mosaic-auth button.danger { background: rgb(220, 53, 69); color: var(--color-accent-text); }
+.mosaic-auth button.danger:hover { background: rgb(200, 35, 51); }
+.mosaic-auth .auth-toggle { text-align: center; margin-top: 20px; }
+.mosaic-auth .auth-toggle p { color: var(--color-text); margin: 10px 0px; }
+.mosaic-auth .auth-toggle a { color: var(--color-accent); text-decoration: none; font-weight: 500; }
+.mosaic-auth .auth-toggle a:hover { text-decoration: underline; }
+.mosaic-auth .local-option { border-top: 1px solid var(--color-border-light); margin-top: 30px; padding-top: 20px; text-align: center; }
+.mosaic-auth .local-option p { color: var(--color-text); margin-bottom: 15px; }
+.mosaic-auth .error-message { background: rgb(248, 215, 218); color: rgb(114, 28, 36); padding: 12px; border-radius: 5px; margin-bottom: 20px; border: 1px solid rgb(245, 198, 203); }
+.mosaic-auth .user-info { margin: 20px 0px; }
+.mosaic-auth .user-info p { margin: 10px 0px; color: var(--color-text); }
+.mosaic-auth .user-info strong { color: var(--color-text-strong); }
+.mosaic-auth .user-info code { background: var(--color-input-bg); padding: 4px 8px; border-radius: 5px; font-family: Consolas, Monaco, monospace; font-size: 14px; word-break: break-all; }
+.mosaic-auth .account-actions { display: flex; gap: 15px; margin-top: 30px; }
+.mosaic-auth .account-actions .button { flex: 1 1 0%; }
+.mosaic-app .modal .onboarding { max-width: 700px; max-height: 90vh; overflow-y: auto; position: relative; }
+.mosaic-app .modal .onboarding .close-btn { position: absolute; top: 10px; right: 10px; background: none; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; font-size: 24px; cursor: pointer; color: var(--color-text-muted); padding: 5px 10px; box-shadow: none; }
+.mosaic-app .modal .onboarding .close-btn:hover { color: var(--color-text-strong); }
+.mosaic-app .modal .onboarding h2 { font: 500 25px / 25px Roboto, sans-serif; letter-spacing: 0.85px; color: var(--color-text-strong); margin-bottom: 15px; text-align: center; }
+.mosaic-app .modal .onboarding .intro { text-align: center; color: var(--color-text); margin-bottom: 25px; }
+.mosaic-app .modal .onboarding .shortcut-category h3 { font: 500 14px / 18px Roboto, sans-serif; color: var(--color-accent); margin-bottom: 10px; text-transform: uppercase; letter-spacing: 0.5px; }
+.mosaic-app .modal .onboarding .components-section { margin-bottom: 20px; padding-bottom: 20px; border-bottom: 1px solid var(--color-border-light); }
+.mosaic-app .modal .onboarding .components-row { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; }
+.mosaic-app .modal .onboarding .component-item { display: flex; flex-direction: column; align-items: center; gap: 4px; }
+.mosaic-app .modal .onboarding .component-item &gt; :first-child { height: 36px; display: flex; align-items: center; justify-content: center; }
+.mosaic-app .modal .onboarding .device-icon svg { width: 36px; height: 36px; }
+.mosaic-app .modal .onboarding .component-item &gt; svg { width: 28px; height: 28px; color: var(--color-text-muted); }
+.mosaic-app .modal .onboarding .component-item .label { font-size: 10px; color: var(--color-text-muted); text-align: center; }
+.mosaic-app .modal .onboarding .hint { text-align: center; font-size: 12px; color: var(--color-text-muted); margin-top: 10px; margin-bottom: 0px; }
+.mosaic-app .modal .onboarding .shortcut-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 25px; margin-bottom: 25px; }
+.mosaic-app .modal .onboarding table { width: 100%; border-collapse: collapse; }
+.mosaic-app .modal .onboarding tr { border-bottom: 1px solid var(--color-border-light); }
+.mosaic-app .modal .onboarding tr:last-child { border-bottom-width: medium; border-bottom-style: none; border-bottom-color: currentcolor; }
+.mosaic-app .modal .onboarding td { padding: 6px 4px; vertical-align: middle; }
+.mosaic-app .modal .onboarding .icon-cell { width: 24px; text-align: center; color: var(--color-text-muted); }
+.mosaic-app .modal .onboarding .icon-cell svg { width: 16px; height: 16px; }
+.mosaic-app .modal .onboarding kbd { background: var(--color-surface-alt); border: 1px solid var(--color-border); border-radius: 4px; padding: 3px 8px; font-family: Consolas, Monaco, monospace; font-size: 11px; white-space: nowrap; box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px; }
+.mosaic-app .modal .onboarding .desc { font-size: 13px; color: var(--color-text); padding-left: 8px; }
+.mosaic-app .modal .onboarding .actions { display: flex; justify-content: space-between; align-items: center; gap: 10px; border-top: 1px solid var(--color-border-light); padding: 20px 5px 5px; margin-top: 10px; }
+.mosaic-app .modal .onboarding .actions button:has(svg) { display: flex; align-items: center; gap: 0.5em; }
+.mosaic-app .history-panel { min-width: 400px; max-height: 80vh; overflow-y: auto; }
+.mosaic-app .history-panel .modal-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; }
+.mosaic-app .history-panel .modal-header h2 { margin: 0px; font: 500 20px / 25px Roboto, sans-serif; color: var(--color-text-strong); }
+.mosaic-app .history-panel .modal-header .close { background: none; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; font-size: 24px; cursor: pointer; color: var(--color-text-muted); padding: 5px 10px; box-shadow: none; }
+.mosaic-app .history-panel .modal-header .close:hover { color: var(--color-text-strong); }
+.mosaic-app .history-panel .upload-section { padding: 1em 0px; border-bottom: 1px solid var(--color-border-light); display: flex; gap: 0.5em; }
+.mosaic-app .history-panel .upload-section button { display: flex; align-items: center; gap: 0.5em; }
+.mosaic-app .history-panel .snapshot-list { padding: 0.5em 0px; }
+.mosaic-app .history-panel .snapshot-item { margin: 0.5em 0px; border: 1px solid var(--color-border-light); border-radius: 5px; }
+.mosaic-app .history-panel .snapshot-item summary { display: flex; justify-content: space-between; align-items: center; padding: 0.75em; cursor: pointer; list-style: none; }
+.mosaic-app .history-panel .snapshot-item summary::after { display: none; }
+.mosaic-app .history-panel .snapshot-item summary .timestamp { font-family: Consolas, Monaco, monospace; font-size: 13px; color: var(--color-text); }
+.mosaic-app .history-panel .snapshot-item summary .actions { display: flex; gap: 0.5em; }
+.mosaic-app .history-panel .snapshot-item summary .actions button { padding: 5px 10px; font-size: 12px; }
+.mosaic-app .history-panel .snapshot-item .preview { padding: 0.75em; border-top: 1px solid var(--color-border-light); background: var(--color-bg); }
+.mosaic-app .history-panel .snapshot-item .preview object { width: 100%; height: 200px; border: 1px solid var(--color-border-light); background: var(--color-surface); }
+.mosaic-app .history-panel .empty { color: var(--color-text-muted); font-style: italic; padding: 1em 0px; }
+.mosaic-app .properties .fieldset-item { grid-column: 1 / -1; border: 1px solid var(--color-input-border); border-radius: 5px; padding: 0.5em; display: grid; grid-template-columns: subgrid; gap: 0.5em; align-items: center; }
+.mosaic-app .properties .fieldset-item .fieldset-legend { grid-column: 1 / -1; display: flex; align-items: center; gap: 0.3em; margin: -1.1em 0px 0px; padding: 0px 0.25em; background: var(--color-surface); width: fit-content; }
+.mosaic-app .properties .remove-btn { background: none; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; cursor: pointer; padding: 0px; box-shadow: none; color: rgb(217, 83, 79); font-size: 16px; display: inline-flex; align-items: center; margin-right: 0.5em; order: -1; }
+.mosaic-app .properties .add-btn { grid-column: 1 / -1; justify-self: start; display: flex; align-items: center; gap: 0.3em; }
+.mosaic-app .properties .bi-x-circle-fill, .mosaic-app .properties .bi-plus-circle-fill { display: none; }
+.mosaic-app .properties .remove-btn:hover .bi-x-circle, .mosaic-app .properties .add-btn:hover .bi-plus-circle, .mosaic-app .properties .add-btn.active .bi-plus-circle { display: none; }
+.mosaic-app .properties .remove-btn:hover .bi-x-circle-fill, .mosaic-app .properties .add-btn:hover .bi-plus-circle-fill, .mosaic-app .properties .add-btn.active .bi-plus-circle-fill { display: inline; }
+.mosaic-app .properties .add-btn.active { background: var(--color-accent); color: var(--color-accent-text); }
+.mosaic-app .tag-badge { display: inline-block; background: var(--color-border-light); color: var(--color-text-muted); font-size: 0.75em; padding: 1px 6px; border-radius: 3px; margin-left: 4px; vertical-align: middle; }
+.mosaic-app .tag-badge.clickable { cursor: pointer; }
+.mosaic-app .tag-badge.clickable:hover { background: var(--color-border); }
+.mosaic-app .tag-badge.active { cursor: pointer; background: var(--color-badge); color: var(--color-badge-text); }
+.mosaic-app .tag-badge.active:hover { background: color-mix(in srgb, var(--color-badge) 85%, black); }
+.mosaic-app .tag-badge.prop-tag { background: color-mix(in srgb, var(--color-badge) 18%, transparent); color: var(--color-text-strong); }
+.mosaic-app .tag-badge.prop-tag.active { background: color-mix(in srgb, var(--color-badge) 70%, black); color: var(--color-badge-text); }
+html, body { width: 100%; height: 100%; overflow: hidden; margin: 0px; padding: 0px; }</style><defs><pattern id="gridfill" patternUnits="userSpaceOnUse" width="50" height="50"><line x1="0" y1="0" x2="50" y2="0" class="grid"></line><line x1="0" y1="0" x2="0" y2="50" class="grid"></line></pattern></defs><rect fill="url(#gridfill)" x="-25000" y="-25000" width="50000" height="50000"></rect><g class="schematic-content"><g class="device wire d" style="transform: matrix(1, 0, 0, 1, -50, 200); transform-origin: 0px 250px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device wire d" style="transform: matrix(1, 0, 0, 1, 50, 200); transform-origin: 100px 250px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device wire d" style="transform: matrix(1, 0, 0, 1, 0, 150); transform-origin: 50px 200px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, 150, 150); transform-origin: 225px 225px;"><rect x="50" y="50" width="50" height="50" class="tetris"></rect></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -50, 0); transform-origin: 50px 100px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, -50, 150); transform-origin: 25px 225px;"><rect x="50" y="50" width="50" height="50" class="tetris"></rect></g><g class="device port" style="transform: matrix(1, 0, 0, 1, -150, 200); transform-origin: -100px 250px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device port" style="transform: matrix(-1, 0, 0, -1, -250, -200); transform-origin: 300px 250px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -150, 200); transform-origin: 250px 200px;"><rect x="50" y="50" width="0" height="0" class="tetris"></rect></g><g class="wire photonic"><polyline points="-25,225 -125,225" class="wirebb"></polyline><polyline points="-25,225 -125,225" class="wire photonic"></polyline></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, 150, 150); transform-origin: 225px 225px;"><text transform="matrix(1, 0, 0, 1, 105, 42.5)" class="identifier"><tspan x="0" dy="0">X2</tspan></text><polyline points="75,25,75,50"></polyline><polyline points="100,75,125,75"></polyline><polyline points="50,75,25,75"></polyline><text x="57.49999999999999" y="75" text-anchor="start" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">coupling_o1</text><text x="92.5" y="75" text-anchor="end" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">coupling_o2</text><text x="75" y="65" text-anchor="middle" dominant-baseline="hanging" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">resonator_o1</text><rect class="outline" x="50" y="50" width="50" height="50"></rect><text x="75" y="75" text-anchor="middle" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="model-name">quarter_wave_resonator_coupled</text></g><g class="wire photonic"><polyline points="75,225 175,225" class="wirebb"></polyline><polyline points="75,225 175,225" class="wire photonic"></polyline></g><g class="wire photonic"><polyline points="25,175 25,75" class="wirebb"></polyline><polyline points="25,175 25,75" class="wire photonic"></polyline></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -50, 0); transform-origin: 25px 75px;"><polyline points="25,25,15,15,0,15,0,35,15,35,25,25"></polyline><text text-anchor="middle" dominant-baseline="middle" transform="matrix(0, -1, 1, 0, -12.5, 25)"><tspan x="0" dy="0">P1</tspan></text></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, -50, 150); transform-origin: 25px 225px;"><text transform="matrix(1, 0, 0, 1, 105, 42.5)" class="identifier"><tspan x="0" dy="0">X1</tspan></text><polyline points="75,25,75,50"></polyline><polyline points="100,75,125,75"></polyline><polyline points="50,75,25,75"></polyline><text x="57.49999999999999" y="75" text-anchor="start" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">coupling_o1</text><text x="92.5" y="75" text-anchor="end" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">coupling_o2</text><text x="75" y="65" text-anchor="middle" dominant-baseline="hanging" transform="matrix(1, 0, 0, 1, 0, 0)" class="port-label">resonator_o1</text><rect class="outline" x="50" y="50" width="50" height="50"></rect><text x="75" y="75" text-anchor="middle" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, 0, 0)" class="model-name">quarter_wave_resonator_coupled</text></g><g class="device port" style="transform: matrix(1, 0, 0, 1, -150, 200); transform-origin: -125px 225px;"><polyline points="25,25,15,15,0,15,0,35,15,35,25,25"></polyline><text text-anchor="end" dominant-baseline="middle" transform="matrix(1, 0, 0, 1, -12.5, 25)"><tspan x="0" dy="0">P2</tspan></text></g><g class="device port" style="transform: matrix(-1, 0, 0, -1, -250, -200); transform-origin: 275px 225px;"><polyline points="25,25,15,15,0,15,0,35,15,35,25,25"></polyline><text text-anchor="start" dominant-baseline="middle" transform="matrix(-1, 0, 0, -1, -12.5, 25)"><tspan x="0" dy="0">P3</tspan></text></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -150, 200); transform-origin: 225px 175px;"><polyline points="25,25,15,15,0,15,0,35,15,35,25,25"></polyline><text text-anchor="middle" dominant-baseline="middle" transform="matrix(0, -1, 1, 0, -12.5, 25)"><tspan x="0" dy="0">P4</tspan></text></g><g class="device wire d" style="transform: matrix(1, 0, 0, 1, -50, 200); transform-origin: -25px 225px;"></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, 150, 150); transform-origin: 225px 225px;"><circle cx="75" cy="25" r="5" class="port photonic"></circle><circle cx="25" cy="75" r="5" class="port photonic"></circle><circle cx="125" cy="75" r="5" class="port photonic"></circle></g><g class="device wire d" style="transform: matrix(1, 0, 0, 1, 50, 200); transform-origin: 75px 225px;"></g><g class="device wire d" style="transform: matrix(1, 0, 0, 1, 0, 150); transform-origin: 25px 175px;"></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -50, 0); transform-origin: 25px 75px;"><circle cx="25" cy="25" r="5" class="port"></circle></g><g class="device ckt" style="transform: matrix(1, 0, 0, 1, -50, 150); transform-origin: 25px 225px;"><circle cx="75" cy="25" r="5" class="port photonic"></circle><circle cx="25" cy="75" r="5" class="port photonic"></circle><circle cx="125" cy="75" r="5" class="port photonic"></circle></g><g class="device port" style="transform: matrix(1, 0, 0, 1, -150, 200); transform-origin: -125px 225px;"><circle cx="25" cy="25" r="5" class="port"></circle></g><g class="device port" style="transform: matrix(-1, 0, 0, -1, -250, -200); transform-origin: 275px 225px;"><circle cx="25" cy="25" r="5" class="port"></circle></g><g class="device port" style="transform: matrix(0, 1, -1, 0, -150, 200); transform-origin: 225px 175px;"><circle cx="25" cy="25" r="5" class="port"></circle></g></g></svg>


### PR DESCRIPTION
## Summary
- configure gdsfactory-plus to show the QPDK library by default
- add a sample coupled quarter-wave resonator schematic and generated SVG preview

## Testing
- `just run-pre` (all hooks passed except `lychee`, which timed out fetching the pre-existing `https://docs.scipy.org/doc/scipy/` URL in `docs/conf.py`)
- `git diff --check`

## Summary by Sourcery

Add a sample resonator schematic and make the QPDK library the default gdsfactory-plus view.

New Features:
- Add a sample coupled quarter-wave resonator schematic with a generated SVG preview.

Enhancements:
- Configure gdsfactory-plus to display the QPDK library by default.