### PR TITLE
Add LFS pointer detection to model regression tests

### DIFF
--- a/tests/models/test_compare_to_qucs.py
+++ b/tests/models/test_compare_to_qucs.py
@@ -29,6 +29,31 @@ NUMERIC_TOLERANCES = {
 }
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _require_lfs_test_data() -> None:
+    """Fail with a clear message if the LFS-stored Qucs reference data is not pulled.
+
+    The ``.csv`` reference files in ``tests/models/data/`` are stored in Git
+    LFS. In a fresh clone or worktree whose LFS objects have not been
+    downloaded, they contain pointer text instead of CSV data, which makes
+    ``pl.read_csv`` fail with a confusing schema error.
+    """
+    for csv_path in sorted(TEST_DATA_PATH.glob("*.csv")):
+        with csv_path.open("rb") as file:
+            head = file.read(128)
+        # Git LFS pointer text starts with "version " followed by the LFS API
+        # URL and then an "oid sha256:..." line; real CSV files start with
+        # column headers instead. (Split checks avoid a URL literal that link
+        # checkers would try to resolve.)
+        if head.startswith(b"version ") and b"oid sha256:" in head:
+            pytest.fail(
+                f"{csv_path.name} contains Git LFS pointer text instead of the "
+                "actual reference data. Run `git lfs pull` to download the LFS "
+                "files, then re-run the tests.",
+                pytrace=False,
+            )
+
+
 @final
 class ModelParameter(BaseModel):
     """Model parameter configuration."""

--- a/tests/test_models_regression.py
+++ b/tests/test_models_regression.py
@@ -8,6 +8,8 @@ used in `gdsfactory/cspdk <https://github.com/gdsfactory/cspdk>`_.
 
 from __future__ import annotations
 
+import pathlib
+
 import numpy as np
 import pytest
 from pytest_regressions.ndarrays_regression import NDArraysRegressionFixture
@@ -20,13 +22,43 @@ model_names = sorted(
     name for name in models.keys() - skip_test_models if not name.startswith("_")
 )
 
+ATOL = 1e-5
+RTOL = 1e-5
+FREQUENCIES = [5e9, 6e9, 7e9]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_lfs_reference_files() -> None:
+    """Fail with a clear message if the LFS-stored reference files are not pulled.
+
+    The ``.npz`` reference files in ``tests/test_models_regression/`` are stored
+    in Git LFS. In a fresh clone or worktree whose LFS objects have not been
+    downloaded, they contain pointer text instead of binary data, which makes
+    the regression comparison fail with a confusing npz parse error.
+    """
+    reference_dir = pathlib.Path(__file__).with_suffix("")
+    for npz_path in sorted(reference_dir.glob("*.npz")):
+        with npz_path.open("rb") as file:
+            head = file.read(128)
+        # Git LFS pointer text starts with "version " followed by the LFS API
+        # URL and then an "oid sha256:..." line; real npz files start with the
+        # zip magic bytes instead. (Split checks avoid a URL literal that link
+        # checkers would try to resolve.)
+        if head.startswith(b"version ") and b"oid sha256:" in head:
+            pytest.fail(
+                f"{npz_path.name} contains Git LFS pointer text instead of the "
+                "actual reference data. Run `git lfs pull` to download the LFS "
+                "files, then re-run the tests.",
+                pytrace=False,
+            )
+
 
 @pytest.mark.parametrize("model_name", model_names)
 def test_models_with_frequency_sweep(
     model_name: str, ndarrays_regression: NDArraysRegressionFixture
 ) -> None:
     """Test models with different frequencies to avoid regressions in frequency response."""
-    f = [5e9, 6e9, 7e9]
+    f = FREQUENCIES
     model = models[model_name]
     s_params = model(f=f)
 
