### PR TITLE
Forward cross_section to nxn junction in tee

### DIFF
--- a/qpdk/cells/waveguides.py
+++ b/qpdk/cells/waveguides.py
@@ -187,6 +187,11 @@ def tee(cross_section: CrossSectionSpec = "cpw") -> gf.Component:
         "east": 1,
         "south": 1,
         "west": 1,
+        "cross_section": cross_section,
+        "wg_width": cross_section.width,
+        "xsize": cross_section.width,
+        "ysize": cross_section.width,
+        "layer": cross_section.layer,
     })
     for port in list(nxn_ref.ports)[:-1]:
         straight_ref = c << straight(

--- a/tests/test_cells_edge_cases.py
+++ b/tests/test_cells_edge_cases.py
@@ -1,9 +1,10 @@
 """Tests for cell validation edge cases — resonator, waveguides."""
 
+import gdsfactory as gf
 import pytest
 
 from qpdk.cells.resonator import resonator
-from qpdk.cells.waveguides import bend_circular
+from qpdk.cells.waveguides import bend_circular, tee
 
 
 class TestResonatorValidation:
@@ -61,6 +62,28 @@ class TestResonatorValidation:
         """Test resonator with closed start."""
         c = resonator(length=4000, meanders=4, open_start=False)
         assert c is not None
+
+
+class TestTee:
+    """Tests for tee junction consistency with the attached straights."""
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "cross_section_name",
+        ["cpw", "meander_inductor_cross_section", "superinductor_cross_section"],
+    )
+    def test_junction_widths_match_cross_section(cross_section_name: str) -> None:
+        """Test that junction ports match the cross-section width and layer.
+
+        The junction must not be built with the default CPW width (10 µm) or
+        layer (M1_DRAW) when ``tee`` is given a different cross-section.
+        """
+        cross_section = gf.get_cross_section(cross_section_name)
+        c = tee(cross_section=cross_section_name)
+        junction = next(inst for inst in c.insts if inst.cell.name.startswith("nxn"))
+        for port in junction.ports:
+            assert port.width == pytest.approx(cross_section.width)
+            assert port.layer == gf.get_layer(cross_section.layer)
 
 
 class TestBendCircularEdgeCases:


### PR DESCRIPTION
tee ignored its cross_section argument when building the central nxn junction, so the junction was always built with the default CPW width (10 µm) and its ports didn't match the attached straights when a different cross-section was passed. The junction now receives cross_section and wg_width. A test builds a tee with the 2 µm meander-inductor cross-section and checks the junction port widths match.

## Summary by Sourcery

Fix tee junction construction to honor the selected cross-section and keep its ports consistent with connected straights.

Bug Fixes:
- Ensure tee junction ports use the supplied cross-section dimensions and layer so they remain compatible with attached waveguides.

Tests:
- Add coverage for tee junction consistency across CPW, meander-inductor, and superinductor cross-sections.