### PR TITLE
Remove silent gap fallback in CPW coupling capacitance model

### DIFF
--- a/qpdk/models/couplers.py
+++ b/qpdk/models/couplers.py
@@ -3,16 +3,13 @@
 from functools import partial
 from typing import cast
 
-import gdsfactory as gf
 import jax
 import jax.numpy as jnp
 import sax
-from gdsfactory.cross_section import CrossSection
 from gdsfactory.typings import CrossSectionSpec
 from jax.typing import ArrayLike
 from sax.models.rf import capacitor, tee
 
-from qpdk.logger import logger
 from qpdk.models.constants import DEFAULT_FREQUENCY, ε_0
 from qpdk.models.cpw import (
     cpw_ep_r_from_cross_section,
@@ -107,26 +104,16 @@ def cpw_cpw_coupling_capacitance(
 
     Returns:
         The total coupling capacitance in Farads.
+
+    Note:
+        Raises ``ValueError`` via :func:`~qpdk.models.cpw.get_cpw_dimensions`
+        if the cross-section has no section with 'etch' in its name, so the
+        CPW gap cannot be determined, or if the conductor width or etch gap
+        is not positive.
     """
     ep_r = cpw_ep_r_from_cross_section(cross_section)
 
-    try:
-        width, cpw_gap = get_cpw_dimensions(cross_section)
-    except ValueError:
-        # Fallback to default CPW width and gap if not found in sections
-        # Not sure if width needs fallback, but gap previously fell back to 6.0
-        logger.warning(
-            "CPW gap not found in cross-section sections. Using default gap of 6.0 µm."
-        )
-        xs = (
-            gf.get_cross_section(cross_section)
-            if isinstance(cross_section, str)
-            else cross_section
-        )
-        if callable(xs):
-            xs = cast(CrossSection, xs())
-        width = xs.width
-        cpw_gap = 6.0
+    width, cpw_gap = get_cpw_dimensions(cross_section)
 
     c_pul = cpw_cpw_coupling_capacitance_per_length_analytical(
         gap=gap,

--- a/qpdk/models/cpw.py
+++ b/qpdk/models/cpw.py
@@ -118,6 +118,10 @@ def get_cpw_dimensions(
 
     Returns:
         tuple[float, float]: Width and gap of the CPW.
+
+    Raises:
+        ValueError: If the conductor width or etch gap is not positive, or if
+            no etch section is found.
     """
     # Make sure a PDK is activated
     from qpdk import PDK  # ruff: ignore[import-outside-top-level]
@@ -126,8 +130,21 @@ def get_cpw_dimensions(
     xs = gf.get_cross_section(cross_section, **kwargs)
 
     width = xs.width
+    if not width > 0:
+        msg = (
+            f"Cross-section '{xs.name}' has non-positive conductor width {width}. "
+            "CPW conductor width must be positive."
+        )
+        raise ValueError(msg)
     etch_section = get_etch_section(xs)
-    return width, etch_section.width
+    etch_gap = etch_section.width
+    if not etch_gap > 0:
+        msg = (
+            f"Cross-section '{xs.name}' has non-positive etch gap {etch_gap}. "
+            "CPW etch gap must be positive."
+        )
+        raise ValueError(msg)
+    return width, etch_gap
 
 
 @cache

--- a/tests/models/test_couplers.py
+++ b/tests/models/test_couplers.py
@@ -2,8 +2,10 @@
 
 from typing import final
 
+import gdsfactory as gf
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from qpdk.models.couplers import (
     coupler_ring,
@@ -72,3 +74,10 @@ class TestCPWCouplingCapacitance:
         c1 = cpw_cpw_coupling_capacitance(f, length=100.0, gap=5.0, cross_section="cpw")
         c2 = cpw_cpw_coupling_capacitance(f, length=200.0, gap=5.0, cross_section="cpw")
         np.testing.assert_allclose(float(c2), 2.0 * float(c1), rtol=1e-6)
+
+    @staticmethod
+    def test_missing_etch_section_raises() -> None:
+        """Test that a cross-section without an etch section raises ValueError."""
+        xs = gf.cross_section.cross_section(width=10.0)
+        with pytest.raises(ValueError, match="etch"):
+            cpw_cpw_coupling_capacitance(5e9, length=100.0, gap=5.0, cross_section=xs)

--- a/tests/models/test_cpw.py
+++ b/tests/models/test_cpw.py
@@ -299,3 +299,35 @@ class TestGetCpwDimensions:
         xs = gf.cross_section.cross_section(width=10.0)
         with pytest.raises(ValueError, match="etch"):
             get_cpw_dimensions(xs)
+
+    @staticmethod
+    def test_zero_width_raises() -> None:
+        """Test that a cross-section with zero conductor width raises ValueError."""
+        # Direct width=0 is rejected by gdsfactory's Section validator, but a
+        # width_function returning 0 is constructible and yields width 0.
+        # The lambda takes the normalized position argument so the cross-section
+        # remains usable (extrudable).
+        xs = gf.CrossSection(
+            sections=(
+                gf.Section(
+                    width_function=lambda *_: 0.0, layer=(1, 0), name="conductor"
+                ),
+                gf.Section(width=6.0, layer=(1, 0), name="etch_m1"),
+            )
+        )
+        with pytest.raises(ValueError, match="conductor width"):
+            get_cpw_dimensions(xs)
+
+    @staticmethod
+    def test_zero_gap_raises() -> None:
+        """Test that a cross-section with zero etch gap raises ValueError."""
+        # A zero-width etch section yields cpw_gap = 0, which would produce
+        # NaN coupling capacitances downstream, so it is rejected.
+        xs = gf.CrossSection(
+            sections=(
+                gf.Section(width=10.0, layer=(1, 0), name="conductor"),
+                gf.Section(width_function=lambda *_: 0.0, layer=(1, 0), name="etch_m1"),
+            )
+        )
+        with pytest.raises(ValueError, match="etch gap"):
+            get_cpw_dimensions(xs)


### PR DESCRIPTION
The unreachable `width is None` guard from an earlier revision was intentionally dropped. The reachable degenerate cases are instead validated with `ValueError` in `get_cpw_dimensions`:

- non-positive conductor width (constructible via a `width_function`; gdsfactory rejects direct `Section(width=0)` with "Section requires `width > 0` or a `width_function`")
- non-positive etch gap (a zero gap previously flowed into `cpw_cpw_coupling_capacitance_per_length_analytical` and produced NaN, and zeroed the Q2D ground plane width in `qpdk/simulation/q3d.py`)

Behavior change is limited to direct calls of `cpw_cpw_coupling_capacitance` (e.g. the `all_models` notebook): previously a `logger.warning` plus a fabricated 6.0 µm gap, now a hard `ValueError`. The in-repo integration points (`coupler_straight`, resonator capacitor settings) already raised `ValueError` from `cpw_z0_from_cross_section` in the next expression, so their observable behavior is unchanged.

## Summary by Sourcery

Enforce valid CPW dimensions and fail explicitly instead of fabricating a fallback coupling gap.

Bug Fixes:
- Reject invalid CPW conductor widths and etch gaps instead of allowing downstream NaN or invalid simulation dimensions.

Enhancements:
- Replace silent CPW coupling-capacitance gap fallback behavior with explicit ValueError validation when CPW dimensions cannot be determined.

Documentation:
- Document the validation errors raised for missing or non-positive CPW dimensions.

Tests:
- Add coverage for missing etch sections and zero conductor-width or etch-gap cross-sections.