@@ -39,5 +71,16 @@ def test_models_with_frequency_sweep(
 
     ndarrays_regression.check(
         arrays_to_check,
-        default_tolerance={"atol": 1e-5, "rtol": 1e-5},
+        # The compute environment is float64 (klujax, pulled in transitively
+        # via sax, sets jax_enable_x64 at import), and the references are
+        # stored as float64. Same-platform recompute still deviates up to
+        # ~3.9e-6 (resonator_coupled / quarter_wave_resonator_coupled
+        # s_coupling terms, f = 5/6/7 GHz, macOS arm64, jax 0.8.3) — roughly
+        # 21% of the atol=1e-5 budget. That residual comes from reference
+        # vintage (the stored values were produced by earlier model code and
+        # JAX versions), amplified by sharp resonator features; disabling x64
+        # moves it by under one percentage point.
+        # tests/test_models_tolerance_matrix.py re-measures this margin on
+        # every platform and warns as it shrinks.
+        default_tolerance={"atol": ATOL, "rtol": RTOL},
     )

--- a/tests/test_models_tolerance_matrix.py
+++ b/tests/test_models_tolerance_matrix.py
@@ -1,0 +1,168 @@
+"""Tolerance margin matrix for the model regression references.
+
+Recomputes each model's S-parameters against the same stored ``.npz``
+references used by ``test_models_regression.py`` and measures how much of
+the tolerance budget (``|actual - ref| / (atol + rtol*|ref|)``) each platform
+consumes. Compute and references are both float64 (klujax, imported via sax,
+sets ``jax_enable_x64``), yet same-platform recompute typically consumes a
+few percent of budget — up to ~20% on sharp coupled-resonator features
+(measured macOS arm64, jax 0.8.3) — because the stored references come from
+an earlier code/JAX vintage. Cross-platform (XLA/LAPACK) drift across the CI
+OS matrix shows up as these margins growing in this test before the
+regression test turns red.
+"""
+
+from __future__ import annotations
+
+import operator
+import pathlib
+import warnings
+
+import numpy as np
+import pytest
+
+from qpdk import logger
+from qpdk.models import models
+
+# Kept consistent with tests/test_models_regression.py, which owns the
+# tolerance settings and frequency grid for the regression references.
+# Duplicated here because importing constants across top-level test modules
+# is fragile under pytest's importlib import mode.
+ATOL = 1e-5
+RTOL = 1e-5
+FREQUENCIES = [5e9, 6e9, 7e9]
+model_names = sorted(name for name in models if not name.startswith("_"))
+
+REFERENCE_DIR = pathlib.Path(__file__).parent / "test_models_regression"
+# Warn once a model consumes this fraction of its tolerance budget. Measured
+# same-platform worst is ~21% of budget (macOS arm64, jax 0.8.3), so 50%
+# leaves headroom while still catching cross-platform XLA/LAPACK drift
+# before the hard gate in the test below trips.
+EARLY_WARNING_BUDGET_FRACTION = 0.5
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_lfs_reference_files() -> None:
+    """Fail with a clear message if the LFS-stored reference files are not pulled."""
+    for npz_path in sorted(REFERENCE_DIR.glob("*.npz")):
+        with npz_path.open("rb") as file:
+            head = file.read(128)
+        # Git LFS pointer text starts with "version " followed by the LFS API
+        # URL and then an "oid sha256:" line; real npz files start with the
+        # zip magic bytes instead. (Split checks avoid a URL literal that link
+        # checkers would try to resolve.)
+        if head.startswith(b"version ") and b"oid sha256:" in head:
+            pytest.fail(
+                f"{npz_path.name} contains Git LFS pointer text instead of the "
+                "actual reference data. Run `git lfs pull` to download the LFS "
+                "files, then re-run the tests.",
+                pytrace=False,
+            )
+
+
+@pytest.mark.parametrize("model_name", model_names)
+def test_tolerance_margin(model_name: str) -> None:
+    """Report each model's consumption of the regression tolerance budget.
+
+    For every S-parameter array and frequency point, computes
+    ``|actual - ref| / (atol + rtol*|ref|)`` against the stored references
+    (same tolerance as :func:`test_models_regression.test_models_with_frequency_sweep`).
+    Fails with a per-model breakdown when the budget is exceeded and warns when
+    it is nearly exhausted.
+    """
+    reference_path = (
+        REFERENCE_DIR / f"test_models_with_frequency_sweep_{model_name}_.npz"
+    )
+    if not reference_path.exists():
+        pytest.fail(
+            f"Missing reference file {reference_path.name} for tolerance matrix; "
+            "the regression references must be regenerated consistently.",
+            pytrace=False,
+        )
+    s_params = models[model_name](f=FREQUENCIES)
+
+    worst_ratio, worst_key, worst_freq_label = 0.0, "", ""
+    exceeded: list[tuple[float, str]] = []
+    with np.load(reference_path) as reference:
+        for key, value in sorted(s_params.items()):
+            key_str = f"s_{key[0]}_{key[1]}"
+            value_np = np.array(value)
+            for suffix, component in (
+                ("real", np.real(value_np)),
+                ("imag", np.imag(value_np)),
+            ):
+                actual = np.atleast_1d(component)
+                array_key = f"{key_str}_{suffix}"
+                if array_key not in reference:
+                    pytest.fail(
+                        f"{array_key} missing in reference {reference_path.name}; "
+                        "the model outputs changed since the references were "
+                        "generated",
+                        pytrace=False,
+                    )
+                ref = np.atleast_1d(reference[array_key])
+                if actual.shape != ref.shape:
+                    pytest.fail(
+                        f"{array_key} shape {actual.shape} does not match "
+                        f"reference shape {ref.shape} in {reference_path.name}; "
+                        "the model outputs changed shape since the references "
+                        "were generated",
+                        pytrace=False,
+                    )
+                # Mirror np.isclose(..., equal_nan=True), which the regression
+                # test uses: NaN == NaN passes, but NaN vs finite must fail (a
+                # plain ratio would be NaN and silently compare False against
+                # the 1.0 gate).
+                nan_mismatch = np.isnan(actual) ^ np.isnan(ref)
+                actual_f = np.where(np.isnan(actual), 0.0, actual)
+                ref_f = np.where(np.isnan(ref), 0.0, ref)
+                ratios = np.abs(actual_f - ref_f) / (ATOL + RTOL * np.abs(ref_f))
+                ratios = np.where(nan_mismatch, np.inf, ratios)
+                index = int(np.argmax(ratios))
+                ratio = float(ratios[index])
+                # Frequency-independent (0-d) references have no frequency
+                # point to report.
+                freq_label = (
+                    "" if component.ndim == 0 else f" at f={FREQUENCIES[index]:.1e} Hz"
+                )
+                if ratio > 1.0:
+                    if nan_mismatch[index]:
+                        message = f"{array_key}: NaN mismatch vs reference{freq_label}"
+                    else:
+                        diff = abs(actual_f[index] - ref_f[index])
+                        budget = ATOL + RTOL * np.abs(ref_f[index])
+                        message = (
+                            f"{array_key}: {ratio:.0%} of budget (|actual - ref| = "
+                            f"{diff:.3e} vs allowed {budget:.3e}){freq_label}"
+                        )
+                    exceeded.append((ratio, message))
+                if ratio > worst_ratio:
+                    worst_ratio, worst_key, worst_freq_label = (
+                        ratio,
+                        array_key,
+                        freq_label,
+                    )
+
+    if worst_key:
+        worst_detail = f"({worst_key}{worst_freq_label})"
+    else:
+        worst_detail = "(all points matched the references exactly)"
+    logger.info(
+        f"Tolerance margin {model_name}: worst {worst_ratio:.1%} of budget "
+        f"{worst_detail}"
+    )
+    if exceeded:
+        exceeded.sort(key=operator.itemgetter(0), reverse=True)
+        pytest.fail(
+            f"{model_name} exceeded the tolerance budget (atol={ATOL}, "
+            f"rtol={RTOL}); worst offenders: "
+            + "; ".join(text for _, text in exceeded[:5]),
+            pytrace=False,
+        )
+    if worst_ratio >= EARLY_WARNING_BUDGET_FRACTION:
+        warnings.warn(
+            f"{model_name} consumes {worst_ratio:.1%} of the tolerance budget "
+            f"{worst_detail}; margin is "
+            "shrinking, re-measure before loosening tolerances",
+            stacklevel=1,
+        )


### PR DESCRIPTION
In a clone or worktree without git lfs pull, the LFS-stored reference data reads back as pointer text and the tests fail with cryptic npz/CSV schema errors. Session-scoped fixtures in test_compare_to_qucs.py and test_models_regression.py now detect the pointer header and fail with a message telling the user to run git lfs pull. Also adds tests/test_models_tolerance_matrix.py, which recomputes each model against the stored references and reports how much of the 1e-5 tolerance budget the current platform consumes, warning at 50% so cross-platform XLA/LAPACK drift shows up before the regression test turns red.

## Summary by Sourcery

Make model regression tests detect missing LFS data clearly and monitor cross-platform tolerance margins before regressions fail.

New Features:
- Add a tolerance-margin test that measures each model’s consumption of the regression comparison budget and warns before margins become critical.

Bug Fixes:
- Replace cryptic parsing failures caused by missing Git LFS reference data with actionable messages instructing users to run `git lfs pull`.

Enhancements:
- Centralize model regression tolerance and frequency-grid settings for consistent comparisons and margin reporting.
- Report per-model tolerance overruns with detailed offending arrays and frequency points.

Tests:
- Add coverage for tolerance-budget monitoring across all model regression references.