### PR TITLE
Make PDF docs build failures fail CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,26 +54,37 @@ jobs:
       - name: Wait for Python dependency installation
         wait: install-deps
       - name: Generate LaTeX files
-        run: just docs-latex || echo "LaTeX build completed with warnings, continuing…"
+        run: just docs-latex
       - name: Compile LaTeX document
-        continue-on-error: true
         uses: xu-cheng/latex-action@6549dc21effb2730855a1281407ecfcececc6c1b # 4.1.0
-        env:
-          XINDYOPTS: "-L english -C utf8 -M sphinx.xdy"
         with:
-          texlive_version: latest
+          texlive_version: "2025" # pin the TeX Live Docker image (latest is floating)
           os: alpine
-          pre_compile: cd docs/_build/latex
-          extra_system_packages: "ghostscript"
+          # XINDYOPTS must be exported here: the action's docker run does not pass step
+          # env into the container, but pre_compile runs in the same shell as the compile
+          # (entrypoint.sh eval's it), so the index pass sees the same flags as
+          # `just docs-pdf` does locally.
+          pre_compile: cd docs/_build/latex && export XINDYOPTS="-L english -C utf8 -M sphinx.xdy"
           root_file: qpdk.tex
           compiler: latexmk
-          continue_on_error: true
           latexmk_use_xelatex: true
-          args: -pdfxe -xelatex -interaction=nonstopmode -f -file-line-error
+          args: -interaction=nonstopmode -file-line-error -halt-on-error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pdf-docs
           path: "./docs/_build/latex/qpdk.pdf"
+          if-no-files-found: error
+      - name: Upload LaTeX build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: latex-logs
+          path: |
+            docs/_build/latex/*.log
+            docs/_build/latex/*.ilg
+            docs/_build/latex/*.blg
+            docs/_build/latex/*.fls
+          if-no-files-found: ignore
   pages:
     permissions:
       actions: read

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,6 +244,33 @@ suppress_warnings = [
 ]
 
 
+def _repair_external_math(content):
+    r"""Repair malformed LaTeX found in external docstring math (e.g. sax).
+
+    - A doubled backslash before a command name (``\ln\\frac``): in math,
+      ``\\`` is a row break and is always followed by whitespace or end of
+      line, so ``\\<command>`` is always a typo.  It breaks the LaTeX build
+      with ``Extra }, or forgotten \right.``.
+    - A bare ``_`` inside ``\text{...}`` (``I_\text{n_ports}``): ``\text``
+      typesets its argument in text mode, where an unescaped ``_`` fails the
+      LaTeX build with ``Missing $ inserted``.
+    - Consecutive bare subscripts on one token (``C_M_S``): invalid LaTeX
+      ("Double subscript") unless grouped, so group them mechanically.
+
+    Returns:
+        The repaired math content.
+    """
+    content = re.sub(
+        r"([A-Za-z0-9]+)_([A-Za-z0-9]+)_([A-Za-z0-9]+)", r"\1_{\2_\3}", content
+    )
+    content = re.sub(r"\\\\([a-zA-Z]+)", r"\\\1", content)
+    return re.sub(
+        r"\\text\{([^{}]*)\}",
+        lambda match: "\\text{" + match.group(1).replace("_", r"\_") + "}",
+        content,
+    )
+
+
 def _dollar_math_to_rst(lines):
     r"""Convert ``$…$`` and ``$$…$$`` math to RST ``:math:`` and ``.. math::`` directives.
 
@@ -262,7 +289,7 @@ def _dollar_math_to_rst(lines):
             i += 1
             # Collect lines until closing ``$$``
             while i < len(lines) and lines[i].strip() != "$$":
-                math_line = lines[i]
+                math_line = _repair_external_math(lines[i])
                 # Ensure math content is indented under the directive
                 if math_line.strip():
                     result.append(f"{indent}   {math_line.strip()}")
@@ -276,7 +303,7 @@ def _dollar_math_to_rst(lines):
         # Convert inline $…$ to :math:`…` (but not $$)
         converted = re.sub(
             r"(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)",
-            r":math:`\1`",
+            lambda match: f":math:`{_repair_external_math(match.group(1))}`",
             lines[i],
         )
         result.append(converted)

--- a/docs/docs.just
+++ b/docs/docs.just
@@ -95,11 +95,4 @@ docs-latex: (_sphinx "latex")
 docs-pdf: docs-latex
     #!/usr/bin/env bash
     set -euo pipefail
-    XINDYOPTS="-M sphinx.xdy" latexmk -pdfxe -xelatex -interaction=nonstopmode -f -file-line-error || {
-        if [ -f qpdk.pdf ]; then
-            echo "PDF generated despite warnings"
-            exit 0
-        else
-            exit 1
-        fi
-    }
+    XINDYOPTS="-L english -C utf8 -M sphinx.xdy" latexmk -xelatex -interaction=nonstopmode -file-line-error -halt-on-error qpdk.tex

--- a/qpdk/cells/inductor.py
+++ b/qpdk/cells/inductor.py
@@ -236,7 +236,7 @@ def lumped_element_resonator(
 
        +-----------+
        | Capacitor |
-    o1 --+   (IDC)   +-- o2
+       o1 --+   (IDC)   +-- o2
        |           |
        | Inductor  |
        | (Meander) |


### PR DESCRIPTION
Closes #769

The "Build PDF docs" job could stay green while the entire PDF pipeline failed: the docs-latex step swallowed LaTeX generation errors with an echo fallback, the latex-action step had continue-on-error at both the GitHub step level and the action input, and latexmk ran with -f. A missing or partial PDF could then reach the pdf-docs artifact and deploy-docs would ship a site without the PDF, even though AGENTS.md documents a successful PDF build as a required merge gate.

- Drop the `|| echo ...` fallback and all continue-on-error/`-f` leniency so real LaTeX errors fail the job (nonstopmode -halt-on-error).

- Upload docs/_build/latex as a latex-logs debug artifact with if: failure() (excluding the partial qpdk.pdf) so a red job comes with the log explaining it.

- Add if-no-files-found: error to the pdf-docs upload so an empty or partially-swallowed build can never produce a silently-skipped artifact upload; a missing PDF now fails the job instead.

- Pin texlive_version to 2025: the action maps "latest" to a floating docker image, while a pinned year resolves to a fixed historic image (the action has no scheme/extra-packages input, so pinning the image version is the deterministic-install mechanism).

- Export XINDYOPTS in pre_compile instead of a step env block: the action's docker run does not forward step env into the container (verified in action.sh at the pinned commit), so the old env block never reached the xindy index pass; pre_compile runs in the same shell as the compile, making CI identical to `just docs-pdf`, which sets the same XINDYOPTS locally.

- Align the local docs-pdf recipe with CI: no -f, no success-on-partial-PDF fallback, same XINDYOPTS flags.

## Summary by Sourcery

Enforce reliable PDF documentation builds by failing on compilation errors and surfacing diagnostics for troubleshooting.

Bug Fixes:
- Make LaTeX and PDF documentation build failures fail CI instead of allowing incomplete builds to pass.
- Repair malformed external math markup that previously caused LaTeX compilation errors.

Enhancements:
- Add failure-time LaTeX log artifacts and require the generated PDF artifact to exist.
- Use a pinned TeX Live image and align local PDF builds with the strict CI compilation settings.

CI:
- Enforce strict PDF documentation compilation and preserve diagnostic logs when the build fails.