### PR TITLE
Q3D assigns pec to all renamed objects incl. substrate

### DIFF
--- a/qpdk/simulation/__init__.py
+++ b/qpdk/simulation/__init__.py
@@ -44,6 +44,7 @@ from qpdk.simulation.aedt_base import (
     AEDTBase,
     add_materials_to_aedt,
     layer_stack_to_gds_mapping,
+    object_names_to_materials,
     prepare_component_for_aedt,
 )
 from qpdk.simulation.hfss import HFSS, lumped_port_rectangle_from_cpw
@@ -57,5 +58,6 @@ __all__ = [
     "add_materials_to_aedt",
     "layer_stack_to_gds_mapping",
     "lumped_port_rectangle_from_cpw",
+    "object_names_to_materials",
     "prepare_component_for_aedt",
 ]

--- a/qpdk/simulation/aedt_base.py
+++ b/qpdk/simulation/aedt_base.py
@@ -189,6 +189,68 @@ def rename_imported_objects(
     return renamed_objects
 
 
+def object_names_to_materials(
+    object_names: list[str],
+    layer_stack: LayerStack,
+) -> dict[str, str]:
+    """Map imported object names to AEDT material names based on the layer stack.
+
+    Resolves each object to its :class:`LayerLevel` either by parsing the
+    ``signal<layer_number>`` GDS import names (same convention as
+    :func:`rename_imported_objects`) or by matching the (renamed) object name
+    against layer stack names. Metal levels (materials with infinite
+    relative permittivity in ``material_properties``) map to ``"pec"``;
+    dielectric levels map to their layer stack material name.
+
+    Returns:
+        Dictionary mapping object names to AEDT material names.
+
+    Raises:
+        ValueError: If an object cannot be resolved to a layer stack level,
+            or its level material is not registered in ``material_properties``.
+            Failing closed avoids silently leaving objects with the project
+            default material, which would make extracted results wrong
+            rather than failed.
+    """
+    num_to_name: dict[int, str] = {}
+    for name, level in layer_stack.layers.items():
+        layer_num = _get_layer_number_from_level(level)
+        if layer_num is not None and layer_num not in num_to_name:
+            num_to_name[layer_num] = name
+
+    def find_level(obj_name: str) -> LayerLevel | None:
+        match = re.match(r"^signal(\d+)(_.*)?$", obj_name)
+        if match and int(match.group(1)) in num_to_name:
+            return layer_stack.layers[num_to_name[int(match.group(1))]]
+        # Exact name first, then prefix match (longest names first so that
+        # e.g. "Airbridge_Via_1" is not matched by "Airbridge")
+        for name in sorted(layer_stack.layers, key=len, reverse=True):
+            if obj_name == name or obj_name.startswith(f"{name}_"):
+                return layer_stack.layers[name]
+        return None
+
+    assignments: dict[str, str] = {}
+    for obj_name in object_names:
+        level = find_level(obj_name)
+        material = level.material if level is not None else None
+        if material is None:
+            raise ValueError(
+                f"Could not resolve AEDT object {obj_name!r} to a layer stack "
+                "level with a material; refusing to leave it with the default "
+                "material."
+            )
+        props = material_properties.get(material)
+        if props is None:
+            raise ValueError(
+                f"Material {material!r} of AEDT object {obj_name!r} is not "
+                "registered in material_properties; refusing to leave it with "
+                "the default material."
+            )
+        is_conductor = props.get("relative_permittivity") == float("inf")
+        assignments[obj_name] = "pec" if is_conductor else material
+    return assignments
+
+
 def add_materials_to_aedt(app: Hfss | Q2d | Q3d) -> None:
     """Add QPDK materials to the PyAEDT application."""
     for name, props in material_properties.items():

--- a/qpdk/simulation/hfss.py
+++ b/qpdk/simulation/hfss.py
@@ -13,6 +13,7 @@ from qpdk.simulation.aedt_base import (
     AEDTBase,
     export_component_to_gds_temp,
     layer_stack_to_gds_mapping,
+    object_names_to_materials,
     rename_imported_objects,
 )
 
@@ -133,17 +134,26 @@ class HFSS(AEDTBase):
             if result:
                 new_objects = list(set(self.modeler.object_names) - existing_objects)
 
-                renamed_objects = rename_imported_objects(
-                    self.hfss, new_objects, layer_stack or LAYER_STACK
-                )
+                stack = layer_stack or LAYER_STACK
+                renamed_objects = rename_imported_objects(self.hfss, new_objects, stack)
 
-                if renamed_objects:
+                # PerfectE is a conductor boundary: assign it only to metal
+                # levels, not to dielectric objects such as the substrate.
+                conductor_objects = [
+                    obj_name
+                    for obj_name, material in object_names_to_materials(
+                        renamed_objects, stack
+                    ).items()
+                    if material == "pec"
+                ]
+
+                if conductor_objects:
                     if import_as_sheets:
                         self.hfss.assign_perfecte_to_sheets(
-                            renamed_objects, name="PEC_Sheets"
+                            conductor_objects, name="PEC_Sheets"
                         )
                     else:
-                        self.hfss.assign_perfect_e(renamed_objects, name="PEC_3D")
+                        self.hfss.assign_perfect_e(conductor_objects, name="PEC_3D")
 
         return result
 

--- a/qpdk/simulation/q3d.py
+++ b/qpdk/simulation/q3d.py
@@ -15,6 +15,7 @@ from qpdk.simulation.aedt_base import (
     AEDTBase,
     export_component_to_gds_temp,
     layer_stack_to_gds_mapping,
+    object_names_to_materials,
     rename_imported_objects,
 )
 
@@ -88,14 +89,26 @@ class Q3D(AEDTBase):
 
             new_objects = list(set(self.modeler.object_names) - existing_objects)
 
-            renamed_objects = rename_imported_objects(
-                self.q3d, new_objects, layer_stack or LAYER_STACK
-            )
+            stack = layer_stack or LAYER_STACK
+            renamed_objects = rename_imported_objects(self.q3d, new_objects, stack)
 
-            if renamed_objects:
-                self.q3d.assign_material(renamed_objects, "pec")
+            # Assign materials from the layer stack: metals become "pec",
+            # substrate/etch objects get their real dielectric materials.
+            # Batched per material to keep AEDT round trips minimal.
+            self.add_materials()
+            objects_to_materials = object_names_to_materials(renamed_objects, stack)
+            by_material: dict[str, list[str]] = {}
+            for obj_name, material in objects_to_materials.items():
+                by_material.setdefault(material, []).append(obj_name)
+            for material, objects in by_material.items():
+                self.q3d.assign_material(objects, material)
 
-            return renamed_objects
+            # Only conductors are meaningful downstream (e.g. net assignment).
+            return [
+                obj_name
+                for obj_name, material in objects_to_materials.items()
+                if material == "pec"
+            ]
 
     def assign_nets_from_ports(
         self,

--- a/qpdk/tech.py
+++ b/qpdk/tech.py
@@ -90,6 +90,7 @@ L = LAYER = LayerMapQPDK
 material_properties = {
     "vacuum": {"relative_permittivity": 1},
     "Nb": {"relative_permittivity": float("inf")},
+    "NbTiN": {"relative_permittivity": float("inf")},
     # Loss tangent from `checchinMeasurementLowTemperatureLoss2022`
     "Si": {"relative_permittivity": 11.45, "loss_tangent": 2.7e-6},
     "AlOx/Al": {"relative_permittivity": float("inf")},

--- a/tests/test_hfss.py
+++ b/tests/test_hfss.py
@@ -2,13 +2,16 @@
 
 import os
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
+import gdsfactory as gf
 import pytest
 from gdsfactory.component import Component
+from gdsfactory.technology import LayerLevel, LayerStack
 from numpy.testing import assert_allclose
 
-from qpdk import LAYER_STACK, PDK
+from qpdk import LAYER, LAYER_STACK, PDK
 from qpdk.cells.capacitor import interdigital_capacitor
 from qpdk.cells.resonator import resonator
 from qpdk.simulation import (
@@ -17,6 +20,7 @@ from qpdk.simulation import (
     Q3D,
     layer_stack_to_gds_mapping,
     lumped_port_rectangle_from_cpw,
+    object_names_to_materials,
     prepare_component_for_aedt,
 )
 from qpdk.simulation.aedt_base import _get_layer_number_from_level
@@ -98,6 +102,133 @@ def test_get_layer_number_from_level():
         derived_layer = MockLogicalLayer()
 
     assert _get_layer_number_from_level(MockDerivedLevel()) == 2
+
+
+@dataclass
+class MockAEDTObject:
+    """Minimal stand-in for a PyAEDT modeler object."""
+
+    name: str
+
+
+class MockModeler:
+    """Minimal stand-in for a PyAEDT modeler."""
+
+    def __init__(self, object_names: list[str]):
+        """Initialize with the names of objects created by the GDS import."""
+        self.object_names = list(object_names)
+        self._objects = {name: MockAEDTObject(name) for name in object_names}
+
+    def __getitem__(self, name: str) -> MockAEDTObject:
+        """Return the modeler object with the given name."""
+        return self._objects[name]
+
+
+@dataclass
+class MockMaterial:
+    """Minimal stand-in for a PyAEDT material."""
+
+    permittivity: float | None = None
+    conductivity: float | None = None
+
+
+class MockMaterials:
+    """Minimal stand-in for a PyAEDT materials manager."""
+
+    def __init__(self) -> None:
+        """Initialize an empty materials database."""
+        self.material_names: list[str] = []
+
+    def exists_material(self, name: str) -> bool:
+        """Return whether the material exists in the project."""
+        return name in self.material_names
+
+    def add_material(self, name: str) -> MockMaterial:
+        """Add a material to the project."""
+        self.material_names.append(name)
+        return MockMaterial()
+
+
+class MockQ3dApp:
+    """Minimal stand-in for a PyAEDT Q3d application."""
+
+    def __init__(self, object_names: list[str]):
+        """Initialize with the names of objects created by the GDS import."""
+        self.imported_object_names = list(object_names)
+        self.modeler = MockModeler([])
+        self.materials = MockMaterials()
+        self.assigned_materials: dict[str, str] = {}
+
+    def import_gds_3d(self, **kwargs: object) -> bool:
+        """Simulate a successful 3D GDS import creating the objects."""
+        self.import_kwargs = kwargs
+        self.modeler.object_names.extend(self.imported_object_names)
+        for name in self.imported_object_names:
+            self.modeler._objects[name] = MockAEDTObject(name)
+        return True
+
+    def assign_material(self, assignment: list, material: str) -> None:
+        for obj in assignment:
+            self.assigned_materials[str(obj)] = material
+
+
+def test_object_names_to_materials():
+    """Test mapping imported object names to materials from the layer stack."""
+    # Layer 1 -> M1 (Nb, a metal -> pec); layer 98 -> Substrate (Si); layer 31 -> TSV (TiN)
+    result = object_names_to_materials(
+        ["signal1", "signal25", "signal98", "signal31", "Substrate", "M1_offset"],
+        LAYER_STACK,
+    )
+
+    # Metals are PEC
+    assert result["signal1"] == "pec"
+    assert result["signal25"] == "pec"  # NbTiN
+    assert result["signal31"] == "pec"
+    assert result["M1_offset"] == "pec"
+    # Substrate and other dielectrics get their real material, not pec
+    assert result["signal98"] == "Si"
+    assert result["Substrate"] == "Si"
+    assert result["Substrate"] != "pec"
+
+    # Objects that cannot be resolved to a layer level fail closed
+    with pytest.raises(ValueError, match="Could not resolve"):
+        object_names_to_materials(["signal7", "unknown_object"], LAYER_STACK)
+
+
+def test_object_names_to_materials_unregistered_material():
+    """Levels with materials missing from material_properties fail closed."""
+    stack = LayerStack(
+        layers={
+            "Custom": LayerLevel(
+                name="Custom",
+                layer=(50, 0),
+                thickness=1,
+                zmin=0.0,
+                material="unobtainium",
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="not registered in material_properties"):
+        object_names_to_materials(["signal50"], stack)
+
+
+def test_q3d_import_assigns_materials_from_layer_stack(tmp_path):
+    """Q3D import must not blanket-assign pec: substrate gets its real material."""
+    comp = gf.components.rectangle(size=(10, 10), layer=LAYER.M1_DRAW)
+
+    # Simulate a GDS import that creates the M1 metal and the Substrate objects
+    app = MockQ3dApp(["signal1", "signal98"])
+    sim = Q3D(app)
+
+    renamed = sim.import_component(comp, gds_path=tmp_path / "comp.gds")
+
+    # Only conductor objects are returned for downstream net assignment
+    assert renamed == ["M1"]
+    # Metal level becomes PEC, substrate gets silicon from the layer stack
+    assert app.assigned_materials["M1"] == "pec"
+    assert app.assigned_materials["Substrate"] == "Si"
+    assert app.assigned_materials["Substrate"] != "pec"
 
 
 @pytest.mark.hfss


### PR DESCRIPTION
Q3D.import_component blanket-assigned "pec" to every imported object, turning the substrate and other dielectric levels into perfect conductors and making extracted parasitics meaningless. Materials are now resolved per object from the layer stack: metal levels (infinite relative permittivity in material_properties) become "pec" while substrate/etch objects get their real dielectric material, which is ensured to exist via add_materials. Also registers the NbTiN layer material in material_properties so it is resolvable. Adds the object_names_to_materials helper and mock-based unit tests; substrate objects are asserted to never receive pec.

## Summary by Sourcery

Assign imported simulation objects according to their layer-stack materials instead of blanket-assigning perfect-conductor properties.

New Features:
- Resolve imported AEDT object materials from the layer stack, assigning PEC only to conductor levels and real dielectric materials to substrate and etch objects.

Bug Fixes:
- Prevent Q3D imports from incorrectly assigning PEC to dielectric objects, preserving meaningful parasitic extraction results.

Enhancements:
- Return only conductor objects from Q3D imports for downstream net assignment.
- Register NbTiN as a resolvable conductor material and fail closed when imported objects or materials cannot be resolved.

Tests:
- Add mock-based tests covering layer-stack material resolution, unregistered materials, and Q3D substrate material assignments.