### PR TITLE
Stop notebook-check test from polluting the real notebooks directory

### DIFF
--- a/tests/test_precommit_notebook_check.py
+++ b/tests/test_precommit_notebook_check.py
@@ -1,84 +1,147 @@
 """Tests for the check-notebook-sources.sh pre-commit hook."""
 
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
 TEMP_NB = "test_orphaned_temp.ipynb"
+SCRIPT_REL_PATH = Path(".github") / "check-notebook-sources.sh"
+SUBPROCESS_TIMEOUT = 60  # seconds
+
+# Minimal valid empty Jupyter notebook
+MINIMAL_NOTEBOOK = '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
+
+
+def _git_env() -> dict[str, str]:
+    """Environment with all GIT_* variables stripped.
+
+    Inherited ``GIT_DIR``/``GIT_WORK_TREE`` (e.g. when pytest is invoked from a
+    git hook or ``git bisect run``) would make ``git init`` and the script's
+    ``git rev-parse --show-toplevel`` resolve to the caller's repository instead
+    of the temporary one.
+
+    Returns:
+        Environment mapping suitable for subprocess calls.
+    """
+    return {
+        key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+    }
+
+
+def _script_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a throwaway git repo with the check script and a known-good notebooks tree.
+
+    The script runs ``git rev-parse --show-toplevel`` and operates on the notebooks/
+    tree of *that* repository, so the only way to isolate the test from the working
+    tree is to run it inside a temporary git repository. The tree is populated with
+    known-good fixtures so the pass case never depends on the developer's
+    working-tree state.
+
+    Returns:
+        Path to the temporary git repository root.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    script = repo_root / SCRIPT_REL_PATH
+    assert script.exists(), f"Script not found at {script}"
+    if shutil.which("git") is None:
+        pytest.skip(
+            "git is not available; check-notebook-sources.sh requires a git repository"
+        )
+
+    repo = tmp_path_factory.mktemp("notebook_check_repo")
+    (repo / SCRIPT_REL_PATH).parent.mkdir()
+    shutil.copy2(script, repo / SCRIPT_REL_PATH)
+
+    # Known-good fixtures: a Python-kernel notebook with its source and a
+    # MATLAB-kernel notebook with its source.
+    (repo / "notebooks" / "src").mkdir(parents=True)
+    (repo / "notebooks" / "python_notebook.ipynb").write_text(MINIMAL_NOTEBOOK)
+    (repo / "notebooks" / "src" / "python_notebook.py").write_text("")
+    (repo / "notebooks" / "matlab_notebook.ipynb").write_text(MINIMAL_NOTEBOOK)
+    (repo / "notebooks" / "src" / "matlab_notebook.m").write_text("")
+
+    try:
+        subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+            ["git", "-C", str(repo), "init", "-q"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT,
+            env=_git_env(),
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or ""
+        pytest.skip(
+            "Could not create temporary git repository for the check: "
+            f"{exc}; git stderr: {detail}"
+        )
+    assert (repo / ".git").is_dir(), f"git init did not create {repo / '.git'}"
+    return repo
 
 
 @pytest.fixture
-def repo_root() -> Path:
-    """Get the repository root directory."""
-    result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return Path(result.stdout.strip())
+def script_repo(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Temporary git repository holding the check script and known-good notebooks."""
+    return _script_repo(tmp_path_factory)
 
 
 @pytest.mark.skip_windows
-def test_check_notebook_sources_logic(repo_root: Path) -> None:
-    """Test the notebook source check script logic (both pass and fail cases).
-
-    Combined into one test to avoid race conditions when running in parallel.
-    """
-    script = repo_root / ".github" / "check-notebook-sources.sh"
-    assert script.exists(), f"Script not found at {script}"
+def test_check_notebook_sources_logic(script_repo: Path) -> None:
+    """Test the notebook source check script logic (both pass and fail cases)."""
+    script = script_repo / SCRIPT_REL_PATH
 
     # 1. Test that the check passes when all notebooks have source files
     result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
         [str(script)],
         capture_output=True,
         text=True,
-        cwd=repo_root,
+        cwd=script_repo,
+        timeout=SUBPROCESS_TIMEOUT,
+        env=_git_env(),
     )
 
     assert result.returncode == 0, f"Check failed (pass case): {result.stderr}"
     assert "All notebooks have corresponding source files" in result.stdout
 
-    # 2. Test that the check fails when a notebook is missing its source file
-    test_notebook = repo_root / "notebooks" / TEMP_NB
+    # 2. Test that the check fails when a notebook is missing its source file.
+    #    The orphaned notebook is created inside the temporary repository, never
+    #    in the real notebooks/ directory.
+    test_notebook = script_repo / "notebooks" / TEMP_NB
+    test_notebook.write_text(MINIMAL_NOTEBOOK)
 
-    try:
-        # Create minimal valid Jupyter notebook
-        test_notebook.write_text(
-            '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}'
-        )
+    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+        [str(script)],
+        capture_output=True,
+        text=True,
+        cwd=script_repo,
+        timeout=SUBPROCESS_TIMEOUT,
+        env=_git_env(),
+    )
 
-        result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
-            [str(script)],
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-        )
-
-        assert result.returncode == 1, "Check should fail with orphaned notebook"
-        assert "Found 1 notebook(s) without corresponding source files" in result.stderr
-        assert TEMP_NB in result.stderr
-        assert f"notebooks/src/{Path(TEMP_NB).stem}.py" in result.stderr
-
-    finally:
-        # Clean up
-        if test_notebook.exists():
-            test_notebook.unlink()
+    assert result.returncode == 1, "Check should fail with orphaned notebook"
+    assert "Found 1 notebook(s) without corresponding source files" in result.stderr
+    assert TEMP_NB in result.stderr
+    assert f"notebooks/src/{Path(TEMP_NB).stem}.py" in result.stderr
 
 
-def test_all_existing_notebooks_have_sources(repo_root: Path) -> None:
+def test_all_existing_notebooks_have_sources() -> None:
     """Verify that all existing .ipynb files have a corresponding jupytext source.
 
     Source files use ``.py`` for Python-kernel notebooks and ``.m`` for
-    MATLAB-kernel notebooks; either is accepted.
+    MATLAB-kernel notebooks; either is accepted. This is a read-only filesystem
+    check against the real notebooks/ directory.
     """
+    repo_root = Path(__file__).resolve().parent.parent
     notebooks_dir = repo_root / "notebooks"
     src_dir = notebooks_dir / "src"
+    assert notebooks_dir.is_dir(), f"notebooks/ directory not found at {notebooks_dir}"
 
     # Find all .ipynb files in notebooks/ (not in subdirectories)
-    # Skip temporary files if they exist due to parallel test execution
-    ipynb_files = [f for f in notebooks_dir.glob("*.ipynb") if f.name != TEMP_NB]
+    ipynb_files = sorted(notebooks_dir.glob("*.ipynb"))
+    assert ipynb_files, f"No .ipynb files found in {notebooks_dir}"
 
     for ipynb_file in ipynb_files:
         py_source = src_dir / f"{ipynb_file.stem}.py"


### PR DESCRIPTION
The notebook-check test wrote its orphaned-notebook fixture into the real notebooks/ directory of the checkout and removed it in a finally block, so an interrupted run left a stray file behind and the pass case depended on the working tree's notebook state. The test now builds a throwaway git repo under tmp_path containing the check script and known-good notebook fixtures and runs the hook there, so it never touches the real checkout. Subprocess calls also get a 60 second timeout.

## Summary by Sourcery

Prevent notebook source-check tests from polluting or depending on the real notebooks directory.

Bug Fixes:
- Isolate notebook-check hook tests in temporary Git repositories so they no longer modify or depend on the real checkout's notebooks directory.
- Add subprocess timeouts to prevent notebook-check tests and repository setup from hanging.

Enhancements:
- Use deterministic, known-good notebook fixtures and sanitized Git environments for isolated hook execution.
- Strengthen the real notebooks directory validation with explicit existence and non-empty checks.

Tests:
- Refactor notebook source-check coverage to exercise both passing and orphaned-notebook cases entirely within temporary test repositories.