### PR TITLE
Fix snspd cell: honor port_type, remove dead code, validate num_meanders

### DIFF
--- a/qpdk/cells/snspd.py
+++ b/qpdk/cells/snspd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 import gdsfactory as gf
 import numpy as np
 from gdsfactory.component import Component
@@ -19,7 +21,7 @@ def snspd(
     turn_ratio: float = 4,
     terminals_same_side: bool = False,
     layer: LayerSpec = LAYER.NbTiN,
-    port_type: str = "electrical",
+    port_type: Literal["electrical", "optical"] = "electrical",
 ) -> Component:
     """Creates an optimally-rounded SNSPD.
 
@@ -41,31 +43,57 @@ def snspd(
             (width, height) of the rectangle formed by the outer boundary of the
             SNSPD.
         num_squares: int | None = None
-            Total number of squares inside the SNSPD length.
+            Total number of squares inside the SNSPD length. If given, overrides
+            `size` with an approximately square SNSPD. The meander count is
+            quantized to whole wire pitches, so the achieved square count
+            (reported in `info["num_squares"]`) is close to but not exactly the
+            requested one.
         turn_ratio: float
             Specifies how much of the SNSPD width is dedicated to the 180 degree
             turn. A `turn_ratio` of 10 will result in 20% of the width being
             comprised of the turn.
         terminals_same_side: If True, both ports will be located on the same side of the SNSPD.
         layer: layer spec to put polygon geometry on.
-        port_type: type of port to add to the component.
+        port_type: type of port to add to the component (`"electrical"` or `"optical"`).
 
     Returns:
         A Component containing the SNSPD geometry.
+
+    Raises:
+        ValueError: If parameters are invalid or the SNSPD is too small for
+            at least 3 meanders.
     """
     if num_squares is not None:
+        if num_squares <= 0:
+            raise ValueError(f"num_squares={num_squares} must be a positive integer.")
+        # num_squares overrides size: build a square SNSPD with the requested
+        # total number of squares. The meander count below is quantized to
+        # whole wire pitches, so the achieved square count (reported in
+        # `info["num_squares"]`) is close to but not exactly the request.
         xy = np.sqrt(num_squares * wire_pitch * wire_width)
         size = (xy, xy)
-        num_squares = None
 
     xsize, ysize = size
-    if num_squares is not None:
-        if xsize is None:
-            xsize = num_squares * wire_pitch * wire_width / ysize
-        elif ysize is None:
-            ysize = num_squares * wire_pitch * wire_width / xsize
+
+    if xsize <= 0 or ysize <= 0:
+        raise ValueError(f"size={size} dimensions must be positive.")
+    if wire_pitch <= wire_width:
+        raise ValueError(
+            f"wire_pitch={wire_pitch} must be greater than wire_width={wire_width}."
+        )
 
     num_meanders = int(np.ceil(ysize / wire_pitch))
