### PR TITLE
fix: resolve type-check follow-ups

### DIFF
--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -94,7 +94,14 @@ def meander_inductor(
     # i.e. pitch = width + 2 * gap, which means wire_gap = 2 * etch_width
     # If no etch section is found, we use a default gap equal to the wire width
     if wire_gap is None:
-        wire_gap = 2 * etch_section.width if etch_section is not None else wire_width
+        if etch_section is not None:
+            if etch_section.width is None:
+                raise ValueError("Etch section must define a width")
+            wire_gap = 2 * etch_section.width
+        else:
+            wire_gap = wire_width
+    if wire_gap is None:
+        raise ValueError("wire_gap could not be inferred from the cross-section")
 
     c = Component()
     pitch = wire_width + wire_gap

--- a/qpdk/models/couplers.py
+++ b/qpdk/models/couplers.py
@@ -234,8 +234,11 @@ if __name__ == "__main__":
     plt.figure(figsize=(10, 6))
 
     # Calculate capacitance per unit length for all gaps simultaneously (shape: (6,))
-    c_pul = cpw_cpw_coupling_capacitance_per_length_analytical(
-        gap=gaps, width=width, cpw_gap=cpw_gap, ep_r=ep_r
+    c_pul = cast(
+        jax.Array,
+        cpw_cpw_coupling_capacitance_per_length_analytical(
+            gap=gaps, width=width, cpw_gap=cpw_gap, ep_r=ep_r
+        ),
     )
 
     # Broadcast to compute total capacitance for all lengths and gaps (shape: (6, 1000))

--- a/tests/test_pdk.py
+++ b/tests/test_pdk.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 import sys
 from collections.abc import Mapping
-from typing import Any, cast, overload
+from typing import Any, cast
 
 if sys.version_info >= (3, 13):
     from typing import TypeIs
@@ -96,32 +96,6 @@ def test_cell_in_pdk(name):
     instances1 = instances_without_info(net1)
     instances2 = instances_without_info(net2)
     assert instances1 == instances2
-
-
-type NormalizedValue = (
-    dict[Any, "NormalizedValue"]
-    | list["NormalizedValue"]
-    | int
-    | float
-    | str
-    | bool
-    | Any
-    | None
-)
-
-
-@overload
-def normalize_numeric_types[K, V](data: Mapping[K, V]) -> dict[K, NormalizedValue]: ...
-@overload
-def normalize_numeric_types(
-    data: list[Any] | tuple[Any, ...] | np.ndarray,
-) -> list[NormalizedValue]: ...
-@overload
-def normalize_numeric_types(data: float | np.floating) -> int | float: ...
-@overload
-def normalize_numeric_types(data: np.integer) -> int: ...
-@overload
-def normalize_numeric_types[T](data: T) -> T: ...
 
 
 def normalize_numeric_types(data: Any) -> Any:


### PR DESCRIPTION
## Summary
- narrow inferred inductor wire-gap values before arithmetic
- type the vectorized coupling-model plotting result as a JAX array
- simplify overlapping test normalization overloads

## Validation
- `uvx prek run --all-files`

## Summary by Sourcery

Resolve remaining type-checking issues across inductor geometry, coupling-model plotting, and test utilities.

Bug Fixes:
- Validate inferred inductor wire-gap values and report missing cross-section widths explicitly.

Enhancements:
- Clarify the vectorized coupling-model result as a JAX array and simplify redundant test normalization type overloads.