+
+    if (not terminals_same_side and (num_meanders % 2) == 0) or (
+        terminals_same_side and (num_meanders % 2) == 1
+    ):
+        num_meanders += 1
+
+    if num_meanders < 3:
+        raise ValueError(
+            f"num_meanders={num_meanders} is too small; the SNSPD needs at least "
+            "3 meanders. Increase `size` or `num_squares`, or decrease `wire_pitch`."
+        )
 
     D = Component()
     hairpin = gf.c.optimal_hairpin(
@@ -77,16 +105,8 @@ def snspd(
         layer=layer,
     )
 
-    if (not terminals_same_side and (num_meanders % 2) == 0) or (
-        terminals_same_side and (num_meanders % 2) == 1
-    ):
-        num_meanders += 1
+    start_nw = D.add_ref(gf.c.compass(size=(xsize / 2, wire_width), layer=layer))
 
-    port_type = "electrical"
-
-    start_nw = D.add_ref(
-        gf.c.compass(size=(xsize / 2, wire_width), layer=layer, port_type=port_type)
-    )
     hp_prev = D.add_ref(hairpin)
     hp_prev.connect("e1", start_nw.ports["e3"])
     alternate = True
@@ -101,14 +121,16 @@ def snspd(
         hp_prev = hp
         alternate = not alternate
 
-    finish_se = D.add_ref(
-        gf.c.compass(size=(xsize / 2, wire_width), layer=layer, port_type=port_type)
-    )
+    finish_se = D.add_ref(gf.c.compass(size=(xsize / 2, wire_width), layer=layer))
     if last_port is not None:
         finish_se.connect("e3", last_port)
 
-    D.add_port(port=start_nw.ports["e1"], name="e1")
-    D.add_port(port=finish_se.ports["e1"], name="e2")
+    # The nanowire geometry itself only makes electrical connections
+    # (`optimal_hairpin` has electrical ports), so honor `port_type` on the
+    # exposed terminal ports.
+    port_prefix = "e" if port_type == "electrical" else "o"
+    D.add_port(port=start_nw.ports["e1"], name=f"{port_prefix}1", port_type=port_type)
+    D.add_port(port=finish_se.ports["e1"], name=f"{port_prefix}2", port_type=port_type)
 
     D.info["num_squares"] = num_meanders * (xsize / wire_width)
     D.info["area"] = xsize * ysize

--- a/tests/test_cells_edge_cases.py
+++ b/tests/test_cells_edge_cases.py
@@ -1,9 +1,12 @@
-"""Tests for cell validation edge cases — resonator, waveguides."""
+"""Tests for cell validation edge cases — resonator, waveguides, snspd."""
 
+import gdsfactory as gf
 import pytest
 
 from qpdk.cells.resonator import resonator
+from qpdk.cells.snspd import snspd
 from qpdk.cells.waveguides import bend_circular
+from qpdk.tech import LAYER
 
 
 class TestResonatorValidation:
@@ -85,3 +88,123 @@ class TestBendCircularEdgeCases:
         for angle in [45.0, 90.0, 180.0]:
             c = bend_circular(angle=angle, radius=100.0)
             assert c is not None
+
+
+class TestSNSPDEdgeCases:
+    """Tests for snspd port_type handling and small-size validation."""
+
+    @staticmethod
+    def test_default_port_type_electrical() -> None:
+        """Test that the default port_type produces electrical ports."""
+        c = snspd()
+        assert {p.name: str(p.port_type) for p in c.ports} == {
+            "e1": "electrical",
+            "e2": "electrical",
+        }
+
+    @staticmethod
+    def test_port_type_optical() -> None:
+        """Test that port_type="optical" produces optical ports."""
+        c = snspd(port_type="optical")
+        assert {p.name: str(p.port_type) for p in c.ports} == {
+            "o1": "optical",
+            "o2": "optical",
+        }
+
+    @staticmethod
+    def test_port_type_optical_netlist_round_trip() -> None:
+        """Test that the optical-port snspd survives a component->netlist->component round trip.
+
+        The flat snspd leaf drops its ports in `get_netlist()`, so wrap it in a
+        hierarchical component whose netlist records the ports and the
+        `port_type` setting of the instance.
+        """
+        c = gf.Component()
+        sref = c << snspd(port_type="optical")
+        c.add_port(name="o1", port=sref.ports["o1"])
+        c.add_port(name="o2", port=sref.ports["o2"])
+        netlist = c.get_netlist()
+
+        yaml_str = c.write_netlist(netlist)
+        c2 = gf.read.from_yaml(yaml_str)
+        assert {p.name: str(p.port_type) for p in c2.ports} == {
+            "o1": "optical",
+            "o2": "optical",
+        }
+        instances = c2.get_netlist()["instances"]
+        settings = instances[next(iter(instances))]["settings"]
+        assert settings["port_type"] == "optical"
+
+    @staticmethod
+    def test_valid_snspd_builds() -> None:
+        """Test that a representative valid snspd builds connected geometry."""
+        c = snspd(size=(10, 8), wire_pitch=0.6)
+        assert c is not None
+        assert c.info["xsize"] > 0
+        # The original defect class was a silently unconnected pad: the wire
+        # on the NbTiN layer must merge into a single connected region.
+        layer_index = gf.get_layer(LAYER.NbTiN)
+        region = gf.kdb.Region(c.begin_shapes_rec(layer_index)).merged()
+        assert len(region) == 1
+
+    @staticmethod
+    def test_num_squares_overrides_size() -> None:
+        """Test that num_squares builds a square SNSPD sized from the squares."""
+        c = snspd(num_squares=1000)
+        assert c is not None
+        assert c.info["xsize"] == c.info["ysize"]
+        # The meander count is quantized to whole wire pitches, so the achieved
+        # square count is close to but not exactly the requested one.
+        assert abs(c.info["num_squares"] - 1000) / 1000 < 0.05
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        ("ysize", "terminals_same_side", "num_squares_expected"),
+        [(1.3, False, 150.0), (2.0, True, 200.0)],
+    )
+    def test_minimal_meanders_connected(
+        ysize: float, terminals_same_side: bool, num_squares_expected: float
+    ) -> None:
+        """Test that the smallest accepted sizes build one connected wire region.
+
+        These sit on the boundary the validation moved: 3 meanders
+        (`num_meanders == 3`) and 4 with same-side terminals, the shapes
+        closest to the old silently-unconnected output.
+        """
+        c = snspd(
+            size=(10, ysize), wire_pitch=0.6, terminals_same_side=terminals_same_side
+        )
+        assert c.info["num_squares"] == num_squares_expected
+        layer_index = gf.get_layer(LAYER.NbTiN)
+        region = gf.kdb.Region(c.begin_shapes_rec(layer_index)).merged()
+        assert len(region) == 1
+
+    @staticmethod
+    def test_nonpositive_num_squares_raises() -> None:
+        """Test that num_squares <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match="num_squares"):
+            snspd(num_squares=0)
+
+    @staticmethod
+    def test_nonpositive_size_raises() -> None:
+        """Test that nonpositive size dimensions raise ValueError."""
+        with pytest.raises(ValueError, match="size"):
+            snspd(size=(0, 8))
+
+    @staticmethod
+    def test_wire_pitch_le_wire_width_raises() -> None:
+        """Test that wire_pitch <= wire_width raises ValueError."""
+        with pytest.raises(ValueError, match="wire_pitch"):
+            snspd(wire_width=0.6, wire_pitch=0.2)
+
+    @staticmethod
+    def test_too_small_size_raises() -> None:
+        """Test that a size fitting fewer than 3 meanders raises ValueError."""
+        with pytest.raises(ValueError, match="num_meanders"):
+            snspd(size=(10, 0.5), wire_pitch=0.6)
+
+    @staticmethod
+    def test_too_small_size_same_side_raises() -> None:
+        """Test that same-side terminals with fewer than 3 meanders raise."""
+        with pytest.raises(ValueError, match="num_meanders"):
+            snspd(size=(10, 1), wire_pitch=0.6, terminals_same_side=True)


### PR DESCRIPTION
snspd documented a port_type argument but then unconditionally overwrote it with "electrical", so requesting optical ports still produced electrical ones. The exposed ports now honor the argument (o1/o2 names for optical) and survive a component -> netlist -> component round trip. The num_squares branch also left dead code behind — it zeroed num_squares, so the following `if num_squares is not None` block could never fire — and num_meanders < 3 now raises a ValueError instead of silently building a degenerate nanowire. Tests for all three behaviors are in tests/test_cells_edge_cases.py.

## Summary by Sourcery

Make SNSPD ports respect their configured type and validate inputs to prevent degenerate components.

Bug Fixes:
- Honor the requested SNSPD port type, including optical port names and metadata through netlist round trips.
- Reject invalid SNSPD dimensions, wire spacing, square counts, and degenerate meander configurations instead of producing invalid geometry.

Enhancements:
- Remove obsolete square-count sizing logic and clarify the behavior of square-count-based sizing.

Tests:
- Add edge-case coverage for SNSPD port handling, netlist round trips, sizing behavior, geometry connectivity, and parameter validation.