### PR TITLE
Add GDSFactory+ v2 compatibility verification suite

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -26,7 +26,9 @@ exclude = [
   # KLayout homepage rejects some automated checks with 415 in CI
   "https://www.klayout.de/",
   # Generated PDF can be unavailable while GitHub Pages deploys it
-  "https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf"
+  "https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf",
+  # VS Code Marketplace gallery API (POST-only; rejects lychee's GET with 405)
+  "https://marketplace.visualstudio.com/_apis/public/gallery.*"
 ]
 
 # Set a timeout

--- a/.github/workflows/test-gfp-upstream.yml
+++ b/.github/workflows/test-gfp-upstream.yml
@@ -1,0 +1,79 @@
+name: Test GDSFactory+ upstream
+
+permissions:
+  contents: read
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  # Gate: the pytest gfp suite targets the gdsfactoryplus v2 API and fails by
+  # design against v1, so it only runs when the latest PyPI release is v2+
+  # (remove this gate once 2.0.0 ships and it is expected to always run).
+  gate-gfp-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      python-versions: ${{ steps.versions.outputs.python-versions }}
+      gfp-major: ${{ steps.versions.outputs.gfp-major }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - name: Resolve latest PyPI gdsfactoryplus and supported Pythons
+        id: versions
+        run: |
+          # `just get-gfp-versions` prints the filtered JSON array first, then
+          # latest=<version> and major=<major> lines of the PyPI gdsfactoryplus release.
+          OUTPUT="$(just get-gfp-versions '["3.11", "3.12", "3.13"]')"
+          echo "python-versions=$(echo "$OUTPUT" | head -n1)" >> "$GITHUB_OUTPUT"
+          MAJOR="$(echo "$OUTPUT" | sed -n 's/^major=//p')"
+          LATEST="$(echo "$OUTPUT" | sed -n 's/^latest=//p')"
+          # Empty major (unknown version) counts as 0 so the test job is skipped
+          echo "gfp-major=${MAJOR:-0}" >> "$GITHUB_OUTPUT"
+          if [[ "${MAJOR:-0}" -lt 2 ]]; then
+            {
+              echo "### GDSFactory+ upstream test skipped"
+              echo
+              echo "Latest PyPI gdsfactoryplus is \`${LATEST:-unknown}\` (< 2.0.0);"
+              echo "the gfp suite requires the v2 API. This gate can be removed once 2.0.0 is released."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+  test-gfp:
+    runs-on: ${{ matrix.os }}
+    needs: gate-gfp-versions
+    if: ${{ needs.gate-gfp-versions.outputs.gfp-major >= 2 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ${{ fromJson(needs.gate-gfp-versions.outputs.python-versions) }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
+      - name: Test GDSFactory+
+        run: just test-gfp
+        env:
+          GFP_API_KEY: ${{ secrets.GFP_API_KEY }} # zizmor: ignore[secrets-outside-env]
+  test-gfp-result:
+    runs-on: ubuntu-latest
+    name: GDSFactory+ test result
+    needs: test-gfp
+    if: always()
+    steps:
+      - name: Check GDSFactory+ test matrix results
+        run: |
+          RESULT="${{ needs.test-gfp.result }}"
+          if [[ "$RESULT" == "success" ]]; then
+            echo "All GDSFactory+ test jobs succeeded"
+            exit 0
+          elif [[ "$RESULT" == "skipped" ]]; then
+            echo "GDSFactory+ test job skipped: latest PyPI gdsfactoryplus is < 2.0.0"
+            exit 0
+          else
+            echo "One or more GDSFactory+ test jobs failed"
+            exit 1
+          fi

--- a/.github/workflows/test-gfp-upstream.yml
+++ b/.github/workflows/test-gfp-upstream.yml
@@ -63,11 +63,18 @@ jobs:
   test-gfp-result:
     runs-on: ubuntu-latest
     name: GDSFactory+ test result
-    needs: test-gfp
+    needs: [test-gfp, gate-gfp-versions]
     if: always()
     steps:
       - name: Check GDSFactory+ test matrix results
         run: |
+          # A failed gate maps the test job to "skipped"; without this
+          # check a broken gate would show up green as "skipped".
+          GATE="${{ needs.gate-gfp-versions.result }}"
+          if [[ "$GATE" == "failure" ]]; then
+            echo "GDSFactory+ version gate failed; the test job did not run meaningfully"
+            exit 1
+          fi
           RESULT="${{ needs.test-gfp.result }}"
           if [[ "$RESULT" == "success" ]]; then
             echo "All GDSFactory+ test jobs succeeded"

--- a/.github/workflows/test-gfp-upstream.yml
+++ b/.github/workflows/test-gfp-upstream.yml
@@ -8,9 +8,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Gate: the pytest gfp suite targets the gdsfactoryplus v2 API and fails by
-  # design against v1, so it only runs when the latest PyPI release is v2+
-  # (remove this gate once 2.0.0 ships and it is expected to always run).
+  # Gate: the pytest gfp suite targets the gdsfactoryplus v2 SDK, which ships
+  # bundled in the public GDSFactory+ VS Code extension (not on PyPI), so it
+  # only runs when the latest extension release is v2+. The gate also skips
+  # the job gracefully when the Marketplace cannot be reached.
   gate-gfp-versions:
     runs-on: ubuntu-latest
     outputs:
@@ -20,12 +21,13 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      - name: Resolve latest PyPI gdsfactoryplus and supported Pythons
+      - name: Resolve latest GDSFactory+ extension version
         id: versions
         run: |
-          # `just get-gfp-versions` prints the filtered JSON array first, then
-          # latest=<version> and major=<major> lines of the PyPI gdsfactoryplus release.
-          OUTPUT="$(just get-gfp-versions '["3.11", "3.12", "3.13"]')"
+          # `just get-gfp-versions` prints the gfp matrix Python versions as a
+          # JSON array first, then latest=<version> and major=<major> lines of
+          # the public GDSFactory+ VS Code extension.
+          OUTPUT="$(just get-gfp-versions)"
           echo "python-versions=$(echo "$OUTPUT" | head -n1)" >> "$GITHUB_OUTPUT"
           MAJOR="$(echo "$OUTPUT" | sed -n 's/^major=//p')"
           LATEST="$(echo "$OUTPUT" | sed -n 's/^latest=//p')"
@@ -35,8 +37,8 @@ jobs:
             {
               echo "### GDSFactory+ upstream test skipped"
               echo
-              echo "Latest PyPI gdsfactoryplus is \`${LATEST:-unknown}\` (< 2.0.0);"
-              echo "the gfp suite requires the v2 API. This gate can be removed once 2.0.0 is released."
+              echo "Latest GDSFactory+ VS Code extension is \`${LATEST:-unknown}\` (< 2.0);"
+              echo "the gfp suite requires the v2 SDK bundled in the extension."
             } >> "$GITHUB_STEP_SUMMARY"
           fi
   test-gfp:
@@ -71,7 +73,7 @@ jobs:
             echo "All GDSFactory+ test jobs succeeded"
             exit 0
           elif [[ "$RESULT" == "skipped" ]]; then
-            echo "GDSFactory+ test job skipped: latest PyPI gdsfactoryplus is < 2.0.0"
+            echo "GDSFactory+ test job skipped: latest VS Code extension release is < 2.0"
             exit 0
           else
             echo "One or more GDSFactory+ test jobs failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,11 +135,18 @@ jobs:
   test-gdsfactoryplus-result:
     runs-on: ubuntu-latest
     name: GDSFactory+ test result
-    needs: test-gdsfactoryplus
+    needs: [test-gdsfactoryplus, filter-gdsfactoryplus-versions]
     if: always()
     steps:
       - name: Check GDSFactory+ test matrix results
         run: |
+          # A failed gate maps the test job to "skipped"; without this
+          # check a broken gate would show up green as "skipped".
+          GATE="${{ needs.filter-gdsfactoryplus-versions.result }}"
+          if [[ "$GATE" == "failure" ]]; then
+            echo "GDSFactory+ version gate failed; the test job did not run meaningfully"
+            exit 1
+          fi
           RESULT="${{ needs.test-gdsfactoryplus.result }}"
           if [[ "$RESULT" == "success" ]]; then
             echo "All GDSFactory+ test jobs succeeded"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,10 @@ jobs:
           # the public GDSFactory+ VS Code extension.
           OUTPUT="$(just get-gfp-versions)"
           echo "python-versions=$(echo "$OUTPUT" | head -n1)" >> "$GITHUB_OUTPUT"
-          echo "gfp-major=$(echo "$OUTPUT" | sed -n 's/^major=//p')" >> "$GITHUB_OUTPUT"
+          MAJOR="$(echo "$OUTPUT" | sed -n 's/^major=//p')"
+          # Empty major (Marketplace unreachable / unknown version) counts as 0
+          # so the gate reliably skips instead of comparing an empty string.
+          echo "gfp-major=${MAJOR:-0}" >> "$GITHUB_OUTPUT"
   # Gate: the pytest gfp suite targets the gdsfactoryplus v2 SDK, which ships
   # bundled in the public GDSFactory+ VS Code extension (not on PyPI). Run the
   # suite only when the latest extension release is v2+; the gate also skips

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,6 @@ jobs:
             exit 1
           fi
   filter-gdsfactoryplus-versions:
-    needs: get-python-versions
     runs-on: ubuntu-latest
     outputs:
       python-versions: ${{ steps.filter.outputs.python-versions }}
@@ -97,18 +96,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      - name: Filter versions for gdsfactoryplus
+      - name: Resolve GDSFactory+ extension version
         id: filter
         run: |
-          INPUT='${{ needs.get-python-versions.outputs.python-versions }}'
-          # `just get-gfp-versions` prints the filtered JSON array first, then
-          # latest=<version> and major=<major> lines of the PyPI gdsfactoryplus release.
-          OUTPUT="$(just get-gfp-versions "$INPUT")"
+          # `just get-gfp-versions` prints the gfp matrix Python versions as a
+          # JSON array first, then latest=<version> and major=<major> lines of
+          # the public GDSFactory+ VS Code extension.
+          OUTPUT="$(just get-gfp-versions)"
           echo "python-versions=$(echo "$OUTPUT" | head -n1)" >> "$GITHUB_OUTPUT"
           echo "gfp-major=$(echo "$OUTPUT" | sed -n 's/^major=//p')" >> "$GITHUB_OUTPUT"
-  # Gate: gdsfactoryplus 2.0.0 is not on PyPI yet, and the pytest gfp suite targets the
-  # v2 API (it fails by design against v1). Run the suite only when the latest PyPI
-  # release is v2+; remove this gate once 2.0.0 ships and the job is expected to always run.
+  # Gate: the pytest gfp suite targets the gdsfactoryplus v2 SDK, which ships
+  # bundled in the public GDSFactory+ VS Code extension (not on PyPI). Run the
+  # suite only when the latest extension release is v2+; the gate also skips
+  # the job gracefully when the Marketplace cannot be reached.
   test-gdsfactoryplus:
     runs-on: ${{ matrix.os }}
     needs: filter-gdsfactoryplus-versions
@@ -142,7 +142,7 @@ jobs:
             echo "All GDSFactory+ test jobs succeeded"
             exit 0
           elif [[ "$RESULT" == "skipped" ]]; then
-            echo "GDSFactory+ test job skipped: latest PyPI gdsfactoryplus is < 2.0.0"
+            echo "GDSFactory+ test job skipped: latest VS Code extension release is < 2.0"
             exit 0
           else
             echo "One or more GDSFactory+ test jobs failed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python-versions: ${{ steps.filter.outputs.python-versions }}
+      gfp-major: ${{ steps.filter.outputs.gfp-major }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -100,10 +101,18 @@ jobs:
         id: filter
         run: |
           INPUT='${{ needs.get-python-versions.outputs.python-versions }}'
-          echo "python-versions=$(just get-gfp-versions "$INPUT")" >> "$GITHUB_OUTPUT"
+          # `just get-gfp-versions` prints the filtered JSON array first, then
+          # latest=<version> and major=<major> lines of the PyPI gdsfactoryplus release.
+          OUTPUT="$(just get-gfp-versions "$INPUT")"
+          echo "python-versions=$(echo "$OUTPUT" | head -n1)" >> "$GITHUB_OUTPUT"
+          echo "gfp-major=$(echo "$OUTPUT" | sed -n 's/^major=//p')" >> "$GITHUB_OUTPUT"
+  # Gate: gdsfactoryplus 2.0.0 is not on PyPI yet, and the pytest gfp suite targets the
+  # v2 API (it fails by design against v1). Run the suite only when the latest PyPI
+  # release is v2+; remove this gate once 2.0.0 ships and the job is expected to always run.
   test-gdsfactoryplus:
     runs-on: ${{ matrix.os }}
     needs: filter-gdsfactoryplus-versions
+    if: ${{ needs.filter-gdsfactoryplus-versions.outputs.gfp-major >= 2 }}
     strategy:
       fail-fast: false
       matrix:
@@ -128,8 +137,12 @@ jobs:
     steps:
       - name: Check GDSFactory+ test matrix results
         run: |
-          if [[ "${{ needs.test-gdsfactoryplus.result }}" == "success" ]]; then
+          RESULT="${{ needs.test-gdsfactoryplus.result }}"
+          if [[ "$RESULT" == "success" ]]; then
             echo "All GDSFactory+ test jobs succeeded"
+            exit 0
+          elif [[ "$RESULT" == "skipped" ]]; then
+            echo "GDSFactory+ test job skipped: latest PyPI gdsfactoryplus is < 2.0.0"
             exit 0
           else
             echo "One or more GDSFactory+ test jobs failed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,20 @@ documentation = "https://gdsfactory.github.io/quantum-rf-pdk/"
 repository = "https://github.com/gdsfactory/quantum-rf-pdk/"
 
 [project.optional-dependencies]
-gdsfactoryplus = ["gdsfactoryplus", "httpx"]
+# Dependencies of the gdsfactoryplus v2 SDK exercised by the gfp test suite.
+# The SDK itself is not on PyPI: gdsfactoryplus >= 2.0 ships bundled inside
+# the public GDSFactory+ VS Code extension, and `just test-gfp` extracts it
+# from there onto PYTHONPATH (see tests/test.just). Listed here are only the
+# SDK's own dependencies that the suite imports.
+gdsfactoryplus = [
+  "doroutes>=1.4.0,<2.0.0",
+  "elvis-lvs",
+  "httpx",
+  "inspice",
+  "jaxellip",
+  "kfnetlist",
+  "sax>=0.18.2,<1",
+]
 graphics = ["trimesh", "pyglet<3"]
 hfss = ["polars", "pyaedt[graphics]>=0.15.0"]
 models = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,8 +159,9 @@ unit = "GHz"
 
 [tool.gdsfactoryplus.pdk]
 name = "qpdk"
-# v1-only key: ignored by gdsfactoryplus >= 2.0 (unknown keys are skipped by
-# its settings schema). Kept until the v2 model-coverage mechanism is known.
+# qpdk-internal convention (never a gdsfactoryplus key in any version; unknown
+# keys are ignored by the v2 settings schema). Read by the model-coverage test
+# in tests/test_gfp_sax.py.
 cells_no_model_expected = [
   "chip_edge",  # chip-finishing fabrication frame, not a circuit element
   "circle",  # geometric utility, not a circuit element
@@ -177,8 +178,9 @@ cells_no_model_expected = [
   "unimon_arm",  # sub-component of unimon; model lives on parent
 ]
 
-# v1-only key: not part of the gdsfactoryplus >= 2.0 settings schema (silently
-# ignored there). Kept until its v2 replacement is confirmed.
+# Read directly from this file by the gdsfactoryplus >= 2.0 sidebar webview
+# (not part of the v2 settings schema; the "Make default" sidebar action
+# also writes this key). Selects the default library chips in the GF+ sidebar.
 [tool.gdsfactoryplus.sidebar]
 default_libraries = ["qpdk"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,9 +155,12 @@ max = 15  # 15GHz
 min = 1  # 1GHz
 name = "f"
 num = 4001
+unit = "GHz"
 
 [tool.gdsfactoryplus.pdk]
 name = "qpdk"
+# v1-only key: ignored by gdsfactoryplus >= 2.0 (unknown keys are skipped by
+# its settings schema). Kept until the v2 model-coverage mechanism is known.
 cells_no_model_expected = [
   "chip_edge",  # chip-finishing fabrication frame, not a circuit element
   "circle",  # geometric utility, not a circuit element
@@ -174,8 +177,14 @@ cells_no_model_expected = [
   "unimon_arm",  # sub-component of unimon; model lives on parent
 ]
 
+# v1-only key: not part of the gdsfactoryplus >= 2.0 settings schema (silently
+# ignored there). Kept until its v2 replacement is confirmed.
 [tool.gdsfactoryplus.sidebar]
 default_libraries = ["qpdk"]
+
+# qpdk has no via_stack cell; tells the v2 Livewire router not to expect vias.
+[tool.gdsfactoryplus.livewire]
+has_vias = false
 
 [tool.interrogate]
 docstring-style = "google"
@@ -235,6 +244,7 @@ filterwarnings = [
   "ignore:jax\\.core\\.unmapped_aval is deprecated:DeprecationWarning",
 ]
 markers = [
+  "gfp: mark test as requiring GDSFactory+ (gdsfactoryplus)",
   "hfss: mark test as requiring HFSS",
   "skip_windows: skip test on Windows",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,60 @@
 
 from __future__ import annotations
 
+import importlib
+import os
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 
 from qpdk import PDK
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+#: When set to "1", tests needing gdsfactoryplus fail instead of skipping.
+GFP_REQUIRED_ENV = "GFP_REQUIRED"
+
+
+def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
+    """Import a gdsfactoryplus module, skipping only when the package is absent.
+
+    A missing ``gdsfactoryplus.*`` submodule while the package itself imports
+    means upstream changed the API these tests guard against — that must fail
+    loudly, never silently skip. Set ``GFP_REQUIRED=1`` to also turn the
+    "package absent" skip into a failure (used in the gfp CI job).
+
+    Returns:
+        The imported module.
+
+    Raises:
+        AssertionError: Unreachable; satisfies the type checker since
+            ``pytest.skip``/``pytest.fail`` only raise.
+    """
+    try:
+        return importlib.import_module(module)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or ""
+        if missing == "gdsfactoryplus":
+            if os.environ.get(GFP_REQUIRED_ENV) == "1":
+                pytest.fail(
+                    "gdsfactoryplus is required (GFP_REQUIRED=1) but not installed"
+                )
+            pytest.skip("gdsfactoryplus not installed")
+        if missing.startswith("gdsfactoryplus"):
+            pytest.fail(
+                f"gdsfactoryplus is installed but {module!r} is unavailable "
+                f"({missing!r} missing) — upstream API changed?"
+            )
+        pytest.skip(f"optional dependency {missing!r} not installed")
+    raise AssertionError("unreachable")
+
+
+@pytest.fixture
+def gfp_sdk() -> ModuleType:
+    """Provide the gdsfactoryplus SDK top-level module (see import_gfp_module)."""
+    return import_gfp_module("gdsfactoryplus")
 
 
 def pytest_collection_modifyitems(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,10 @@ def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
     A missing ``gdsfactoryplus.*`` submodule while the package itself imports
     means upstream changed the API these tests guard against — that must fail
     loudly, never silently skip. Set ``GFP_REQUIRED=1`` to also turn the
-    "package absent" skip into a failure (used in the gfp CI job).
+    "package absent" skip and any missing transitive dependency into
+    failures (used in the gfp CI job, where ``just test-gfp`` provisions
+    everything); otherwise a silently missing dependency would green the CI
+    with the SAX/LVS coverage gone.
 
     gdsfactoryplus >= 2.0 is not on PyPI; it ships bundled in the public
     GDSFactory+ VS Code extension. ``just test-gfp`` provisions it from the
@@ -41,9 +44,10 @@ def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
         return importlib.import_module(module)
     except ModuleNotFoundError as exc:
         missing = exc.name or ""
+        required = os.environ.get(GFP_REQUIRED_ENV) == "1"
         if missing == "gdsfactoryplus":
             hint = "run `just fetch-gfp` and source build/gfp-vsix/env.sh"
-            if os.environ.get(GFP_REQUIRED_ENV) == "1":
+            if required:
                 pytest.fail(
                     f"gdsfactoryplus is required (GFP_REQUIRED=1) but not "
                     f"importable — {hint}"
@@ -55,6 +59,13 @@ def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
             pytest.fail(
                 f"gdsfactoryplus is installed but {module!r} is unavailable "
                 f"({missing!r} missing) — upstream API changed?"
+            )
+        if required:
+            pytest.fail(
+                f"gdsfactoryplus is required (GFP_REQUIRED=1) but its "
+                f"dependency {missing!r} is not importable — the SDK "
+                "provisioning is broken; run `just fetch-gfp` and source "
+                "build/gfp-vsix/env.sh, or install the gdsfactoryplus extra"
             )
         pytest.skip(
             f"optional dependency {missing!r} not installed", allow_module_level=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,10 @@ def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
     loudly, never silently skip. Set ``GFP_REQUIRED=1`` to also turn the
     "package absent" skip into a failure (used in the gfp CI job).
 
+    gdsfactoryplus >= 2.0 is not on PyPI; it ships bundled in the public
+    GDSFactory+ VS Code extension. ``just test-gfp`` provisions it from the
+    extension automatically (see ``fetch-gfp`` in ``tests/test.just``).
+
     Returns:
         The imported module.
 
@@ -38,24 +42,24 @@ def import_gfp_module(module: str = "gdsfactoryplus") -> ModuleType:
     except ModuleNotFoundError as exc:
         missing = exc.name or ""
         if missing == "gdsfactoryplus":
+            hint = "run `just fetch-gfp` and source build/gfp-vsix/env.sh"
             if os.environ.get(GFP_REQUIRED_ENV) == "1":
                 pytest.fail(
-                    "gdsfactoryplus is required (GFP_REQUIRED=1) but not installed"
+                    f"gdsfactoryplus is required (GFP_REQUIRED=1) but not "
+                    f"importable — {hint}"
                 )
-            pytest.skip("gdsfactoryplus not installed")
+            pytest.skip(
+                f"gdsfactoryplus not installed ({hint})", allow_module_level=True
+            )
         if missing.startswith("gdsfactoryplus"):
             pytest.fail(
                 f"gdsfactoryplus is installed but {module!r} is unavailable "
                 f"({missing!r} missing) — upstream API changed?"
             )
-        pytest.skip(f"optional dependency {missing!r} not installed")
+        pytest.skip(
+            f"optional dependency {missing!r} not installed", allow_module_level=True
+        )
     raise AssertionError("unreachable")
-
-
-@pytest.fixture
-def gfp_sdk() -> ModuleType:
-    """Provide the gdsfactoryplus SDK top-level module (see import_gfp_module)."""
-    return import_gfp_module("gdsfactoryplus")
 
 
 def pytest_collection_modifyitems(

--- a/tests/test.just
+++ b/tests/test.just
@@ -1,4 +1,4 @@
-PYTEST_COMMAND := "uv run --extra models --extra graphics --extra hfss --extra qutip --group dev pytest -n auto"
+PYTEST_COMMAND := "uv run --extra models --extra graphics --extra hfss --extra qutip --group dev pytest -n auto --dist loadgroup"
 
 # Check if Git LFS is available and pull LFS files
 [private]
@@ -246,13 +246,15 @@ fetch-gfp version="latest":
     )
     print(f"extracted to {OUT}; source {env_sh} for PYTHONPATH and GFP_BIN")
 
-# Run GDSFactory+ tests (pytest-based suite marked `gfp`; replaces the removed v2 `gfp test` CLI).
+# Run GDSFactory+ tests (pytest-based suite marked `gfp`; replaces the `gfp test` CLI removed in v2).
 # GFP_REQUIRED=1: gdsfactoryplus and its v2 API must be present (no silent skips).
 # The SDK and the `gfp` binary are not pip-installable: gdsfactoryplus >= 2.0
 # ships bundled in the public GDSFactory+ VS Code extension, so when the SDK is
 # not importable this recipe first extracts both from the extension (fetch-gfp).
 # The gfp-marked tests live in the three files listed below; naming them
 # explicitly avoids collecting the whole repo under the minimal gfp extras.
+# --dist loadgroup keeps the server tests (xdist_group "gfp-server", which
+# share one gfp serve process and the repo's build/ dir) on a single worker.
 [group('test')]
 test-gfp *args:
     #!/usr/bin/env bash
@@ -264,5 +266,5 @@ test-gfp *args:
         just fetch-gfp
         source build/gfp-vsix/env.sh
     fi
-    GFP_REQUIRED=1 uv run --extra gdsfactoryplus --group dev pytest -m gfp -n auto \
+    GFP_REQUIRED=1 uv run --extra gdsfactoryplus --group dev pytest -m gfp -n auto --dist loadgroup \
         tests/test_gfp_lvs.py tests/test_gfp_sax.py tests/test_gfp_server.py {{ args }}

--- a/tests/test.just
+++ b/tests/test.just
@@ -179,7 +179,10 @@ fetch-gfp version="latest":
             )
 
         def version_key(v):
-            return [int(x) if x.isdigit() else 0 for x in v.split(".")]
+            # Release versions must beat prereleases at equal numbers
+            # ("2.1.0" > "2.1.0-beta"), so append a release flag; the
+            # non-digit component of a prerelease sorts as 0 either way.
+            return ([int(x) if x.isdigit() else 0 for x in v.split(".")], "-" not in v)
 
         return max(versions, key=version_key)
 
@@ -231,13 +234,21 @@ fetch-gfp version="latest":
                     target_path.parent.mkdir(parents=True, exist_ok=True)
                     target_path.write_bytes(vsix.read(member))
 
-        gfp_bin = OUT / "bin" / ("gfp.exe" if IS_WINDOWS else "gfp")
-        if not IS_WINDOWS:
-            gfp_bin.chmod(gfp_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         stamp.write_text(wanted)
 
+    # Validate on every run (not just fresh extraction) and chmod
+    # unconditionally: zip extraction does not preserve the exec bit, so
+    # a stamp hit on a re-cloned or partially cleaned checkout would
+    # otherwise produce a non-executable gfp with no error.
     gfp_bin = OUT / "bin" / ("gfp.exe" if IS_WINDOWS else "gfp")
     sdk_dirs = [OUT / "bin" / "python" / "gdsfactoryplus", OUT / "bin" / "python" / "nyancad"]
+    if not gfp_bin.is_file():
+        raise SystemExit(f"extraction incomplete: {gfp_bin} is missing from {OUT}")
+    missing_dirs = [str(d) for d in sdk_dirs if not d.is_dir()]
+    if missing_dirs:
+        raise SystemExit(f"extraction incomplete: SDK dirs missing: {missing_dirs}")
+    if not IS_WINDOWS:
+        gfp_bin.chmod(gfp_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
     sep = os.pathsep
     env_sh = OUT / "env.sh"
     env_sh.write_text(

--- a/tests/test.just
+++ b/tests/test.just
@@ -67,18 +67,20 @@ test-models-force: (_pytest "-s tests/test_models_regression.py --force-regen")
 test-hfss *args: check-lfs
     uv run --all-extras --group dev pytest -m hfss {{ args }}
 
-# Filter a JSON array of Python versions to only those supported by the latest version of gdsfactoryplus on PyPI.
+# Query the latest version of the public GDSFactory+ VS Code extension.
 # Output contract (used by .github/workflows/test.yml and test-gfp-upstream.yml):
-#   line 1: JSON array of supported Python versions (the original behavior)
-#   line 2: latest=<latest gdsfactoryplus version on PyPI> (empty when unknown)
+#   line 1: JSON array of Python versions for the gfp test matrix
+#   line 2: latest=<latest extension version> (empty when unknown)
 #   line 3: major=<major version of that release> (empty when unknown)
 [group('test')]
 [script('uv', 'run', '--script')]
-get-gfp-versions versions:
-    import json, urllib.request, sys, re
+get-gfp-versions:
+    import json, urllib.request
 
-    # Emit the latest= and major= lines of the output contract.
-    # major is empty when the version is unknown or not <int>.<int>... shaped.
+    # The extension bundles a cp312-only SDK and runtime, so the gfp
+    # matrix is pinned to Python 3.12 regardless of the main matrix.
+    print(json.dumps(["3.12"]))
+
     def print_version_info(latest):
         major = ""
         if latest:
@@ -88,58 +90,179 @@ get-gfp-versions versions:
         print(f"latest={latest or ''}")
         print(f"major={major}")
 
-    v_in = json.loads('{{ versions }}')
+    def version_key(v):
+        return [int(x) if x.isdigit() else 0 for x in v.split(".")]
+
     try:
-        with urllib.request.urlopen("https://pypi.org/pypi/gdsfactoryplus/json") as r:
-            data = json.loads(r.read().decode())
-
-        latest = data.get("info", {}).get("version")
-        info = data.get("info", {})
-        req = info.get("requires_python", "")
-        rels = data.get("releases", {}).get(latest, [])
-
-        def supports_version(rel, t, v):
-            python_version = rel.get("python_version", "")
-            has_cp_tag = f"cp{t}" in python_version
-            has_py_tag = f"py{t}" in python_version
-            has_plain_version = v in python_version
-            return has_cp_tag or has_py_tag or has_plain_version
-
-        v_out = []
-        for v in v_in:
-            t = v.replace(".", "")
-            # Check for wheels first as they are definitive
-            if any(supports_version(rel, t, v) for rel in rels):
-                v_out.append(v)
-            elif req:
-                # Fallback to parsing requires_python string for the latest version
-                vm = int(v.split('.')[1])
-                # Match major.minor patterns like >=3.11, <3.14, ~=3.12
-                m_ge = re.search(r'>=3\.(\d+)', req)
-                m_lt = re.search(r'<3\.(\d+)', req)
-                m_ti = re.search(r'~=3\.(\d+)', req)
-
-                is_supported = True
-                if m_ge and vm < int(m_ge.group(1)): is_supported = False
-                if m_lt and vm >= int(m_lt.group(1)): is_supported = False
-                if m_ti and vm != int(m_ti.group(1)): is_supported = False
-
-                if is_supported:
-                    v_out.append(v)
-        # If filtering resulted in an empty list, fallback to input to avoid breaking the matrix
-        print(json.dumps(v_out or v_in))
-        print_version_info(latest)
+        body = json.dumps({
+            "filters": [{
+                "criteria": [{"filterType": 7, "value": "gdsfactory.gdsfactoryplus"}],
+                "pageNumber": 1,
+                "pageSize": 1,
+                "sortBy": 0,
+                "sortOrder": 0,
+            }],
+            "assetTypes": [],
+            "flags": 1,  # IncludeVersions
+        }).encode()
+        req = urllib.request.Request(
+            "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=7.2-preview.1",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json;api-version=7.2-preview.1",
+                "User-Agent": "quantum-rf-pdk-ci",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = json.loads(r.read())
+        extensions = data.get("results", [{}])[0].get("extensions", [])
+        versions = (
+            [v["version"] for v in extensions[0].get("versions", [])]
+            if extensions
+            else []
+        )
+        print_version_info(max(versions, key=version_key) if versions else None)
     except Exception:
-        # Fallback to input versions on any error (network, parsing, etc.);
-        # unknown version → empty latest/major so consumers can skip the gfp job
-        print(json.dumps(v_in))
+        # Unknown version → empty latest/major so consumers skip the gfp job
         print_version_info(None)
+
+# Download the public GDSFactory+ VS Code extension and extract the bundled
+# gdsfactoryplus SDK and `gfp` binary into build/gfp-vsix/ (neither is
+# pip-installable: gdsfactoryplus >= 2.0 ships only inside the extension).
+# Writes build/gfp-vsix/env.sh exporting PYTHONPATH (SDK + bundled nyancad)
+# and GFP_BIN (binary) for `just test-gfp` to source.
+[group('test')]
+[script('uv', 'run', '--script')]
+fetch-gfp version="latest":
+    import gzip, io, json, os, platform, shutil, stat, urllib.request, zipfile
+    from pathlib import Path
+
+    PUBLISHER = "gdsfactory"
+    EXTENSION = "gdsfactoryplus"
+    API = "https://marketplace.visualstudio.com/_apis/public/gallery"
+    OUT = Path("build/gfp-vsix")
+    IS_WINDOWS = platform.system() == "Windows"
+
+    def resolve_latest():
+        body = json.dumps({
+            "filters": [{
+                "criteria": [{"filterType": 7, "value": f"{PUBLISHER}.{EXTENSION}"}],
+                "pageNumber": 1,
+                "pageSize": 1,
+                "sortBy": 0,
+                "sortOrder": 0,
+            }],
+            "assetTypes": [],
+            "flags": 1,  # IncludeVersions
+        }).encode()
+        req = urllib.request.Request(
+            f"{API}/extensionquery?api-version=7.2-preview.1",
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json;api-version=7.2-preview.1",
+                "User-Agent": "quantum-rf-pdk-ci",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = json.loads(r.read())
+        extensions = data.get("results", [{}])[0].get("extensions", [])
+        versions = (
+            [v["version"] for v in extensions[0].get("versions", [])]
+            if extensions
+            else []
+        )
+        if not versions:
+            raise SystemExit(
+                f"extension {PUBLISHER}.{EXTENSION} not found on the Marketplace"
+            )
+
+        def version_key(v):
+            return [int(x) if x.isdigit() else 0 for x in v.split(".")]
+
+        return max(versions, key=version_key)
+
+    def target_platform():
+        arch = {
+            "x86_64": "x64",
+            "amd64": "x64",
+            "arm64": "arm64",
+            "aarch64": "arm64",
+        }.get(platform.machine().lower())
+        os_name = {"Darwin": "darwin", "Linux": "linux", "Windows": "win32"}.get(
+            platform.system()
+        )
+        if not arch or not os_name:
+            raise SystemExit(
+                f"unsupported platform: {platform.system()} {platform.machine()}"
+            )
+        return f"{os_name}-{arch}"
+
+    version = "{{ version }}"
+    target = target_platform()
+    if version == "latest":
+        version = resolve_latest()
+    stamp = OUT / "VERSION"
+    wanted = f"{version} {target}"
+
+    if stamp.exists() and stamp.read_text().strip() == wanted:
+        print(f"gdsfactoryplus {wanted} already extracted at {OUT}")
+    else:
+        url = (
+            f"{API}/publishers/{PUBLISHER}/vsextensions/{EXTENSION}"
+            f"/{version}/vspackage?targetPlatform={target}"
+        )
+        print(f"downloading {PUBLISHER}.{EXTENSION} {version} ({target})")
+        req = urllib.request.Request(url, headers={"User-Agent": "quantum-rf-pdk-ci"})
+        with urllib.request.urlopen(req, timeout=600) as r:
+            payload = r.read()
+        # The Marketplace may serve the VSIX gzip-encoded.
+        if payload[:2] == b"\x1f\x8b":
+            payload = gzip.decompress(payload)
+
+        if OUT.exists():
+            shutil.rmtree(OUT)
+        OUT.mkdir(parents=True)
+        with zipfile.ZipFile(io.BytesIO(payload)) as vsix:
+            for member in vsix.namelist():
+                if member.startswith("extension/bin/") and not member.endswith("/"):
+                    target_path = OUT / member.removeprefix("extension/")
+                    target_path.parent.mkdir(parents=True, exist_ok=True)
+                    target_path.write_bytes(vsix.read(member))
+
+        gfp_bin = OUT / "bin" / ("gfp.exe" if IS_WINDOWS else "gfp")
+        if not IS_WINDOWS:
+            gfp_bin.chmod(gfp_bin.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        stamp.write_text(wanted)
+
+    gfp_bin = OUT / "bin" / ("gfp.exe" if IS_WINDOWS else "gfp")
+    sdk_dirs = [OUT / "bin" / "python" / "gdsfactoryplus", OUT / "bin" / "python" / "nyancad"]
+    sep = os.pathsep
+    env_sh = OUT / "env.sh"
+    env_sh.write_text(
+        f'export PYTHONPATH="{sep.join(str(d.resolve()) for d in sdk_dirs)}"\n'
+        f'export GFP_BIN="{gfp_bin.resolve()}"\n'
+    )
+    print(f"extracted to {OUT}; source {env_sh} for PYTHONPATH and GFP_BIN")
 
 # Run GDSFactory+ tests (pytest-based suite marked `gfp`; replaces the removed v2 `gfp test` CLI).
 # GFP_REQUIRED=1: gdsfactoryplus and its v2 API must be present (no silent skips).
-# The `gfp` binary is not pip-installable, so binary-dependent tests
-# (tests/test_gfp_server.py) still skip when it is missing — see that module's docstring.
-# `uv run` syncs the `gdsfactoryplus` extra and `dev` group automatically.
+# The SDK and the `gfp` binary are not pip-installable: gdsfactoryplus >= 2.0
+# ships bundled in the public GDSFactory+ VS Code extension, so when the SDK is
+# not importable this recipe first extracts both from the extension (fetch-gfp).
+# The gfp-marked tests live in the three files listed below; naming them
+# explicitly avoids collecting the whole repo under the minimal gfp extras.
 [group('test')]
 test-gfp *args:
-    GFP_REQUIRED=1 uv run --extra gdsfactoryplus --group dev pytest -m gfp -n auto {{ args }}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -f build/gfp-vsix/env.sh ]]; then
+        source build/gfp-vsix/env.sh
+    fi
+    if ! uv run --no-sync python -c "import gdsfactoryplus" 2>/dev/null; then
+        just fetch-gfp
+        source build/gfp-vsix/env.sh
+    fi
+    GFP_REQUIRED=1 uv run --extra gdsfactoryplus --group dev pytest -m gfp -n auto \
+        tests/test_gfp_lvs.py tests/test_gfp_sax.py tests/test_gfp_server.py {{ args }}

--- a/tests/test.just
+++ b/tests/test.just
@@ -67,11 +67,27 @@ test-models-force: (_pytest "-s tests/test_models_regression.py --force-regen")
 test-hfss *args: check-lfs
     uv run --all-extras --group dev pytest -m hfss {{ args }}
 
-# Filter a JSON array of Python versions to only those supported by the latest version of gdsfactoryplus on PyPI
+# Filter a JSON array of Python versions to only those supported by the latest version of gdsfactoryplus on PyPI.
+# Output contract (used by .github/workflows/test.yml and test-gfp-upstream.yml):
+#   line 1: JSON array of supported Python versions (the original behavior)
+#   line 2: latest=<latest gdsfactoryplus version on PyPI> (empty when unknown)
+#   line 3: major=<major version of that release> (empty when unknown)
 [group('test')]
 [script('uv', 'run', '--script')]
 get-gfp-versions versions:
     import json, urllib.request, sys, re
+
+    # Emit the latest= and major= lines of the output contract.
+    # major is empty when the version is unknown or not <int>.<int>... shaped.
+    def print_version_info(latest):
+        major = ""
+        if latest:
+            head = latest.split(".")[0]
+            if head.isdigit():
+                major = head
+        print(f"latest={latest or ''}")
+        print(f"major={major}")
+
     v_in = json.loads('{{ versions }}')
     try:
         with urllib.request.urlopen("https://pypi.org/pypi/gdsfactoryplus/json") as r:
@@ -112,11 +128,18 @@ get-gfp-versions versions:
                     v_out.append(v)
         # If filtering resulted in an empty list, fallback to input to avoid breaking the matrix
         print(json.dumps(v_out or v_in))
+        print_version_info(latest)
     except Exception:
-        # Fallback to input versions on any error (network, parsing, etc.)
+        # Fallback to input versions on any error (network, parsing, etc.);
+        # unknown version → empty latest/major so consumers can skip the gfp job
         print(json.dumps(v_in))
+        print_version_info(None)
 
-# Run GDSFactory+ tests
+# Run GDSFactory+ tests (pytest-based suite marked `gfp`; replaces the removed v2 `gfp test` CLI).
+# GFP_REQUIRED=1: gdsfactoryplus and its v2 API must be present (no silent skips).
+# The `gfp` binary is not pip-installable, so binary-dependent tests
+# (tests/test_gfp_server.py) still skip when it is missing — see that module's docstring.
+# `uv run` syncs the `gdsfactoryplus` extra and `dev` group automatically.
 [group('test')]
-test-gfp:
-    uv run --extra gdsfactoryplus gfp test
+test-gfp *args:
+    GFP_REQUIRED=1 uv run --extra gdsfactoryplus --group dev pytest -m gfp -n auto {{ args }}

--- a/tests/test.just
+++ b/tests/test.just
@@ -91,7 +91,13 @@ get-gfp-versions:
         print(f"major={major}")
 
     def version_key(v):
-        return [int(x) if x.isdigit() else 0 for x in v.split(".")]
+        # Split off any prerelease suffix and add a release flag so a
+        # stable release beats prereleases at equal version numbers
+        # ("2.1.0" over "2.1.0-beta.1"): without splitting, the "1" in
+        # "2.1.0-beta.1" parses as an extra numeric component and sorts
+        # after the stable release.
+        nums = v.split("-")[0].split(".")
+        return ([int(x) if x.isdigit() else 0 for x in nums], "-" not in v)
 
     try:
         body = json.dumps({
@@ -179,10 +185,13 @@ fetch-gfp version="latest":
             )
 
         def version_key(v):
-            # Release versions must beat prereleases at equal numbers
-            # ("2.1.0" > "2.1.0-beta"), so append a release flag; the
-            # non-digit component of a prerelease sorts as 0 either way.
-            return ([int(x) if x.isdigit() else 0 for x in v.split(".")], "-" not in v)
+            # Split off any prerelease suffix and add a release flag so a
+            # stable release beats prereleases at equal version numbers
+            # ("2.1.0" over "2.1.0-beta.1"): without splitting, the "1" in
+            # "2.1.0-beta.1" parses as an extra numeric component and sorts
+            # after the stable release.
+            nums = v.split("-")[0].split(".")
+            return ([int(x) if x.isdigit() else 0 for x in nums], "-" not in v)
 
         return max(versions, key=version_key)
 

--- a/tests/test_gfp_lvs.py
+++ b/tests/test_gfp_lvs.py
@@ -13,8 +13,9 @@ against this PDK:
   noise for hierarchical GDS: library leaf-cell ports connect in their
   parent, and ``resonator_o1`` of ``quarter_wave_resonator_coupled`` is
   intentionally unterminated (capacitive coupling through the gap).
-- ``check_drc``: remote submission smoke test against the
-  ``quantum_rf`` deck, skipped unless ``GFP_API_KEY`` is set.
+- ``check_drc``: remote submission smoke test, skipped unless
+  ``GFP_API_KEY`` is set and ``[tool.gdsfactoryplus.project].identifier``
+  (the portal project slug submissions are filed under) is configured.
 
 Behavioral notes these tests encode:
 
@@ -42,6 +43,7 @@ never received from untrusted sources.
 from __future__ import annotations
 
 import os
+import tomllib
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -68,10 +70,30 @@ SCHEMATIC_PATH = PROJECT_ROOT / "qpdk/samples/resonator_test_chip_yaml.pic.yml"
 #: Environment variable holding the gdsfactoryplus DRC API key.
 GFP_API_KEY_ENV = "GFP_API_KEY"
 
-#: ``[tool.gdsfactoryplus.drc] pdk`` in pyproject.toml; also the portal
-#: project slug for this PDK's DRC submissions (qpdk configures no
-#: ``[tool.gdsfactoryplus.project].identifier``).
-QUANTUM_RF_SLUG = "quantum_rf"
+
+def _portal_project_slug() -> str | None:
+    """Read the GDSFactory+ portal project slug from ``pyproject.toml``.
+
+    ``[tool.gdsfactoryplus.project].identifier`` is the cloud portal project
+    that DRC submissions are filed under (orthogonal to
+    ``[tool.gdsfactoryplus.drc] pdk``, which names the DRC process deck).
+    qpdk leaves it unset; the GF+ extension writes it on first interactive
+    DRC use.
+
+    Returns:
+        The configured slug, or ``None`` when not configured.
+    """
+    with (PROJECT_ROOT / "pyproject.toml").open("rb") as stream:
+        data = tomllib.load(stream)
+    slug = (
+        data
+        .get("tool", {})
+        .get("gdsfactoryplus", {})
+        .get("project", {})
+        .get("identifier")
+    )
+    return slug or None
+
 
 #: Connectivity-check categories that indicate real defects. ``DanglingPort``
 #: is excluded on purpose (see module docstring).
@@ -207,12 +229,18 @@ def test_connectivity_no_shorts_or_overlaps(
 )
 def test_drc_submission_smoke(gfp_check: ModuleType, tmp_path: Path) -> None:
     """Submit a small qpdk cell to the remote DRC service without error."""
+    project_slug = _portal_project_slug()
+    if project_slug is None:
+        pytest.skip(
+            "[tool.gdsfactoryplus.project].identifier not set in pyproject.toml "
+            "— no portal project configured for DRC submissions",
+        )
     gds_path = tmp_path / "double_pad_transmon.gds"
     double_pad_transmon().write_gds(gds_path)
 
     submission = gfp_check.check_drc(
         str(gds_path),
-        project_slug=QUANTUM_RF_SLUG,
+        project_slug=project_slug,
         api_key=os.environ[GFP_API_KEY_ENV],
     )
 

--- a/tests/test_gfp_lvs.py
+++ b/tests/test_gfp_lvs.py
@@ -7,7 +7,9 @@ against this PDK:
   ``resonator_test_chip_yaml.pic.yml`` schematic with zero violations
   (elvis engine).
 - ``check_lvs`` detects real violations (negative control, so the passing
-  assertion above cannot become vacuous).
+  assertions above cannot become vacuous).
+- ``check_lvs`` also runs against a hand-authored ``.gsch`` nyancir (the
+  other schematic dialect the gfp app produces), positive and negative.
 - ``check_connectivity``: the report is parseable and contains no
   short/overlap/mismatch violations. ``DanglingPort`` items are expected
   noise for hierarchical GDS: library leaf-cell ports connect in their
@@ -42,11 +44,12 @@ never received from untrusted sources.
 
 from __future__ import annotations
 
+import json
 import os
 import tomllib
 import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import gdsfactory as gf
 import pytest
@@ -66,6 +69,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 #: Schematic describing the resonator test chip (wrapper sample).
 SCHEMATIC_PATH = PROJECT_ROOT / "qpdk/samples/resonator_test_chip_yaml.pic.yml"
+
+#: Fully qualified factory id of the resonator test chip sample.
+_CHIP_QUALNAME = "qpdk.samples.resonator_test_chip.resonator_test_chip_python"
+
+#: Chip ports the nyancir exposes; must match the wrapper GDS ports.
+_NYANCIR_PORTS = ("o1", "o2", "o3", "o4")
 
 #: Environment variable holding the gdsfactoryplus DRC API key.
 GFP_API_KEY_ENV = "GFP_API_KEY"
@@ -140,6 +149,80 @@ def chip_yaml_gds(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return gds_path
 
 
+def _nyancir_document() -> dict[str, Any]:
+    """Build a ``.gsch`` nyancir mirroring the wrapper layout.
+
+    One ``type: "ckt"`` instance of the sample factory named like the
+    wrapper GDS instance (``resonator_test_chip``), with its four ports
+    exposed through ``type: "port"`` markers.
+
+    Returns:
+        Nyancir document ready to be serialized to a ``.gsch`` file.
+    """
+    document: dict[str, Any] = {
+        "chip:resonator_test_chip": {
+            "type": "ckt",
+            "model": _CHIP_QUALNAME,
+            "name": "resonator_test_chip",
+            "transform": [1, 0, 0, 1, 0, 0],
+            "x": 0,
+            "y": 0,
+            "props": {},
+            "nets": {port: f"net_{port}" for port in _NYANCIR_PORTS},
+        }
+    }
+    for port in _NYANCIR_PORTS:
+        document[f"chip:{port}"] = {
+            "type": "port",
+            "name": port,
+            "x": 0,
+            "y": 0,
+            "nets": {"P": f"net_{port}"},
+        }
+    return document
+
+
+@pytest.fixture(scope="module")
+def nyancir_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build a self-contained project root holding a ``.gsch`` schematic.
+
+    ``check_lvs`` resolves a ``.gsch`` schematic and its
+    ``models.nyanlib`` through nyancad's ``FileAPI`` relative to
+    ``project_root``; the hand-authored nyanlib entry mirrors what the
+    ``gfp`` binary generates for the sample factory (only the component
+    ``name`` is read for a Python-factory leaf).
+
+    Returns:
+        Path to the temporary project root.
+    """
+    root = tmp_path_factory.mktemp("gfp_nyancir")
+    (root / "resonator_test_chip_gfp.gsch").write_text(
+        json.dumps(_nyancir_document(), indent=2)
+    )
+    (root / "models.nyanlib").write_text(
+        json.dumps(
+            {
+                f"models:{_CHIP_QUALNAME}": {
+                    "name": "resonator_test_chip_python",
+                    "type": "ckt",
+                    "tags": ["qpdk"],
+                }
+            },
+            indent=2,
+        )
+    )
+    return root
+
+
+@pytest.fixture(scope="module")
+def nyancir_chip_gds(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Write the nyancir-matching wrapper layout GDS to a temp directory."""
+    PDK.activate()  # not applied to module-scoped fixtures by the autouse hook
+    gds_path = tmp_path_factory.mktemp("gfp_verify") / "resonator_test_chip_gfp.gds"
+    _wrapper_component("resonator_test_chip_gfp").write_gds(gds_path)
+    return gds_path
+
+
 def _leaf_category(item: ET.Element) -> str:
     """Return the leaf category path of a LYRDB item, e.g. ``LVS.open``."""
     return item.findtext("category") or ""
@@ -191,6 +274,46 @@ def test_lvs_reports_a_broken_layout(gfp_check: ModuleType, tmp_path: Path) -> N
         str(SCHEMATIC_PATH),
         "qpdk",
         project_root=str(PROJECT_ROOT),
+    )
+    root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
+    items = list(root.iter("item"))
+    descriptions = " | ".join(_item_description(item) for item in items)
+
+    assert items, "LVS accepted a layout that lost the o4 port connection"
+    assert "o4" in descriptions, f"Violations do not mention o4:\n{descriptions}"
+
+
+def test_lvs_resonator_test_chip_matches_nyancir(
+    gfp_check: ModuleType, nyancir_root: Path, nyancir_chip_gds: Path
+) -> None:
+    """Elvis LVS reports zero violations for the sample chip vs a ``.gsch``."""
+    xml = gfp_check.check_lvs(
+        str(nyancir_chip_gds),
+        str(nyancir_root / "resonator_test_chip_gfp.gsch"),
+        "qpdk",
+        project_root=str(nyancir_root),
+    )
+    root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
+
+    assert root.tag == "report-database", xml[:500]
+    violations = _describe_violations(root)
+    assert not list(root.iter("item")), f"LVS violations:\n{violations}"
+
+
+def test_lvs_nyancir_reports_a_broken_layout(
+    gfp_check: ModuleType, nyancir_root: Path, tmp_path: Path
+) -> None:
+    """Negative control: a dropped o4 port must violate the ``.gsch`` LVS."""
+    gds_path = tmp_path / "resonator_test_chip_gfp_broken.gds"
+    _wrapper_component("resonator_test_chip_gfp_broken", with_o4=False).write_gds(
+        gds_path
+    )
+
+    xml = gfp_check.check_lvs(
+        str(gds_path),
+        str(nyancir_root / "resonator_test_chip_gfp.gsch"),
+        "qpdk",
+        project_root=str(nyancir_root),
     )
     root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
     items = list(root.iter("item"))

--- a/tests/test_gfp_lvs.py
+++ b/tests/test_gfp_lvs.py
@@ -1,0 +1,220 @@
+"""Verification checks of gdsfactoryplus v2 (LVS, connectivity, DRC smoke).
+
+Covers the gdsfactoryplus 2.0.0 verification API (``gdsfactoryplus.check``)
+against this PDK:
+
+- ``check_lvs``: the ``resonator_test_chip_yaml`` sample layout matches its
+  ``resonator_test_chip_yaml.pic.yml`` schematic with zero violations
+  (elvis engine).
+- ``check_lvs`` detects real violations (negative control, so the passing
+  assertion above cannot become vacuous).
+- ``check_connectivity``: the report is parseable and contains no
+  short/overlap/mismatch violations. ``DanglingPort`` items are expected
+  noise for hierarchical GDS: library leaf-cell ports connect in their
+  parent, and ``resonator_o1`` of ``quarter_wave_resonator_coupled`` is
+  intentionally unterminated (capacitive coupling through the gap).
+- ``check_drc``: remote submission smoke test against the
+  ``quantum_rf`` deck, skipped unless ``GFP_API_KEY`` is set.
+
+Behavioral notes these tests encode:
+
+- ``check_lvs`` accepts ``.gsch`` (via nyancir) and ``.pic.yml`` schematics;
+  ``.pic.yml`` files are resolved recursively from ``project_root`` by
+  component name, so only components with their own ``*.pic.yml`` expand.
+- The SDK LVS flow does not forward qpdk's ``[tool.elvis.equivalent-ports]``
+  config (``launcher``: ``o1``/``waveport``). Empirically this does not
+  break the resonator test chip: elvis derives equivalent-port groups from
+  GDS pin metadata and the launcher nets produce neither opens nor port
+  mismatches.
+
+The schematic/layout pairing mirrors the gfp app: the ``.pic.yml`` sample is
+a wrapper around ``resonator_test_chip_python``, so the compared layout is a
+wrapper cell containing that chip as a single instance — the hierarchy the
+gfp app builds from the schematic. A flattened ``resonator_test_chip_python``
+GDS does NOT match this schematic (its top cell directly contains the
+resonator/probeline instances) and is intentionally not used here.
+
+Reports are parsed with stdlib ``xml.etree`` (bandit XML rules are ignored
+at the use sites): the LYRDB output is generated locally by elvis/klayout,
+never received from untrusted sources.
+"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET  # ruff: ignore[suspicious-xml-etree-import]
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import gdsfactory as gf
+import pytest
+from conftest import import_gfp_module
+
+from qpdk import PDK
+from qpdk.cells import double_pad_transmon
+from qpdk.samples.resonator_test_chip import resonator_test_chip_python
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+pytestmark = pytest.mark.gfp
+
+#: qpdk repository root (parent of ``tests/``); the pic.yml search root.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+#: Schematic describing the resonator test chip (wrapper sample).
+SCHEMATIC_PATH = PROJECT_ROOT / "qpdk/samples/resonator_test_chip_yaml.pic.yml"
+
+#: Environment variable holding the gdsfactoryplus DRC API key.
+GFP_API_KEY_ENV = "GFP_API_KEY"
+
+#: ``[tool.gdsfactoryplus.drc] pdk`` in pyproject.toml; also the portal
+#: project slug for this PDK's DRC submissions (qpdk configures no
+#: ``[tool.gdsfactoryplus.project].identifier``).
+QUANTUM_RF_SLUG = "quantum_rf"
+
+#: Connectivity-check categories that indicate real defects. ``DanglingPort``
+#: is excluded on purpose (see module docstring).
+CONNECTIVITY_VIOLATION_CATEGORIES = frozenset({
+    "PortOverlap",
+    "InstanceOverlap",
+    "CellShapeInstanceOverlap",
+    "PortMismatch",
+})
+
+
+@pytest.fixture
+def gfp_check() -> ModuleType:
+    """Provide the gdsfactoryplus.check module (see import_gfp_module)."""
+    return import_gfp_module("gdsfactoryplus.check")
+
+
+def _wrapper_component(name: str, *, with_o4: bool = True) -> gf.Component:
+    """Build and return the layout the ``resonator_test_chip_yaml.pic.yml`` describes.
+
+    A single instance ``resonator_test_chip`` of ``resonator_test_chip_python``
+    with all four probeline ports exposed on the wrapper, matching the
+    ``instances``/``ports`` sections of the schematic.
+
+    Returns:
+        Wrapper component whose top-cell name matches the schematic.
+    """
+    chip = resonator_test_chip_python()
+    wrapper = gf.Component(name)
+    ref = wrapper.add_ref(chip, name="resonator_test_chip")
+    for port_name in ("o1", "o2", "o3", "o4"):
+        if port_name == "o4" and not with_o4:
+            continue
+        wrapper.add_port(port_name, port=ref.ports[port_name])
+    return wrapper
+
+
+@pytest.fixture(scope="module")
+def chip_yaml_gds(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Write the schematic-matching test-chip layout GDS to a temp directory."""
+    PDK.activate()  # not applied to module-scoped fixtures by the autouse hook
+    gds_path = tmp_path_factory.mktemp("gfp_verify") / "resonator_test_chip_yaml.gds"
+    _wrapper_component("resonator_test_chip_yaml").write_gds(gds_path)
+    return gds_path
+
+
+def _leaf_category(item: ET.Element) -> str:
+    """Return the leaf category path of a LYRDB item, e.g. ``LVS.open``."""
+    return item.findtext("category") or ""
+
+
+def _item_description(item: ET.Element) -> str:
+    """Return the human-readable text values of a LYRDB item."""
+    return "; ".join(
+        (value.text or "").removeprefix("text: ").strip()
+        for value in item.findall("./values/value")
+        if (value.text or "").startswith("text: ")
+    )
+
+
+def _describe_violations(root: ET.Element) -> str:
+    """Format all LYRDB items for assertion failure messages."""
+    return "\n".join(
+        f"[{_leaf_category(item)}] {_item_description(item)}"
+        for item in root.iter("item")
+    )
+
+
+def test_lvs_resonator_test_chip_matches_schematic(
+    gfp_check: ModuleType, chip_yaml_gds: Path
+) -> None:
+    """Elvis LVS reports zero violations for the sample chip vs its pic.yml."""
+    xml = gfp_check.check_lvs(
+        str(chip_yaml_gds),
+        str(SCHEMATIC_PATH),
+        "qpdk",
+        project_root=str(PROJECT_ROOT),
+    )
+    root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
+
+    assert root.tag == "report-database", xml[:500]
+    violations = _describe_violations(root)
+    assert not list(root.iter("item")), f"LVS violations:\n{violations}"
+
+
+def test_lvs_reports_a_broken_layout(gfp_check: ModuleType, tmp_path: Path) -> None:
+    """Negative control: dropping the o4 port must produce LVS violations."""
+    gds_path = tmp_path / "resonator_test_chip_yaml_broken.gds"
+    _wrapper_component("resonator_test_chip_yaml_broken", with_o4=False).write_gds(
+        gds_path
+    )
+
+    xml = gfp_check.check_lvs(
+        str(gds_path),
+        str(SCHEMATIC_PATH),
+        "qpdk",
+        project_root=str(PROJECT_ROOT),
+    )
+    root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
+    items = list(root.iter("item"))
+    descriptions = " | ".join(_item_description(item) for item in items)
+
+    assert items, "LVS accepted a layout that lost the o4 port connection"
+    assert "o4" in descriptions, f"Violations do not mention o4:\n{descriptions}"
+
+
+def test_connectivity_no_shorts_or_overlaps(
+    gfp_check: ModuleType, chip_yaml_gds: Path
+) -> None:
+    """Connectivity check finds no shorts/overlaps/mismatches on the sample.
+
+    ``check_connectivity`` aggregates kfactory's port mismatch, dangling
+    port, instance overlap, and shape/instance overlap checks into one
+    LYRDB report. ``DanglingPort`` items are expected (see module
+    docstring); every other category indicates a real defect.
+    """
+    xml = gfp_check.check_connectivity(str(chip_yaml_gds), verbose=False)
+    root = ET.fromstring(xml)  # ruff: ignore[suspicious-xml-element-tree-usage]
+
+    assert root.tag == "report-database", xml[:500]
+    unexpected = [
+        f"[{_leaf_category(item)}] {_item_description(item)}"
+        for item in root.iter("item")
+        if _leaf_category(item).rsplit(".", maxsplit=1)[-1]
+        in CONNECTIVITY_VIOLATION_CATEGORIES
+    ]
+    assert not unexpected, "Connectivity violations:\n" + "\n".join(unexpected)
+
+
+@pytest.mark.skipif(
+    not os.environ.get(GFP_API_KEY_ENV),
+    reason="GFP_API_KEY not set — remote DRC submission would fail",
+)
+def test_drc_submission_smoke(gfp_check: ModuleType, tmp_path: Path) -> None:
+    """Submit a small qpdk cell to the remote DRC service without error."""
+    gds_path = tmp_path / "double_pad_transmon.gds"
+    double_pad_transmon().write_gds(gds_path)
+
+    submission = gfp_check.check_drc(
+        str(gds_path),
+        project_slug=QUANTUM_RF_SLUG,
+        api_key=os.environ[GFP_API_KEY_ENV],
+    )
+
+    assert submission["sub_id"], f"Missing sub_id in submission: {submission}"
+    assert submission["status"], f"Missing status in submission: {submission}"

--- a/tests/test_gfp_sax.py
+++ b/tests/test_gfp_sax.py
@@ -1,0 +1,237 @@
+"""gdsfactoryplus v2 SAX simulation and model-contract tests.
+
+Covers the v2 (>= 2.0.0) SDK SAX surface against this PDK:
+
+- Layout-driven simulation: ``simulate_layout_sax`` materializes a
+  schematic (``.gsch`` nyancir file) to a layout, runs KLayout
+  LayoutToNetlist extraction, and feeds the resulting netlist to SAX.
+  The v1 ``gdsfactoryplus.serve.sax._run_simulation`` server API no
+  longer exists; this module replaces the test that used it.
+- Model contract: every model in ``PDK.models`` must accept ``f`` in Hz
+  (the v2 frontend sweeps frequency, see ``[tool.gdsfactoryplus.sim.x]``
+  ``name = "f"`` in ``pyproject.toml``).
+- Model coverage: ``inspect_layout_sax_models`` must not ask for SAX
+  models beyond the exemptions in ``pyproject.toml``
+  (``[tool.gdsfactoryplus.pdk] cells_no_model_expected``).
+
+The nyancir (``.gsch``) fixture is authored directly as JSON in the
+Mosaic dialect. The file holds one ``type: "ckt"`` instance of the
+sample factory plus four ``type: "port"`` markers exposing its
+``o1``..``o4`` ports.
+
+The PDK qualified name is ``"qpdk.PDK"``: the v2 API resolves
+``pdk_qn`` as ``<module>.<attribute>`` (like ``ihp.PDK``), not a bare
+package name.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import pytest
+from conftest import import_gfp_module
+
+from qpdk import PDK
+from qpdk.models.resonator import (
+    resonator_test_chip_python as resonator_test_chip_python_model,
+)
+
+sax_sim = import_gfp_module("gdsfactoryplus.sim.sax")
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Speed of light in µm/s — converts between the API's wavelengths (µm)
+#: and the models' native frequencies (Hz), matching gdsfactoryplus.
+_SPEED_OF_LIGHT_UM_PER_S = 299_792_458_000_000.0
+
+#: Fully qualified factory id of the resonator test chip sample.
+_CHIP_QUALNAME = "qpdk.samples.resonator_test_chip.resonator_test_chip_python"
+
+#: Chip ports exposed by the nyancir port markers.
+_PORT_NAMES = ("o1", "o2", "o3", "o4")
+
+#: RF band under test, in Hz.
+_F_MIN_HZ = 4e9
+_F_MAX_HZ = 10e9
+
+#: ``PDK.models`` entries, sorted so parametrized failures identify the model.
+_MODEL_PARAMS: list[tuple[str, Callable[..., Any]]] = sorted(PDK.models.items())
+
+
+def _resonator_test_chip_nyancir() -> dict[str, Any]:
+    """Build a nyancir (``.gsch``) document for the resonator test chip.
+
+    One ``type: "ckt"`` instance of the sample factory, with each of its
+    four ports wired to a ``type: "port"`` marker through a shared net
+    name — the minimal Mosaic-dialect schematic that exposes ``o1``..``o4``
+    as top-level ports.
+
+    Returns:
+        Nyancir document ready to be serialized to a ``.gsch`` file.
+    """
+    document: dict[str, Any] = {
+        "chip:X1": {
+            "type": "ckt",
+            "model": _CHIP_QUALNAME,
+            "name": "X1",
+            "transform": [1, 0, 0, 1, 0, 0],
+            "x": 0,
+            "y": 0,
+            "props": {},
+            "nets": {port: f"net_{port}" for port in _PORT_NAMES},
+        }
+    }
+    for port in _PORT_NAMES:
+        document[f"chip:{port}"] = {
+            "type": "port",
+            "name": port,
+            "x": 0,
+            "y": 0,
+            "nets": {"P": f"net_{port}"},
+        }
+    return document
+
+
+@pytest.fixture(scope="module")
+def nyancir_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Write the resonator-test-chip nyancir to a temporary ``.gsch`` file.
+
+    The stem is deliberately distinct from any PDK cell name so the
+    materialized top cell does not collide in the shared kfactory
+    registry when several tests run in one process.
+
+    Returns:
+        Path to the written ``.gsch`` nyancir file.
+    """
+    path = tmp_path_factory.mktemp("nyancir") / "resonator_test_chip_gfp.gsch"
+    path.write_text(json.dumps(_resonator_test_chip_nyancir(), indent=2))
+    return path
+
+
+@pytest.mark.gfp
+def test_resonator_test_chip_layout_sax_simulation(nyancir_path: Path) -> None:
+    """Simulate the chip through the v2 layout-driven SAX pipeline.
+
+    Replaces the removed v1
+    ``test_resonator_test_chip_runs_through_layout_simulation_server``:
+    the layout netlist is extracted from materialized geometry, the chip
+    resolves to its registered SAX model, and the frequency sweep must
+    agree with the reference model evaluated at the same frequencies.
+    """
+    result = sax_sim.simulate_layout_sax(
+        str(nyancir_path),
+        "qpdk.PDK",
+        # The API represents the 4--10 GHz band as wavelengths in µm.
+        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
+        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
+        wl_num=3,
+        sweep_frequency=True,
+    )
+
+    wavelengths = np.asarray(result["wavelengths"], dtype=float)
+    assert len(wavelengths) == 3
+    assert wavelengths[0] == pytest.approx(299_792.458 / 4)
+    assert wavelengths[-1] == pytest.approx(299_792.458 / 10)
+
+    sdict = result["sdict"]
+    ports = {name for key in sdict for name in key.split(",")}
+    assert ports == {"o1", "o2", "o3", "o4"}
+    for entry in sdict.values():
+        assert len(entry["real"]) == len(entry["imag"]) == 3
+
+    # The sweep is called with ascending frequencies in Hz (f = c / λ);
+    # derive them back from the returned canonical wavelengths.
+    frequencies = _SPEED_OF_LIGHT_UM_PER_S / wavelengths
+    expected = resonator_test_chip_python_model(f=frequencies)
+    zero = np.zeros(len(wavelengths), dtype=complex)
+    simulated_keys = {tuple(key.split(",")) for key in sdict}
+
+    for key in set(expected) | simulated_keys:
+        entry = sdict.get(f"{key[0]},{key[1]}")
+        actual = (
+            zero
+            if entry is None  # near-zero terms may be dropped
+            else np.asarray(entry["real"]) + 1j * np.asarray(entry["imag"])
+        )
+        np.testing.assert_allclose(
+            actual,
+            expected.get(key, zero),
+            rtol=1e-6,
+            atol=1e-6,
+            err_msg=f"S-parameters disagree for {key}",
+        )
+
+
+def _cells_no_model_expected() -> set[str]:
+    """Read the SAX-model exemptions from ``pyproject.toml``."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as stream:
+        data = tomllib.load(stream)
+    return set(data["tool"]["gdsfactoryplus"]["pdk"]["cells_no_model_expected"])
+
+
+@pytest.mark.gfp
+def test_layout_sax_model_coverage(nyancir_path: Path) -> None:
+    """Model resolution over the extracted layout honors the exemptions.
+
+    Components without a SAX model are acceptable only when they are
+    listed in ``[tool.gdsfactoryplus.pdk] cells_no_model_expected``;
+    anything else is an upstream regression to fix with a model.
+    """
+    info = sax_sim.inspect_layout_sax_models(str(nyancir_path), "qpdk.PDK")
+
+    unexpected = set(info["missing_models"]) - _cells_no_model_expected()
+    assert not unexpected, (
+        f"Layout pipeline reported missing SAX models {sorted(unexpected)}; "
+        "add a model or extend cells_no_model_expected in pyproject.toml"
+    )
+    assert {"resonator_test_chip_python", _CHIP_QUALNAME} & set(
+        info["resolved_models"]
+    ), f"chip model unresolved: {info}"
+
+
+@pytest.mark.gfp
+@pytest.mark.parametrize(("model_name", "model"), _MODEL_PARAMS)
+def test_pdk_model_accepts_f_in_hz(model_name: str, model: Callable) -> None:
+    """Every PDK model is callable with ``f`` alone, in Hz.
+
+    The v2 frontend sweeps frequency (``[tool.gdsfactoryplus.sim.x]``
+    ``name = "f"``), so ``sax.circuit`` calls each model with ``f=`` in
+    Hz and no other arguments beyond instance settings. Models that
+    cannot be called this way break every v2 SAX simulation that uses
+    them.
+    """
+    try:
+        parameters = inspect.signature(model).parameters
+    except (TypeError, ValueError) as exc:
+        pytest.skip(f"{model_name} has no inspectable signature: {exc}")
+    else:
+        if "f" not in parameters:
+            pytest.skip(f"{model_name} does not take an 'f' parameter")
+        required_beyond_f = [
+            name
+            for name, parameter in parameters.items()
+            if name != "f"
+            and parameter.default is inspect.Parameter.empty
+            and parameter.kind
+            in {
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        ]
+        if required_beyond_f:
+            pytest.skip(f"{model_name} requires {required_beyond_f} without defaults")
+
+        s_params = model(f=np.linspace(_F_MIN_HZ, _F_MAX_HZ, 3))
+
+        assert isinstance(s_params, dict), f"{model_name} returned {type(s_params)}"
+        assert s_params, f"{model_name} returned an empty S-parameter dict"
+        for key, value in s_params.items():
+            arr = np.broadcast_to(np.asarray(value, dtype=complex), (3,))
+            assert np.isfinite(arr).all(), f"{model_name} S[{key}] is not finite"

--- a/tests/test_gfp_sax.py
+++ b/tests/test_gfp_sax.py
@@ -75,6 +75,16 @@ _SPEED_OF_LIGHT_UM_PER_S = 299_792_458_000_000.0
 #: Fully qualified factory id of the resonator test chip sample.
 _CHIP_QUALNAME = "qpdk.samples.resonator_test_chip.resonator_test_chip_python"
 
+#: An exempted cell (listed in ``cells_no_model_expected``: its SAX model
+#: lives on the full ``plate_capacitor``). Unlike portless exemptions such
+#: as ``chip_edge``, it has one port, so an instance wired into a net
+#: survives netlist pruning and is reported as a missing model — the only
+#: way to exercise the exemptions subtraction.
+_EXEMPT_CELL_QUALNAME = "qpdk.cells.capacitor.plate_capacitor_single"
+
+#: File name of the nyancir that instantiates the exempted cell.
+_EXEMPT_GSCH_NAME = "resonator_test_chip_exemption.gsch"
+
 #: Chip ports exposed by the nyancir port markers.
 _PORT_NAMES = ("o1", "o2", "o3", "o4")
 
@@ -138,7 +148,7 @@ def _resonator_test_chip_nyanlib(
 
     Mirrors the entries the ``gfp`` binary generates (see
     ``build/models.nyanlib``): for a Python-factory leaf, the Mosaic
-    netlist builder only reads the component ``name`` and ``type``
+    netlist builder only reads the component ``name``
     (``nyancad.netlist.kf_component_name``).
 
     Args:
@@ -192,7 +202,8 @@ def mosaic_project_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
     the repository root with a ``gfp``-generated nyanlib. A throwaway
     root with a hand-authored nyanlib exercises the same SDK path
     without cross-test ordering dependencies. Holds a default-props and
-    a tuned-props nyancir (see ``_TUNED_GSCH_NAME``).
+    a tuned-props nyancir (see ``_TUNED_GSCH_NAME``), plus an exemption
+    nyancir (see ``_EXEMPT_GSCH_NAME``) for the model-coverage test.
 
     Returns:
         Path to the temporary project root.
@@ -205,9 +216,25 @@ def mosaic_project_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
             indent=2,
         )
     )
-    (root / "models.nyanlib").write_text(
-        json.dumps(_resonator_test_chip_nyanlib(), indent=2)
-    )
+    exemption_document = _resonator_test_chip_nyancir()
+    exemption_document["cap:E1"] = {
+        "type": "ckt",
+        "model": _EXEMPT_CELL_QUALNAME,
+        "name": "E1",
+        "transform": [1, 0, 0, 1, 0, 0],
+        "x": 0,
+        "y": 0,
+        "props": {},
+        "nets": {"o1": "net_o2"},
+    }
+    (root / _EXEMPT_GSCH_NAME).write_text(json.dumps(exemption_document, indent=2))
+    nyanlib = _resonator_test_chip_nyanlib()
+    nyanlib[f"models:{_EXEMPT_CELL_QUALNAME}"] = {
+        "name": "plate_capacitor_single",
+        "type": "ckt",
+        "tags": ["qpdk"],
+    }
+    (root / "models.nyanlib").write_text(json.dumps(nyanlib, indent=2))
     return root
 
 
@@ -293,14 +320,21 @@ def _assert_sweep_matches_reference(
 
     for key in set(expected) | simulated_keys:
         entry = sdict.get(f"{key[0]},{key[1]}")
-        actual = (
-            zero
-            if entry is None  # near-zero terms may be dropped
-            else np.asarray(entry["real"]) + 1j * np.asarray(entry["imag"])
-        )
+        expected_value = expected.get(key, zero)
+        if entry is None:
+            # The SDK drops entries whose |S| stays below 1e-5 across the
+            # whole band (sim/sax.py ``_sweep``), so an absent entry only
+            # guarantees the reference is under that threshold — comparing
+            # it to zero at a tighter tolerance would spuriously fail.
+            assert np.abs(np.asarray(expected_value)).max() < 1e-5, (
+                f"S[{key}] is missing from the sdict but the reference is "
+                "not negligible; the SDK should not have dropped it"
+            )
+            continue
+        actual = np.asarray(entry["real"]) + 1j * np.asarray(entry["imag"])
         np.testing.assert_allclose(
             actual,
-            expected.get(key, zero),
+            expected_value,
             rtol=1e-6,
             atol=1e-6,
             err_msg=f"S-parameters disagree for {key}",
@@ -439,7 +473,10 @@ def test_layout_sax_model_coverage(nyancir_path: Path) -> None:
 
     Components without a SAX model are acceptable only when they are
     listed in ``[tool.gdsfactoryplus.pdk] cells_no_model_expected``;
-    anything else is an upstream regression to fix with a model.
+    anything else is an upstream regression to fix with a model. This
+    fixture resolves only the chip (unmodelled leaf cells are dropped
+    during layout extraction and never reported), so the exemptions
+    list is genuinely exercised by ``test_mosaic_sax_model_coverage``.
     """
     info = sax_sim.inspect_layout_sax_models(str(nyancir_path), "qpdk.PDK")
 
@@ -459,14 +496,23 @@ def test_mosaic_sax_model_coverage(mosaic_project_root: Path) -> None:
 
     Same contract as the layout pipeline, but for
     ``inspect_mosaic_sax_models`` (schematic-driven resolution from
-    ``project_root``).
+    ``project_root``). The schematic instantiates ``plate_capacitor_single``
+    — a cell exempted via ``cells_no_model_expected`` because its model
+    lives on the full ``plate_capacitor`` — wired into a live net so it
+    survives pruning and is reported as a missing model. That makes the
+    subtraction below real: removing the cell from the exemptions must
+    fail this test.
     """
     info = sax_sim.inspect_mosaic_sax_models(
-        str(mosaic_project_root / _GSCH_NAME),
+        str(mosaic_project_root / _EXEMPT_GSCH_NAME),
         "qpdk.PDK",
         project_root=str(mosaic_project_root),
     )
 
+    assert "plate_capacitor_single" in info["missing_models"], (
+        "the exemption fixture no longer reports plate_capacitor_single "
+        f"as missing, so the exemptions subtraction is not exercised: {info}"
+    )
     unexpected = set(info["missing_models"]) - _cells_no_model_expected()
     assert not unexpected, (
         f"Schematic pipeline reported missing SAX models {sorted(unexpected)}; "

--- a/tests/test_gfp_sax.py
+++ b/tests/test_gfp_sax.py
@@ -7,17 +7,26 @@ Covers the v2 (>= 2.0.0) SDK SAX surface against this PDK:
   LayoutToNetlist extraction, and feeds the resulting netlist to SAX.
   The v1 ``gdsfactoryplus.serve.sax._run_simulation`` server API no
   longer exists; this module replaces the test that used it.
+- Schematic-driven simulation: ``simulate_mosaic_sax`` builds the
+  netlist directly from the same nyancir schematic (no layout
+  materialization) and runs SAX on it — both paths must agree with the
+  reference model.
 - Model contract: every model in ``PDK.models`` must accept ``f`` in Hz
   (the v2 frontend sweeps frequency, see ``[tool.gdsfactoryplus.sim.x]``
   ``name = "f"`` in ``pyproject.toml``).
-- Model coverage: ``inspect_layout_sax_models`` must not ask for SAX
-  models beyond the exemptions in ``pyproject.toml``
+- Model coverage: ``inspect_layout_sax_models`` and
+  ``inspect_mosaic_sax_models`` must not ask for SAX models beyond the
+  exemptions in ``pyproject.toml``
   (``[tool.gdsfactoryplus.pdk] cells_no_model_expected``).
 
-The nyancir (``.gsch``) fixture is authored directly as JSON in the
+The nyancir (``.gsch``) fixtures are authored directly as JSON in the
 Mosaic dialect. The file holds one ``type: "ckt"`` instance of the
 sample factory plus four ``type: "port"`` markers exposing its
-``o1``..``o4`` ports.
+``o1``..``o4`` ports. The Mosaic (schematic-driven) pipeline resolves
+both the ``.gsch`` and ``models.nyanlib`` through nyancad's ``FileAPI``
+relative to ``project_root``, so its fixture builds a self-contained
+project root: the nyancir plus a hand-authored ``models.nyanlib`` with
+the single entry the ``gfp`` binary generates for the sample factory.
 
 The PDK qualified name is ``"qpdk.PDK"``: the v2 API resolves
 ``pdk_qn`` as ``<module>.<attribute>`` (like ``ihp.PDK``), not a bare
@@ -45,6 +54,9 @@ sax_sim = import_gfp_module("gdsfactoryplus.sim.sax")
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+#: File name of the resonator-test-chip nyancir inside both fixture roots.
+_GSCH_NAME = "resonator_test_chip_gfp.gsch"
 
 #: Speed of light in µm/s — converts between the API's wavelengths (µm)
 #: and the models' native frequencies (Hz), matching gdsfactoryplus.
@@ -98,6 +110,26 @@ def _resonator_test_chip_nyancir() -> dict[str, Any]:
     return document
 
 
+def _resonator_test_chip_nyanlib() -> dict[str, Any]:
+    """Build a minimal ``models.nyanlib`` for the resonator test chip.
+
+    Mirrors the single entry the ``gfp`` binary generates for the sample
+    factory (``build/models.nyanlib``): for a Python-factory leaf, the
+    Mosaic netlist builder only reads the component ``name`` and ``type``
+    (``nyancad.netlist.kf_component_name``).
+
+    Returns:
+        Nyanlib document ready to be serialized to a ``.nyanlib`` file.
+    """
+    return {
+        f"models:{_CHIP_QUALNAME}": {
+            "name": "resonator_test_chip_python",
+            "type": "ckt",
+            "tags": ["qpdk"],
+        }
+    }
+
+
 @pytest.fixture(scope="module")
 def nyancir_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Write the resonator-test-chip nyancir to a temporary ``.gsch`` file.
@@ -109,31 +141,43 @@ def nyancir_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     Returns:
         Path to the written ``.gsch`` nyancir file.
     """
-    path = tmp_path_factory.mktemp("nyancir") / "resonator_test_chip_gfp.gsch"
+    path = tmp_path_factory.mktemp("nyancir") / _GSCH_NAME
     path.write_text(json.dumps(_resonator_test_chip_nyancir(), indent=2))
     return path
 
 
-@pytest.mark.gfp
-def test_resonator_test_chip_layout_sax_simulation(nyancir_path: Path) -> None:
-    """Simulate the chip through the v2 layout-driven SAX pipeline.
+@pytest.fixture(scope="module")
+def mosaic_project_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build a self-contained project root for the Mosaic pipeline.
 
-    Replaces the removed v1
-    ``test_resonator_test_chip_runs_through_layout_simulation_server``:
-    the layout netlist is extracted from materialized geometry, the chip
-    resolves to its registered SAX model, and the frequency sweep must
-    agree with the reference model evaluated at the same frequencies.
+    The schematic-driven pipeline resolves the ``.gsch`` and
+    ``models.nyanlib`` relative to ``project_root`` through nyancad's
+    ``FileAPI``, so both must live in one directory; the real app uses
+    the repository root with a ``gfp``-generated nyanlib. A throwaway
+    root with a hand-authored nyanlib exercises the same SDK path
+    without cross-test ordering dependencies.
+
+    Returns:
+        Path to the temporary project root.
     """
-    result = sax_sim.simulate_layout_sax(
-        str(nyancir_path),
-        "qpdk.PDK",
-        # The API represents the 4--10 GHz band as wavelengths in µm.
-        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
-        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
-        wl_num=3,
-        sweep_frequency=True,
+    root = tmp_path_factory.mktemp("mosaic_project")
+    (root / _GSCH_NAME).write_text(json.dumps(_resonator_test_chip_nyancir(), indent=2))
+    (root / "models.nyanlib").write_text(
+        json.dumps(_resonator_test_chip_nyanlib(), indent=2)
     )
+    return root
 
+
+def _assert_sweep_matches_reference(result: dict[str, Any]) -> None:
+    """Assert a simulation result is the reference model over the 4--10 GHz band.
+
+    Checks the returned sweep grid, the exposed chip ports, and that every
+    S-parameter entry agrees with ``resonator_test_chip_python`` evaluated at
+    the same frequencies (near-zero terms may be dropped from the sdict).
+
+    Args:
+        result: Return value of ``simulate_layout_sax``/``simulate_mosaic_sax``.
+    """
     wavelengths = np.asarray(result["wavelengths"], dtype=float)
     assert len(wavelengths) == 3
     assert wavelengths[0] == pytest.approx(299_792.458 / 4)
@@ -168,6 +212,52 @@ def test_resonator_test_chip_layout_sax_simulation(nyancir_path: Path) -> None:
         )
 
 
+@pytest.mark.gfp
+def test_resonator_test_chip_layout_sax_simulation(nyancir_path: Path) -> None:
+    """Simulate the chip through the v2 layout-driven SAX pipeline.
+
+    Replaces the removed v1
+    ``test_resonator_test_chip_runs_through_layout_simulation_server``:
+    the layout netlist is extracted from materialized geometry, the chip
+    resolves to its registered SAX model, and the frequency sweep must
+    agree with the reference model evaluated at the same frequencies.
+    """
+    result = sax_sim.simulate_layout_sax(
+        str(nyancir_path),
+        "qpdk.PDK",
+        # The API represents the 4--10 GHz band as wavelengths in µm.
+        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
+        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
+        wl_num=3,
+        sweep_frequency=True,
+    )
+    _assert_sweep_matches_reference(result)
+
+
+@pytest.mark.gfp
+def test_resonator_test_chip_mosaic_sax_simulation(
+    mosaic_project_root: Path,
+) -> None:
+    """Simulate the chip through the v2 schematic-driven (Mosaic) SAX pipeline.
+
+    ``simulate_mosaic_sax`` builds the netlist directly from the nyancir
+    schematic (resolving the schematic and ``models.nyanlib`` from
+    ``project_root``) without materializing any layout geometry — the
+    path used when simulating straight from a schematic. It must agree
+    with the reference model exactly like the layout-driven pipeline.
+    """
+    result = sax_sim.simulate_mosaic_sax(
+        str(mosaic_project_root / _GSCH_NAME),
+        "qpdk.PDK",
+        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
+        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
+        wl_num=3,
+        project_root=str(mosaic_project_root),
+        sweep_frequency=True,
+    )
+    _assert_sweep_matches_reference(result)
+
+
 def _cells_no_model_expected() -> set[str]:
     """Read the SAX-model exemptions from ``pyproject.toml``."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
@@ -189,6 +279,30 @@ def test_layout_sax_model_coverage(nyancir_path: Path) -> None:
     unexpected = set(info["missing_models"]) - _cells_no_model_expected()
     assert not unexpected, (
         f"Layout pipeline reported missing SAX models {sorted(unexpected)}; "
+        "add a model or extend cells_no_model_expected in pyproject.toml"
+    )
+    assert {"resonator_test_chip_python", _CHIP_QUALNAME} & set(
+        info["resolved_models"]
+    ), f"chip model unresolved: {info}"
+
+
+@pytest.mark.gfp
+def test_mosaic_sax_model_coverage(mosaic_project_root: Path) -> None:
+    """Model resolution over the schematic honors the exemptions.
+
+    Same contract as the layout pipeline, but for
+    ``inspect_mosaic_sax_models`` (schematic-driven resolution from
+    ``project_root``).
+    """
+    info = sax_sim.inspect_mosaic_sax_models(
+        str(mosaic_project_root / _GSCH_NAME),
+        "qpdk.PDK",
+        project_root=str(mosaic_project_root),
+    )
+
+    unexpected = set(info["missing_models"]) - _cells_no_model_expected()
+    assert not unexpected, (
+        f"Schematic pipeline reported missing SAX models {sorted(unexpected)}; "
         "add a model or extend cells_no_model_expected in pyproject.toml"
     )
     assert {"resonator_test_chip_python", _CHIP_QUALNAME} & set(

--- a/tests/test_gfp_sax.py
+++ b/tests/test_gfp_sax.py
@@ -10,7 +10,10 @@ Covers the v2 (>= 2.0.0) SDK SAX surface against this PDK:
 - Schematic-driven simulation: ``simulate_mosaic_sax`` builds the
   netlist directly from the same nyancir schematic (no layout
   materialization) and runs SAX on it — both paths must agree with the
-  reference model.
+  reference model. The schematic-driven tests also cover the two
+  features only that path exercises: hierarchical subcircuits (a
+  ``.gsch`` instantiated from another ``.gsch``) and instance ``props``
+  reaching the model.
 - Model contract: every model in ``PDK.models`` must accept ``f`` in Hz
   (the v2 frontend sweeps frequency, see ``[tool.gdsfactoryplus.sim.x]``
   ``name = "f"`` in ``pyproject.toml``).
@@ -58,6 +61,13 @@ if TYPE_CHECKING:
 #: File name of the resonator-test-chip nyancir inside both fixture roots.
 _GSCH_NAME = "resonator_test_chip_gfp.gsch"
 
+#: A non-default ``resonator_length`` (µm) used to prove instance ``props``
+#: reach the model; the default in ``resonator_test_chip_python`` is 4000.
+_TUNED_RESONATOR_LENGTH = 6000.0
+
+#: File name of the nyancir whose chip instance overrides ``resonator_length``.
+_TUNED_GSCH_NAME = "resonator_test_chip_tuned.gsch"
+
 #: Speed of light in µm/s — converts between the API's wavelengths (µm)
 #: and the models' native frequencies (Hz), matching gdsfactoryplus.
 _SPEED_OF_LIGHT_UM_PER_S = 299_792_458_000_000.0
@@ -75,14 +85,25 @@ _F_MAX_HZ = 10e9
 #: ``PDK.models`` entries, sorted so parametrized failures identify the model.
 _MODEL_PARAMS: list[tuple[str, Callable[..., Any]]] = sorted(PDK.models.items())
 
+#: Models exempt from the ``f``-in-Hz call contract (e.g. models that
+#: legitimately require instance settings with no defaults). Extend only
+#: with a justification, never to silence a failure.
+_F_CONTRACT_EXEMPT: frozenset[str] = frozenset()
 
-def _resonator_test_chip_nyancir() -> dict[str, Any]:
+
+def _resonator_test_chip_nyancir(
+    props: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """Build a nyancir (``.gsch``) document for the resonator test chip.
 
     One ``type: "ckt"`` instance of the sample factory, with each of its
     four ports wired to a ``type: "port"`` marker through a shared net
     name — the minimal Mosaic-dialect schematic that exposes ``o1``..``o4``
     as top-level ports.
+
+    Args:
+        props: Instance settings forwarded to the factory/model; defaults
+            to none.
 
     Returns:
         Nyancir document ready to be serialized to a ``.gsch`` file.
@@ -95,7 +116,7 @@ def _resonator_test_chip_nyancir() -> dict[str, Any]:
             "transform": [1, 0, 0, 1, 0, 0],
             "x": 0,
             "y": 0,
-            "props": {},
+            "props": dict(props or {}),
             "nets": {port: f"net_{port}" for port in _PORT_NAMES},
         }
     }
@@ -110,24 +131,39 @@ def _resonator_test_chip_nyancir() -> dict[str, Any]:
     return document
 
 
-def _resonator_test_chip_nyanlib() -> dict[str, Any]:
+def _resonator_test_chip_nyanlib(
+    subcircuit_ids: dict[str, str] | None = None,
+) -> dict[str, Any]:
     """Build a minimal ``models.nyanlib`` for the resonator test chip.
 
-    Mirrors the single entry the ``gfp`` binary generates for the sample
-    factory (``build/models.nyanlib``): for a Python-factory leaf, the
-    Mosaic netlist builder only reads the component ``name`` and ``type``
+    Mirrors the entries the ``gfp`` binary generates (see
+    ``build/models.nyanlib``): for a Python-factory leaf, the Mosaic
+    netlist builder only reads the component ``name`` and ``type``
     (``nyancad.netlist.kf_component_name``).
+
+    Args:
+        subcircuit_ids: Extra ``{schem_id: component_name}`` entries for
+            ``.gsch`` files the top schematic instantiates as
+            subcircuits; each needs its own nyanlib entry naming the
+            SAX subcircuit.
 
     Returns:
         Nyanlib document ready to be serialized to a ``.nyanlib`` file.
     """
-    return {
+    lib: dict[str, Any] = {
         f"models:{_CHIP_QUALNAME}": {
             "name": "resonator_test_chip_python",
             "type": "ckt",
             "tags": ["qpdk"],
         }
     }
+    for schem_id, component_name in (subcircuit_ids or {}).items():
+        lib[f"models:{schem_id}"] = {
+            "name": component_name,
+            "type": "ckt",
+            "tags": ["qpdk"],
+        }
+    return lib
 
 
 @pytest.fixture(scope="module")
@@ -155,20 +191,72 @@ def mosaic_project_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
     ``FileAPI``, so both must live in one directory; the real app uses
     the repository root with a ``gfp``-generated nyanlib. A throwaway
     root with a hand-authored nyanlib exercises the same SDK path
-    without cross-test ordering dependencies.
+    without cross-test ordering dependencies. Holds a default-props and
+    a tuned-props nyancir (see ``_TUNED_GSCH_NAME``).
 
     Returns:
         Path to the temporary project root.
     """
     root = tmp_path_factory.mktemp("mosaic_project")
     (root / _GSCH_NAME).write_text(json.dumps(_resonator_test_chip_nyancir(), indent=2))
+    (root / _TUNED_GSCH_NAME).write_text(
+        json.dumps(
+            _resonator_test_chip_nyancir({"resonator_length": _TUNED_RESONATOR_LENGTH}),
+            indent=2,
+        )
+    )
     (root / "models.nyanlib").write_text(
         json.dumps(_resonator_test_chip_nyanlib(), indent=2)
     )
     return root
 
 
-def _assert_sweep_matches_reference(result: dict[str, Any]) -> None:
+@pytest.fixture(scope="module")
+def mosaic_hierarchy_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Build a two-level Mosaic project: top ``.gsch`` instantiating a sub ``.gsch``.
+
+    The top schematic's single instance references ``sub.gsch`` by its
+    project-relative id (the Mosaic subcircuit mechanism); the sub
+    schematic holds the chip leaf. The subcircuit is a transparent port
+    feed-through, so the top-level S-parameters must equal the chip
+    model.
+
+    Returns:
+        Path to the temporary project root.
+    """
+    root = tmp_path_factory.mktemp("mosaic_hierarchy")
+    (root / "sub.gsch").write_text(json.dumps(_resonator_test_chip_nyancir(), indent=2))
+    top_document: dict[str, Any] = {
+        "sub:X1": {
+            "type": "ckt",
+            "model": "sub.gsch",
+            "name": "X1",
+            "transform": [1, 0, 0, 1, 0, 0],
+            "x": 0,
+            "y": 0,
+            "props": {},
+            "nets": {port: f"net_{port}" for port in _PORT_NAMES},
+        }
+    }
+    for port in _PORT_NAMES:
+        top_document[f"top:{port}"] = {
+            "type": "port",
+            "name": port,
+            "x": 0,
+            "y": 0,
+            "nets": {"P": f"net_{port}"},
+        }
+    (root / "top.gsch").write_text(json.dumps(top_document, indent=2))
+    (root / "models.nyanlib").write_text(
+        json.dumps(_resonator_test_chip_nyanlib({"sub.gsch": "sub"}), indent=2)
+    )
+    return root
+
+
+def _assert_sweep_matches_reference(
+    result: dict[str, Any],
+    expected_model: Callable[..., Any] | None = None,
+) -> None:
     """Assert a simulation result is the reference model over the 4--10 GHz band.
 
     Checks the returned sweep grid, the exposed chip ports, and that every
@@ -177,7 +265,14 @@ def _assert_sweep_matches_reference(result: dict[str, Any]) -> None:
 
     Args:
         result: Return value of ``simulate_layout_sax``/``simulate_mosaic_sax``.
+        expected_model: Model to compare against; defaults to the reference
+            model with default settings.
     """
+    if expected_model is None:
+        expected_model = resonator_test_chip_python_model
+    # The API canonicalizes to wavelength-descending (frequency-ascending)
+    # order regardless of the wl_min/wl_max argument order — verified against
+    # the public extension bundle.
     wavelengths = np.asarray(result["wavelengths"], dtype=float)
     assert len(wavelengths) == 3
     assert wavelengths[0] == pytest.approx(299_792.458 / 4)
@@ -192,7 +287,7 @@ def _assert_sweep_matches_reference(result: dict[str, Any]) -> None:
     # The sweep is called with ascending frequencies in Hz (f = c / λ);
     # derive them back from the returned canonical wavelengths.
     frequencies = _SPEED_OF_LIGHT_UM_PER_S / wavelengths
-    expected = resonator_test_chip_python_model(f=frequencies)
+    expected = expected_model(f=frequencies)
     zero = np.zeros(len(wavelengths), dtype=complex)
     simulated_keys = {tuple(key.split(",")) for key in sdict}
 
@@ -258,6 +353,78 @@ def test_resonator_test_chip_mosaic_sax_simulation(
     _assert_sweep_matches_reference(result)
 
 
+@pytest.mark.gfp
+def test_mosaic_hierarchical_subcircuit_simulation(
+    mosaic_hierarchy_root: Path,
+) -> None:
+    """Simulate a ``.gsch`` instantiated from another ``.gsch`` (subcircuit).
+
+    The Mosaic netlist builder resolves subcircuits recursively: a
+    device's ``model`` may name another schematic's project-relative id,
+    whose own netlist is composed into the parent by SAX. The
+    subcircuit here is a transparent port feed-through around the chip,
+    so the top-level S-parameters must still equal the reference model.
+    """
+    result = sax_sim.simulate_mosaic_sax(
+        str(mosaic_hierarchy_root / "top.gsch"),
+        "qpdk.PDK",
+        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
+        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
+        wl_num=3,
+        project_root=str(mosaic_hierarchy_root),
+        sweep_frequency=True,
+    )
+    _assert_sweep_matches_reference(result)
+
+
+@pytest.mark.gfp
+def test_mosaic_instance_props_reach_model(mosaic_project_root: Path) -> None:
+    """Instance ``props`` override model settings in the schematic pipeline.
+
+    A schematic-tuned chip (``resonator_length`` set on the instance)
+    must simulate as the reference model called with that setting, and
+    must differ from the default-settings result — the second assertion
+    keeps this test from passing vacuously if the pipeline ever drops
+    instance props.
+    """
+    result = sax_sim.simulate_mosaic_sax(
+        str(mosaic_project_root / _TUNED_GSCH_NAME),
+        "qpdk.PDK",
+        wl_min=_SPEED_OF_LIGHT_UM_PER_S / 10e9,
+        wl_max=_SPEED_OF_LIGHT_UM_PER_S / 4e9,
+        wl_num=3,
+        project_root=str(mosaic_project_root),
+        sweep_frequency=True,
+    )
+    _assert_sweep_matches_reference(
+        result,
+        expected_model=lambda f: resonator_test_chip_python_model(
+            resonator_length=_TUNED_RESONATOR_LENGTH, f=f
+        ),
+    )
+
+    # Anti-vacuity: the tuned sweep must not equal the default sweep.
+    wavelengths = np.asarray(result["wavelengths"], dtype=float)
+    frequencies = _SPEED_OF_LIGHT_UM_PER_S / wavelengths
+    default = resonator_test_chip_python_model(f=frequencies)
+    zero = np.zeros(len(wavelengths), dtype=complex)
+    differs_from_default = False
+    for key in set(default):
+        entry = result["sdict"].get(f"{key[0]},{key[1]}")
+        actual = (
+            zero
+            if entry is None  # near-zero terms may be dropped
+            else np.asarray(entry["real"]) + 1j * np.asarray(entry["imag"])
+        )
+        if not np.allclose(actual, default[key], rtol=1e-6, atol=1e-6):
+            differs_from_default = True
+            break
+    assert differs_from_default, (
+        "tuned instance simulated identically to the default settings — "
+        "instance props may have been dropped by the pipeline"
+    )
+
+
 def _cells_no_model_expected() -> set[str]:
     """Read the SAX-model exemptions from ``pyproject.toml``."""
     pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
@@ -319,33 +486,45 @@ def test_pdk_model_accepts_f_in_hz(model_name: str, model: Callable) -> None:
     ``name = "f"``), so ``sax.circuit`` calls each model with ``f=`` in
     Hz and no other arguments beyond instance settings. Models that
     cannot be called this way break every v2 SAX simulation that uses
-    them.
+    them. A model failing this contract must be fixed or explicitly
+    added to ``_F_CONTRACT_EXEMPT`` — skipping on contract violations
+    would let regressions pass silently.
+
+    Raises:
+        AssertionError: Unreachable; ``pytest.fail`` always raises first.
     """
+    if model_name in _F_CONTRACT_EXEMPT:
+        pytest.skip(f"{model_name} is exempt from the f-in-Hz contract")
+
     try:
         parameters = inspect.signature(model).parameters
     except (TypeError, ValueError) as exc:
-        pytest.skip(f"{model_name} has no inspectable signature: {exc}")
-    else:
-        if "f" not in parameters:
-            pytest.skip(f"{model_name} does not take an 'f' parameter")
-        required_beyond_f = [
-            name
-            for name, parameter in parameters.items()
-            if name != "f"
-            and parameter.default is inspect.Parameter.empty
-            and parameter.kind
-            in {
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY,
-            }
-        ]
-        if required_beyond_f:
-            pytest.skip(f"{model_name} requires {required_beyond_f} without defaults")
+        pytest.fail(f"{model_name} has no inspectable signature: {exc}")
+        raise AssertionError("unreachable") from None  # pytest.fail always raises
+    if "f" not in parameters:
+        pytest.fail(f"{model_name} does not take an 'f' parameter")
+    required_beyond_f = [
+        name
+        for name, parameter in parameters.items()
+        if name != "f"
+        and parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+    ]
+    if required_beyond_f:
+        pytest.fail(
+            f"{model_name} requires {required_beyond_f} without defaults; "
+            "it cannot be swept by sax.circuit — fix the model or exempt it "
+            "in _F_CONTRACT_EXEMPT"
+        )
 
-        s_params = model(f=np.linspace(_F_MIN_HZ, _F_MAX_HZ, 3))
+    s_params = model(f=np.linspace(_F_MIN_HZ, _F_MAX_HZ, 3))
 
-        assert isinstance(s_params, dict), f"{model_name} returned {type(s_params)}"
-        assert s_params, f"{model_name} returned an empty S-parameter dict"
-        for key, value in s_params.items():
-            arr = np.broadcast_to(np.asarray(value, dtype=complex), (3,))
-            assert np.isfinite(arr).all(), f"{model_name} S[{key}] is not finite"
+    assert isinstance(s_params, dict), f"{model_name} returned {type(s_params)}"
+    assert s_params, f"{model_name} returned an empty S-parameter dict"
+    for key, value in s_params.items():
+        arr = np.broadcast_to(np.asarray(value, dtype=complex), (3,))
+        assert np.isfinite(arr).all(), f"{model_name} S[{key}] is not finite"

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -11,10 +11,6 @@ this PDK:
   ``.pic.yml`` sample factories; the server exposes Python factories via
   ``listFactories``.
 - Nyanlib generation: server startup writes ``build/models.nyanlib``.
-- Component picker: ``gdsfactoryplus.component_picker``/``get_component``
-  resolves qpdk cells; ``get_component`` also default-constructs the full
-  ``PDK.cells`` registry (skipping cells with required parameters), the
-  per-cell build sweep that ``gfp test`` did in gdsfactoryplus v1.
 
 The tests need the ``gfp`` binary, which is not pip-installable. Discovery:
 ``GFP_BIN`` environment variable, then ``gfp`` on ``PATH``. When the binary
@@ -27,8 +23,6 @@ tests keep their skip.
 
 from __future__ import annotations
 
-import functools
-import inspect
 import json
 import os
 import shutil
@@ -42,14 +36,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conftest import import_gfp_module
-
-from qpdk import PDK
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Generator
-    from types import ModuleType
-    from typing import Any
+    from collections.abc import Generator
 
 #: qpdk repository root (parent of ``tests/``).
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -66,10 +55,6 @@ NYANLIB_SPOT_CHECKS = (
     "models:qpdk.cells.resonator.quarter_wave_resonator_coupled",
     "models:qpdk.cells.transmon.double_pad_transmon",
 )
-
-#: Environment variable that makes ``component_picker`` return its default
-#: deterministically (docs builds) instead of building an ipywidgets picker.
-DOCS_ENV = "SIMULATION_TEMPLATES_DOCS"
 
 
 # ---------------------------------------------------------------------------
@@ -396,107 +381,3 @@ def test_gfp_stats_subprocess(gfp_bin: str) -> None:
         assert f'"name":"{factory_name}"' in result.stderr, (
             f"pic.yml factory {factory_name!r} not discovered by gfp stats"
         )
-
-
-@pytest.mark.gfp
-def test_component_picker_docs_mode(monkeypatch: pytest.MonkeyPatch) -> None:
-    """component_picker returns the default deterministically in docs mode."""
-    gfp = import_gfp_module("gdsfactoryplus")
-    monkeypatch.setenv(DOCS_ENV, "1")
-
-    cell_names = list(PDK.cells)
-    selected = gfp.component_picker("double_pad_transmon", cell_names)
-    assert selected == "double_pad_transmon"
-
-    with pytest.raises(ValueError, match=r"not in pdk\.cells"):
-        gfp.component_picker("not_a_qpdk_cell", cell_names)
-
-
-@pytest.mark.gfp
-def test_component_picker_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Without the docs env var, component_picker builds an ipywidgets picker."""
-    gfp = import_gfp_module("gdsfactoryplus")
-    import_gfp_module("ipywidgets")  # skips when ipywidgets is not installed
-    monkeypatch.delenv(DOCS_ENV, raising=False)
-
-    picker = gfp.component_picker("double_pad_transmon", ["double_pad_transmon"])
-    assert picker.value == "double_pad_transmon"
-    assert list(picker.options) == ["double_pad_transmon"]
-
-
-@pytest.mark.gfp
-def test_get_component_builds_qpdk_cells(gfp_sdk: ModuleType) -> None:
-    """get_component instantiates the picked qpdk cell."""
-    for cell_name in ("double_pad_transmon", "quarter_wave_resonator_coupled"):
-        component = gfp_sdk.get_component(cell_name, cell_name)
-        # Instantiated cells carry hashed parameter suffixes in their name.
-        assert component.name.startswith(cell_name)
-
-
-def _base_cell_name(cell: Callable[..., Any], default: str) -> str:
-    """Name of the underlying factory behind a registered cell.
-
-    ``PDK.cells`` may map a registry key to a partial or an alias (e.g.
-    ``straight_shorted = straight``), whose built components are named after
-    the underlying function instead of the registry key.
-
-    Args:
-        cell: The registered cell factory.
-        default: Name to return when the factory exposes no ``__name__``.
-
-    Returns:
-        The ``__name__`` of the unwrapped factory, or ``default``.
-    """
-    obj: Any = cell
-    while isinstance(obj, functools.partial):
-        obj = obj.func
-    return getattr(obj, "__name__", "") or default
-
-
-@pytest.mark.gfp
-@pytest.mark.parametrize("cell_name", sorted(PDK.cells))
-def test_get_component_builds_all_qpdk_cells(
-    gfp_sdk: ModuleType, cell_name: str
-) -> None:
-    """get_component default-constructs every registered qpdk cell.
-
-    Per-cell build sweep through the gfp registry path, mirroring the
-    ``gfp test`` behavior of gdsfactoryplus v1: cells whose signature has
-    required (default-less) parameters cannot be built with defaults and are
-    skipped. If the signature cannot be inspected, the build is attempted
-    rather than skipping blindly. Built components carry hashed parameter
-    suffixes in their name; partial/alias registry entries are named after
-    their underlying factory, so the name is checked against that.
-
-    Args:
-        gfp_sdk: The gdsfactoryplus SDK top-level module.
-        cell_name: Name of the qpdk cell to instantiate.
-    """
-    try:
-        signature = inspect.signature(PDK.cells[cell_name])
-    except (TypeError, ValueError):
-        required: list[str] = []
-    else:
-        required = [
-            param.name
-            for param in signature.parameters.values()
-            if param.default is inspect.Parameter.empty
-            and param.kind
-            in {
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.KEYWORD_ONLY,
-            }
-        ]
-    if required:
-        pytest.skip(
-            f"cell cannot be default-constructed: requires {', '.join(required)}"
-        )
-
-    component = gfp_sdk.get_component(cell_name, cell_name)
-    base_name = _base_cell_name(
-        PDK.cells[cell_name], cell_name.rsplit(".", maxsplit=1)[-1]
-    )
-    assert component.name.startswith(base_name), (
-        f"{cell_name!r} built a component named {component.name!r}"
-    )

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -13,12 +13,13 @@ this PDK:
 - Nyanlib generation: server startup writes ``build/models.nyanlib``.
 
 The tests need the ``gfp`` binary, which is not pip-installable. Discovery:
-``GFP_BIN`` environment variable, then ``gfp`` on ``PATH``. When the binary
-is missing (or non-functional) these tests skip — even under
-``GFP_REQUIRED=1``. ``GFP_REQUIRED=1`` (as set in the gfp CI jobs) still
-turns the "package absent" and "v2 API missing" skips from
-``conftest.import_gfp_module`` into failures; only the binary-dependent
-tests keep their skip.
+``GFP_BIN`` environment variable, then ``gfp`` on ``PATH``. A missing or
+non-functional binary skips in local runs but fails under ``GFP_REQUIRED=1``
+(the gfp CI job provisions the binary via ``just fetch-gfp``, so absence
+there means a broken setup — otherwise CI could pass with the server
+coverage silently gone). ``GFP_REQUIRED=1`` likewise turns the "package
+absent" and "v2 API missing" skips from ``conftest.import_gfp_module``
+into failures.
 """
 
 from __future__ import annotations
@@ -37,6 +38,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
+from conftest import GFP_REQUIRED_ENV
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -176,20 +178,26 @@ class GfpServer:
 def _find_gfp_binary() -> str:
     """Locate the ``gfp`` binary (GFP_BIN env var, else ``gfp`` on PATH).
 
-    The binary is not pip-installable, so a missing (or non-functional)
-    binary always skips — even under ``GFP_REQUIRED=1``; only the Python
-    package and its v2 API are required by that policy (see conftest).
+    The binary is not pip-installable: a missing binary skips in local
+    runs but fails under ``GFP_REQUIRED=1`` (see the module docstring).
 
     Returns:
         Path to the ``gfp`` binary.
 
     Raises:
-        AssertionError: Unreachable; ``pytest.skip`` always raises before this.
+        AssertionError: Unreachable; ``pytest.skip``/``pytest.fail`` always
+            raise before this.
     """
     if env := os.environ.get("GFP_BIN"):
         return str(Path(env).resolve())
     if path := shutil.which("gfp"):
         return path
+    if os.environ.get(GFP_REQUIRED_ENV) == "1":
+        pytest.fail(
+            "gfp binary not found (set GFP_BIN or put gfp on PATH) — "
+            "GFP_REQUIRED=1 requires one; run `just fetch-gfp` and source "
+            "build/gfp-vsix/env.sh"
+        )
     pytest.skip("gfp binary not found (set GFP_BIN or put gfp on PATH)")
     raise AssertionError("unreachable")
 
@@ -293,13 +301,26 @@ def spawn_gfp_server(
 
 @pytest.fixture(scope="session")
 def gfp_bin() -> str:
-    """Path to a functional ``gfp`` binary, discovered or skipped."""
+    """Path to a functional ``gfp`` binary, discovered or skipped.
+
+    A non-functional binary skips in local runs but fails under
+    ``GFP_REQUIRED=1`` (see the module docstring).
+
+    Returns:
+        Path to a functional ``gfp`` binary.
+    """
     binary = _find_gfp_binary()
     try:
         subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
             [binary, "hello"], capture_output=True, timeout=10, check=True
         )
     except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        if os.environ.get(GFP_REQUIRED_ENV) == "1":
+            pytest.fail(
+                f"gfp binary at {binary} is not functional — GFP_REQUIRED=1 "
+                "requires one; run `just fetch-gfp` and source "
+                "build/gfp-vsix/env.sh"
+            )
         pytest.skip(f"gfp binary at {binary} is not functional")
     return binary
 

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import shutil
 import signal
 import socket
@@ -42,6 +43,14 @@ if TYPE_CHECKING:
 
 #: qpdk repository root (parent of ``tests/``).
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+#: Sentinel the stdout reader thread enqueues at EOF.
+_EOF = object()
+
+# Server tests share one ``gfp serve`` instance and the repository's
+# ``build/`` directory, so they must never be split across xdist workers;
+# run the suite with ``--dist loadgroup`` (test-gfp does).
+pytestmark = pytest.mark.xdist_group("gfp-server")
 
 #: ``.pic.yml`` factories that indexing must discover from ``qpdk/samples/``.
 PIC_YAML_FACTORIES = (
@@ -64,11 +73,26 @@ NYANLIB_SPOT_CHECKS = (
 
 @dataclass
 class StdioRpc:
-    """Content-Length framed JSON-RPC 2.0 client over stdin/stdout."""
+    """Content-Length framed JSON-RPC 2.0 client over stdin/stdout.
+
+    A daemon reader thread parses framed messages off the server's
+    stdout into a queue, so every wait enforces its own timeout. Direct
+    blocking ``readline`` calls could hang the harness forever when the
+    server stops emitting a full frame.
+    """
 
     proc: subprocess.Popen
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _id: int = field(default=0)
+    _messages: queue.Queue = field(default_factory=queue.Queue)
+    _reader: threading.Thread = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Start the daemon reader thread pumping stdout into the queue."""
+        self._reader = threading.Thread(
+            target=self._pump_stdout, name="gfp-rpc-reader", daemon=True
+        )
+        self._reader.start()
 
     def call(
         self, method: str, params: dict | None = None, timeout: float = 60
@@ -83,7 +107,27 @@ class StdioRpc:
             body = json.dumps(msg).encode()
             frame = f"Content-Length: {len(body)}\r\n\r\n".encode() + body
             self._write(frame)
-            return self._read_response(req_id, timeout)
+            deadline = time.monotonic() + timeout
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    error = f"Timed out waiting for response to request {req_id}"
+                    raise TimeoutError(error)
+                try:
+                    incoming = self._messages.get(timeout=remaining)
+                except queue.Empty:
+                    error = f"Timed out waiting for response to request {req_id}"
+                    raise TimeoutError(error) from None
+                if incoming is _EOF:
+                    error = (
+                        f"gfp server closed its stdout before responding "
+                        f"to request {req_id}"
+                    )
+                    raise EOFError(error)
+                # Calls are serialized by _lock, so anything else is a
+                # stale response or a server notification; drop it.
+                if incoming.get("id") == req_id:
+                    return incoming
 
     def _write(self, data: bytes) -> None:
         stdin = self.proc.stdin
@@ -91,58 +135,32 @@ class StdioRpc:
         stdin.write(data)
         stdin.flush()
 
-    def _readline(self) -> bytes:
+    def _pump_stdout(self) -> None:
+        """Read framed JSON-RPC messages from stdout until EOF (daemon thread)."""
         stdout = self.proc.stdout
         assert stdout is not None  # spawned with stdout=PIPE
-        return stdout.readline()
-
-    def _read(self, n: int) -> bytes:
-        stdout = self.proc.stdout
-        assert stdout is not None  # spawned with stdout=PIPE
-        return stdout.read(n)
-
-    def _read_response(self, req_id: int, timeout: float) -> dict:
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            content_length = self._read_header(deadline)
-            if content_length is None:
-                msg = f"Timed out reading response for request {req_id}"
-                raise TimeoutError(msg)
-            raw = self._read_exact(content_length, deadline)
-            if raw is None:
-                msg = f"Timed out reading body for request {req_id}"
-                raise TimeoutError(msg)
-            resp = json.loads(raw)
-            if resp.get("id") == req_id:
-                return resp
-        msg = f"Timed out waiting for response to request {req_id}"
-        raise TimeoutError(msg)
-
-    def _read_header(self, deadline: float) -> int | None:
-        content_length = None
         while True:
-            if time.monotonic() >= deadline:
-                return None
-            line = self._readline()
-            if not line:
-                return None
-            text = line.decode().strip()
-            if not text:
-                break
-            if text.lower().startswith("content-length:"):
-                content_length = int(text.split(":", 1)[1].strip())
-        return content_length
-
-    def _read_exact(self, n: int, deadline: float) -> bytes | None:
-        buf = b""
-        while len(buf) < n:
-            if time.monotonic() >= deadline:
-                return None
-            chunk = self._read(n - len(buf))
-            if not chunk:
-                return None
-            buf += chunk
-        return buf
+            content_length = 0
+            saw_header = False
+            while line := stdout.readline():
+                text = line.decode(errors="replace").strip()
+                if not text:
+                    break  # blank line ends the header block
+                if text.lower().startswith("content-length:"):
+                    content_length = int(text.split(":", 1)[1].strip())
+                    saw_header = True
+            else:
+                break  # EOF between frames
+            if not saw_header:
+                continue
+            body = stdout.read(content_length)
+            if len(body) < content_length:
+                break  # EOF mid-frame
+            try:
+                self._messages.put(json.loads(body))
+            except json.JSONDecodeError:
+                continue  # skip malformed frames; the request will time out
+        self._messages.put(_EOF)
 
 
 @dataclass
@@ -202,14 +220,18 @@ def spawn_gfp_server(
         "w", encoding="utf-8"
     )
 
-    port = _free_port()
-    proc = subprocess.Popen(  # ruff: ignore[subprocess-without-shell-equals-true]
-        [gfp_bin, "serve", "--port", str(port)],
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=log_file,
-        cwd=str(project_root),
-    )
+    try:
+        port = _free_port()
+        proc = subprocess.Popen(  # ruff: ignore[subprocess-without-shell-equals-true]
+            [gfp_bin, "serve", "--port", str(port)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=log_file,
+            cwd=str(project_root),
+        )
+    except BaseException:
+        log_file.close()
+        raise
 
     rpc = StdioRpc(proc)
     deadline = time.monotonic() + startup_timeout
@@ -222,7 +244,10 @@ def spawn_gfp_server(
                 and result.get("index_error") is None
             ):
                 break
-        except (TimeoutError, OSError, json.JSONDecodeError):
+        except (EOFError, TimeoutError, OSError, json.JSONDecodeError):
+            # Not ready yet (server still booting or a frame not yet
+            # parseable): retry until the deadline. The poll() check below
+            # turns an early server exit into a proper failure.
             pass
         if proc.poll() is not None:
             log_file.close()

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -12,7 +12,9 @@ this PDK:
   ``listFactories``.
 - Nyanlib generation: server startup writes ``build/models.nyanlib``.
 - Component picker: ``gdsfactoryplus.component_picker``/``get_component``
-  resolve qpdk cells.
+  resolves qpdk cells; ``get_component`` also default-constructs the full
+  ``PDK.cells`` registry (skipping cells with required parameters), the
+  per-cell build sweep that ``gfp test`` did in gdsfactoryplus v1.
 
 The tests need the ``gfp`` binary, which is not pip-installable. Discovery:
 ``GFP_BIN`` environment variable, then ``gfp`` on ``PATH``. When the binary
@@ -25,6 +27,8 @@ tests keep their skip.
 
 from __future__ import annotations
 
+import functools
+import inspect
 import json
 import os
 import shutil
@@ -43,8 +47,9 @@ from conftest import import_gfp_module
 from qpdk import PDK
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable, Generator
     from types import ModuleType
+    from typing import Any
 
 #: qpdk repository root (parent of ``tests/``).
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -426,3 +431,72 @@ def test_get_component_builds_qpdk_cells(gfp_sdk: ModuleType) -> None:
         component = gfp_sdk.get_component(cell_name, cell_name)
         # Instantiated cells carry hashed parameter suffixes in their name.
         assert component.name.startswith(cell_name)
+
+
+def _base_cell_name(cell: Callable[..., Any], default: str) -> str:
+    """Name of the underlying factory behind a registered cell.
+
+    ``PDK.cells`` may map a registry key to a partial or an alias (e.g.
+    ``straight_shorted = straight``), whose built components are named after
+    the underlying function instead of the registry key.
+
+    Args:
+        cell: The registered cell factory.
+        default: Name to return when the factory exposes no ``__name__``.
+
+    Returns:
+        The ``__name__`` of the unwrapped factory, or ``default``.
+    """
+    obj: Any = cell
+    while isinstance(obj, functools.partial):
+        obj = obj.func
+    return getattr(obj, "__name__", "") or default
+
+
+@pytest.mark.gfp
+@pytest.mark.parametrize("cell_name", sorted(PDK.cells))
+def test_get_component_builds_all_qpdk_cells(
+    gfp_sdk: ModuleType, cell_name: str
+) -> None:
+    """get_component default-constructs every registered qpdk cell.
+
+    Per-cell build sweep through the gfp registry path, mirroring the
+    ``gfp test`` behavior of gdsfactoryplus v1: cells whose signature has
+    required (default-less) parameters cannot be built with defaults and are
+    skipped. If the signature cannot be inspected, the build is attempted
+    rather than skipping blindly. Built components carry hashed parameter
+    suffixes in their name; partial/alias registry entries are named after
+    their underlying factory, so the name is checked against that.
+
+    Args:
+        gfp_sdk: The gdsfactoryplus SDK top-level module.
+        cell_name: Name of the qpdk cell to instantiate.
+    """
+    try:
+        signature = inspect.signature(PDK.cells[cell_name])
+    except (TypeError, ValueError):
+        required: list[str] = []
+    else:
+        required = [
+            param.name
+            for param in signature.parameters.values()
+            if param.default is inspect.Parameter.empty
+            and param.kind
+            in {
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            }
+        ]
+    if required:
+        pytest.skip(
+            f"cell cannot be default-constructed: requires {', '.join(required)}"
+        )
+
+    component = gfp_sdk.get_component(cell_name, cell_name)
+    base_name = _base_cell_name(
+        PDK.cells[cell_name], cell_name.rsplit(".", maxsplit=1)[-1]
+    )
+    assert component.name.startswith(base_name), (
+        f"{cell_name!r} built a component named {component.name!r}"
+    )

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -1,0 +1,428 @@
+"""Server-side integration tests for gdsfactoryplus v2 (the ``gfp`` server).
+
+Covers the server-side integration surface of gdsfactoryplus 2.0.0 against
+this PDK:
+
+- Settings loading: the server loads ``[tool.gdsfactoryplus]`` from the
+  project ``pyproject.toml`` and serves it over the ``getSettings`` RPC
+  (the Python SDK ``gdsfactoryplus.settings.get_settings()`` only reads
+  defaults, so it is intentionally not used here).
+- Indexing: ``gfp stats``/``gfp index`` discovers qpdk cells and the
+  ``.pic.yml`` sample factories; the server exposes Python factories via
+  ``listFactories``.
+- Nyanlib generation: server startup writes ``build/models.nyanlib``.
+- Component picker: ``gdsfactoryplus.component_picker``/``get_component``
+  resolve qpdk cells.
+
+The tests need the ``gfp`` binary, which is not pip-installable. Discovery:
+``GFP_BIN`` environment variable, then ``gfp`` on ``PATH``. When the binary
+is missing (or non-functional) these tests skip — even under
+``GFP_REQUIRED=1``. ``GFP_REQUIRED=1`` (as set in the gfp CI jobs) still
+turns the "package absent" and "v2 API missing" skips from
+``conftest.import_gfp_module`` into failures; only the binary-dependent
+tests keep their skip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from conftest import import_gfp_module
+
+from qpdk import PDK
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from types import ModuleType
+
+#: qpdk repository root (parent of ``tests/``).
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+#: ``.pic.yml`` factories that indexing must discover from ``qpdk/samples/``.
+PIC_YAML_FACTORIES = (
+    "qubit_test_chip",
+    "flipmon_test_chip",
+    "resonator_test_chip_yaml",
+)
+
+#: Well-known qpdk cells that must appear in the generated nyanlib.
+NYANLIB_SPOT_CHECKS = (
+    "models:qpdk.cells.resonator.quarter_wave_resonator_coupled",
+    "models:qpdk.cells.transmon.double_pad_transmon",
+)
+
+#: Environment variable that makes ``component_picker`` return its default
+#: deterministically (docs builds) instead of building an ipywidgets picker.
+DOCS_ENV = "SIMULATION_TEMPLATES_DOCS"
+
+
+# ---------------------------------------------------------------------------
+# Minimal stdio JSON-RPC harness (adapted from the gfp integration tests)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StdioRpc:
+    """Content-Length framed JSON-RPC 2.0 client over stdin/stdout."""
+
+    proc: subprocess.Popen
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _id: int = field(default=0)
+
+    def call(
+        self, method: str, params: dict | None = None, timeout: float = 60
+    ) -> dict:
+        """Send a JSON-RPC request and return the matching response object."""
+        with self._lock:
+            self._id += 1
+            req_id = self._id
+            msg: dict = {"jsonrpc": "2.0", "id": req_id, "method": method}
+            if params is not None:
+                msg["params"] = params
+            body = json.dumps(msg).encode()
+            frame = f"Content-Length: {len(body)}\r\n\r\n".encode() + body
+            self._write(frame)
+            return self._read_response(req_id, timeout)
+
+    def _write(self, data: bytes) -> None:
+        stdin = self.proc.stdin
+        assert stdin is not None  # spawned with stdin=PIPE
+        stdin.write(data)
+        stdin.flush()
+
+    def _readline(self) -> bytes:
+        stdout = self.proc.stdout
+        assert stdout is not None  # spawned with stdout=PIPE
+        return stdout.readline()
+
+    def _read(self, n: int) -> bytes:
+        stdout = self.proc.stdout
+        assert stdout is not None  # spawned with stdout=PIPE
+        return stdout.read(n)
+
+    def _read_response(self, req_id: int, timeout: float) -> dict:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            content_length = self._read_header(deadline)
+            if content_length is None:
+                msg = f"Timed out reading response for request {req_id}"
+                raise TimeoutError(msg)
+            raw = self._read_exact(content_length, deadline)
+            if raw is None:
+                msg = f"Timed out reading body for request {req_id}"
+                raise TimeoutError(msg)
+            resp = json.loads(raw)
+            if resp.get("id") == req_id:
+                return resp
+        msg = f"Timed out waiting for response to request {req_id}"
+        raise TimeoutError(msg)
+
+    def _read_header(self, deadline: float) -> int | None:
+        content_length = None
+        while True:
+            if time.monotonic() >= deadline:
+                return None
+            line = self._readline()
+            if not line:
+                return None
+            text = line.decode().strip()
+            if not text:
+                break
+            if text.lower().startswith("content-length:"):
+                content_length = int(text.split(":", 1)[1].strip())
+        return content_length
+
+    def _read_exact(self, n: int, deadline: float) -> bytes | None:
+        buf = b""
+        while len(buf) < n:
+            if time.monotonic() >= deadline:
+                return None
+            chunk = self._read(n - len(buf))
+            if not chunk:
+                return None
+            buf += chunk
+        return buf
+
+
+@dataclass
+class GfpServer:
+    """A running ``gfp serve`` process against the qpdk project."""
+
+    rpc: StdioRpc
+    process: subprocess.Popen
+    project_root: Path
+    log_path: Path
+
+
+def _find_gfp_binary() -> str:
+    """Locate the ``gfp`` binary (GFP_BIN env var, else ``gfp`` on PATH).
+
+    The binary is not pip-installable, so a missing (or non-functional)
+    binary always skips — even under ``GFP_REQUIRED=1``; only the Python
+    package and its v2 API are required by that policy (see conftest).
+
+    Returns:
+        Path to the ``gfp`` binary.
+
+    Raises:
+        AssertionError: Unreachable; ``pytest.skip`` always raises before this.
+    """
+    if env := os.environ.get("GFP_BIN"):
+        return str(Path(env).resolve())
+    if path := shutil.which("gfp"):
+        return path
+    pytest.skip("gfp binary not found (set GFP_BIN or put gfp on PATH)")
+    raise AssertionError("unreachable")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def spawn_gfp_server(
+    gfp_bin: str, project_root: Path, startup_timeout: float = 300
+) -> Generator[GfpServer, None, None]:
+    """Spawn ``gfp serve`` against a project root and wait until it is ready.
+
+    Ready means the server's own startup signals have settled: ``indexing``
+    false and ``nyanlib_generating`` false in ``getInfo`` — at that point the
+    startup nyanlib cycle has published ``build/models.nyanlib``.
+
+    Yields:
+        GfpServer: the running server with a ready stdio RPC client.
+
+    """
+    log_path = project_root / "build" / "test-gfp-serve.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    log_file = Path(log_path).open(  # ruff: ignore[open-file-with-context-handler]
+        "w", encoding="utf-8"
+    )
+
+    port = _free_port()
+    proc = subprocess.Popen(  # ruff: ignore[subprocess-without-shell-equals-true]
+        [gfp_bin, "serve", "--port", str(port)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=log_file,
+        cwd=str(project_root),
+    )
+
+    rpc = StdioRpc(proc)
+    deadline = time.monotonic() + startup_timeout
+    while time.monotonic() < deadline:
+        try:
+            result = rpc.call("getInfo", {}, timeout=30).get("result", {})
+            if (
+                not result.get("indexing", True)
+                and not result.get("nyanlib_generating", True)
+                and result.get("index_error") is None
+            ):
+                break
+        except (TimeoutError, OSError, json.JSONDecodeError):
+            pass
+        if proc.poll() is not None:
+            log_file.close()
+            pytest.fail(
+                f"gfp serve exited with code {proc.returncode} before becoming ready. "
+                f"See {log_path}"
+            )
+        time.sleep(2)
+    else:
+        proc.terminate()
+        proc.wait(timeout=5)
+        log_file.close()
+        pytest.fail(
+            f"gfp serve did not become ready within {startup_timeout}s. See {log_path}"
+        )
+
+    yield GfpServer(rpc=rpc, process=proc, project_root=project_root, log_path=log_path)
+
+    if proc.stdin:
+        proc.stdin.close()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    log_file.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def gfp_bin() -> str:
+    """Path to a functional ``gfp`` binary, discovered or skipped."""
+    binary = _find_gfp_binary()
+    try:
+        subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+            [binary, "hello"], capture_output=True, timeout=10, check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pytest.skip(f"gfp binary at {binary} is not functional")
+    return binary
+
+
+@pytest.fixture(scope="session")
+def gfp_server(gfp_bin: str) -> Generator[GfpServer, None, None]:
+    """One ``gfp serve`` instance shared by all server tests in this module.
+
+    Deletes ``build/models.nyanlib`` first so the startup nyanlib generation
+    cycle actually runs (the server republishes it before reporting ready).
+
+    Yields:
+        GfpServer: the running server, ready for RPC calls.
+
+    """
+    nyanlib_path = PROJECT_ROOT / "build" / "models.nyanlib"
+    if nyanlib_path.exists():
+        nyanlib_path.unlink()
+
+    yield from spawn_gfp_server(gfp_bin, PROJECT_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gfp
+def test_settings_snapshot_from_server(gfp_server: GfpServer) -> None:
+    """The server merges [tool.gdsfactoryplus] from pyproject.toml into getSettings."""
+    resp = gfp_server.rpc.call("getSettings", {}, timeout=30)
+    assert "result" in resp, f"getSettings failed: {resp}"
+    settings = resp["result"]
+
+    assert settings["name"] == "qpdk"
+    assert settings["pdk"]["name"] == "qpdk"
+    assert settings["drc"]["pdk"] == "quantum_rf"
+    assert settings["drc"]["timeout"] == 300
+    assert settings["sim"]["x"]["name"] == "f"
+    assert settings["sim"]["x"]["min"] == 1
+    assert settings["sim"]["x"]["max"] == 15
+    assert settings["sim"]["x"]["num"] == 4001
+    assert settings["sim"]["x"]["unit"] == "GHz"
+    assert settings["livewire"]["has_vias"] is False
+
+
+@pytest.mark.gfp
+def test_nyanlib_generated_at_startup(gfp_server: GfpServer) -> None:
+    """Server startup publishes a non-empty models.nyanlib with qpdk cells."""
+    nyanlib_path = gfp_server.project_root / "build" / "models.nyanlib"
+    assert nyanlib_path.is_file(), (
+        f"server reported startup complete but {nyanlib_path} is missing. "
+        f"See {gfp_server.log_path}"
+    )
+    assert nyanlib_path.stat().st_size > 0, (
+        f"server reported startup complete but {nyanlib_path} is empty. "
+        f"See {gfp_server.log_path}"
+    )
+
+    nyanlib = json.loads(nyanlib_path.read_text())
+    assert isinstance(nyanlib, dict)
+    for key in NYANLIB_SPOT_CHECKS:
+        assert key in nyanlib, (
+            f"{key} missing from models.nyanlib; "
+            f"qpdk entries present: {sorted(k for k in nyanlib if '.qpdk.' in k)[:10]}"
+        )
+        assert nyanlib[key].get("name"), f"nyanlib entry {key} has no name"
+
+
+@pytest.mark.gfp
+def test_server_indexes_qpdk_cells(gfp_server: GfpServer) -> None:
+    """ListFactories exposes indexed qpdk Python factories."""
+    resp = gfp_server.rpc.call("listFactories", {}, timeout=120)
+    assert "result" in resp, f"listFactories failed: {resp}"
+    qualified_names = [
+        factory.get("qualified_name") for factory in resp["result"]["factories"]
+    ]
+    for expected in (
+        "qpdk.cells.transmon.double_pad_transmon",
+        "qpdk.cells.resonator.quarter_wave_resonator_coupled",
+    ):
+        assert qualified_names.count(expected) >= 1, (
+            f"{expected} not indexed; sample of indexed names: "
+            f"{[n for n in qualified_names if n and '.qpdk.' in n][:10]}"
+        )
+
+
+@pytest.mark.gfp
+def test_gfp_stats_subprocess(gfp_bin: str) -> None:
+    """``gfp stats`` succeeds, indexes qpdk and discovers the pic.yml factories."""
+    result = subprocess.run(  # ruff: ignore[subprocess-without-shell-equals-true]
+        [gfp_bin, "--cwd", str(PROJECT_ROOT), "stats"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"gfp stats failed (rc={result.returncode}).\nstdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr[-2000:]}"
+    )
+
+    # Index summary lands on stdout; per-factory tracing logs on stderr.
+    assert "Files:" in result.stdout
+    assert "\nqpdk " in result.stdout, (
+        f"qpdk missing from stats library table:\n{result.stdout}"
+    )
+
+    for factory_name in PIC_YAML_FACTORIES:
+        assert f'"name":"{factory_name}"' in result.stderr, (
+            f"pic.yml factory {factory_name!r} not discovered by gfp stats"
+        )
+
+
+@pytest.mark.gfp
+def test_component_picker_docs_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """component_picker returns the default deterministically in docs mode."""
+    gfp = import_gfp_module("gdsfactoryplus")
+    monkeypatch.setenv(DOCS_ENV, "1")
+
+    cell_names = list(PDK.cells)
+    selected = gfp.component_picker("double_pad_transmon", cell_names)
+    assert selected == "double_pad_transmon"
+
+    with pytest.raises(ValueError, match=r"not in pdk\.cells"):
+        gfp.component_picker("not_a_qpdk_cell", cell_names)
+
+
+@pytest.mark.gfp
+def test_component_picker_interactive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the docs env var, component_picker builds an ipywidgets picker."""
+    gfp = import_gfp_module("gdsfactoryplus")
+    import_gfp_module("ipywidgets")  # skips when ipywidgets is not installed
+    monkeypatch.delenv(DOCS_ENV, raising=False)
+
+    picker = gfp.component_picker("double_pad_transmon", ["double_pad_transmon"])
+    assert picker.value == "double_pad_transmon"
+    assert list(picker.options) == ["double_pad_transmon"]
+
+
+@pytest.mark.gfp
+def test_get_component_builds_qpdk_cells(gfp_sdk: ModuleType) -> None:
+    """get_component instantiates the picked qpdk cell."""
+    for cell_name in ("double_pad_transmon", "quarter_wave_resonator_coupled"):
+        component = gfp_sdk.get_component(cell_name, cell_name)
+        # Instantiated cells carry hashed parameter suffixes in their name.
+        assert component.name.startswith(cell_name)

--- a/tests/test_gfp_server.py
+++ b/tests/test_gfp_server.py
@@ -258,7 +258,13 @@ def spawn_gfp_server(
         time.sleep(2)
     else:
         proc.terminate()
-        proc.wait(timeout=5)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            # A wedged server must not mask the startup-timeout failure
+            # below with a TimeoutExpired traceback.
+            proc.kill()
+            proc.wait()
         log_file.close()
         pytest.fail(
             f"gfp serve did not become ready within {startup_timeout}s. See {log_path}"

--- a/tests/test_resonator_test_chip.py
+++ b/tests/test_resonator_test_chip.py
@@ -40,25 +40,6 @@ def test_resonator_test_chip_resolves_in_active_pdk(component_name: str) -> None
     assert {port for key in s_params for port in key} == {"o1", "o2", "o3", "o4"}
 
 
-def test_resonator_test_chip_runs_through_layout_simulation_server() -> None:
-    """Exercise the editor's layout-driven SAX path without a .gsch workaround."""
-    sax_server = pytest.importorskip("gdsfactoryplus.serve.sax")
-    PDK.activate()
-    result = sax_server._run_simulation(
-        "qpdk.samples.resonator_test_chip.resonator_test_chip_python",
-        {
-            # The server API represents 4--10 GHz as wavelengths in µm.
-            "wl_min": 299_792.458 / 10,
-            "wl_max": 299_792.458 / 4,
-            "wl_num": 3,
-            "layout": {},
-        },
-    )
-
-    assert len(result["wavelengths"]) == 3
-    assert set(result["sdict"]) == {"o1", "o2", "o3", "o4"}
-
-
 def test_resonator_test_chip_exposes_launcher_waveports() -> None:
     """Expose both ends of both resonator-test-chip probelines."""
     component = resonator_test_chip_python()

--- a/uv.lock
+++ b/uv.lock
@@ -712,6 +712,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -739,12 +748,48 @@ wheels = [
 ]
 
 [[package]]
+name = "doroutes"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "kfactory" },
+    { name = "kwasm" },
+    { name = "numpy" },
+    { name = "shapely" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/e1/5efc6532956756f27195a2c194a880ae5034f48fe3dae373bfab36140d3a/doroutes-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dacb67a9a5d2f1503033bd7b5694bc994280d388be69da449a5df9ded719e428", size = 3323227, upload-time = "2026-08-28T11:54:34.048Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/92/05a2b16cfb6ef80fc358350f5bd2c937cf99c832e202690368451f337dca/doroutes-1.4.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:457b36b3ee773744d4c8ea306157afc5b96a711e5f831f9414a172e0a0815f16", size = 3532991, upload-time = "2026-08-28T11:54:35.499Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/16/3eb75e3813893b3c0e47d8d5e091bd777480336fb3bc9a305126cb39d16c/doroutes-1.4.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:953aa439c87d691612d8d1b99be11bf425d7b0066461afa60861748218910580", size = 3678953, upload-time = "2026-08-28T11:54:36.926Z" },
+    { url = "https://files.pythonhosted.org/packages/50/82/b8c2f83e3786fca6ee2cb05793ee1b1e3f7029809fac43f8a3aea5917501/doroutes-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:701a734e179a6e0ff09be38fd59ae156eb1b433e1cf88c04818ebae7a2d734ba", size = 3114413, upload-time = "2026-08-28T11:54:38.361Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/d03f5d789f4495ea7cb213521ee2864af5227e70a1adeaedb94384be6014/doroutes-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2af2eaa72eaba2cef2c7a4e5fcfde32729b7a4f318451aee29bd2a184bb1c23b", size = 3323056, upload-time = "2026-08-28T11:54:39.674Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/11608359381310a53c04686b2bc20656c7e025137eddd831b44fb93d3ddd/doroutes-1.4.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1765ff6ad31b8cbcc1d92cf4d6cb1c03666cde73987df1f9f1d4f62e573262ae", size = 3532665, upload-time = "2026-08-28T11:54:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4484f129463a358c07f0333ebec2b5abb171c8a5d3abc8dd8f47b5c7ef73/doroutes-1.4.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c6ea8bfa6bf46a393b4affeb000def0dc9c2245216ae9431a59f0700fc5d8a28", size = 3678740, upload-time = "2026-08-28T11:54:42.629Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/09/c2ca9d26dd6843bdac14604c8863233991b0819af91ba9faf5a8d4f44855/doroutes-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:c4d88c0ee3605d936bfe477ac8f5b438244f3b49bce9d332f5c6b7b7bee56add", size = 3114015, upload-time = "2026-08-28T11:54:43.959Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
+name = "elvis-lvs"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/a7/548a8063588049e5f7b1c1db0e5a6aadc5a5a0d270b8969351d63a7f8bd6/elvis_lvs-0.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4c695edc42177c6ecef39bd1324f29aa24c6ed10cae5ac08be3d789427e6589c", size = 2098456, upload-time = "2026-05-19T10:52:34.448Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c4/5053108c239ec82fa30fbd377795cc3639c2061e280fb7c84221a9d2962c/elvis_lvs-0.2.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8c8876d86fc9b8b870b164122fdef1ce0fd07e8b7c0e29efbcdd9a5ce3bb3e2e", size = 2311378, upload-time = "2026-05-19T10:52:36.417Z" },
+    { url = "https://files.pythonhosted.org/packages/db/cd/675908027918d2c7084e123693fd15d40d299232bcbd8d73e68bf43ee185/elvis_lvs-0.2.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98daac2465ae70ec8bba1d48487f5975929076732faae88c701d86fd3505cd56", size = 2428526, upload-time = "2026-05-19T10:52:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d0/698d8711bd2b01ba996180b23bd905c7f49caa461b314ac7cd4130a4a0b0/elvis_lvs-0.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:b3ec4c6db2b5de51c6e4b232151cd524022490787c01035ca833f2823574a5ea", size = 2038362, upload-time = "2026-05-19T10:52:39.791Z" },
+    { url = "https://files.pythonhosted.org/packages/30/0c/c49254ada90f469dc697a86d80abbd323e7d51b7f47a9f042119bd1ec3b5/elvis_lvs-0.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38aaff4f1d8548d827f1b6fb73cd13442d2b2e1aa23af1035db55f7d3a36d453", size = 2097850, upload-time = "2026-05-19T10:52:41.498Z" },
+    { url = "https://files.pythonhosted.org/packages/24/55/a7f6c8c43da9ede03081bcbd4d6e982e4d5f29ed4c89f8c805930ea7efbb/elvis_lvs-0.2.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:68774f4c62f98e6d6b1d4eac41602c3c732783ba5b039111230ff20c86e82ace", size = 2310903, upload-time = "2026-05-19T10:52:43.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/75/e389d943080146c85813a5cec1621711b4a0aadf8d65f4b3a4470aed7b10/elvis_lvs-0.2.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:754b16d98c260c22f811bc2da3ae0ae7595818db689560b85370952dfbda81dd", size = 2428700, upload-time = "2026-05-19T10:52:44.824Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ee/d629c7f07d8ac7121df650923ab2f41fe7e6808beef9af1ce13fe2a9307c/elvis_lvs-0.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:0a90ee64130bf87c6d86212a1493cdf70deb6429d12514f53d867f28af6db261", size = 2037972, upload-time = "2026-05-19T10:52:46.64Z" },
 ]
 
 [[package]]
@@ -1026,17 +1071,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gdsfactoryplus"
-version = "1.0.18"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/9b/6d2632ee12b673dbf3333a038746b9a894f0a5796281d481d2b6b904bac6/gdsfactoryplus-1.0.18-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:29cd99e7a623fe6f7cb69cff7f587c7e9d30295d92d748ba0fc169351130d59c", size = 5159945, upload-time = "2025-10-22T23:08:16.53Z" },
-    { url = "https://files.pythonhosted.org/packages/92/52/3870c83b060059f603ccef864fa8305c886c18aeffd65451b4a188fbc1d4/gdsfactoryplus-1.0.18-cp312-cp312-manylinux_2_39_aarch64.whl", hash = "sha256:bea5a40fc719b903aa10b4e564a81a0d611db30a55660d8d3ae0d558dfae55e3", size = 11634644, upload-time = "2025-10-22T23:08:19.867Z" },
-    { url = "https://files.pythonhosted.org/packages/37/df/11c0f592f92a8ffcc76d9c16068e036553100b48fcdfdf61f7d2c35e8a01/gdsfactoryplus-1.0.18-cp312-cp312-manylinux_2_39_x86_64.whl", hash = "sha256:9470ec4dcbd65eb6cb7a6e5745d32907e654768ed4d085e9b403c6d1683cd992", size = 12218322, upload-time = "2025-10-22T23:08:21.918Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/6f/8ecf7c2500bc208ead2b32ec9be1b77b916857645b9e32731f3a65a086f3/gdsfactoryplus-1.0.18-cp312-cp312-win_amd64.whl", hash = "sha256:5164e4040a3fdfbd3543c8371c67df94ee05d4215a7be7a318fbbb601640e327", size = 3512825, upload-time = "2025-10-22T23:08:23.827Z" },
-]
-
-[[package]]
 name = "gdstk"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1227,6 +1261,33 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1345,6 +1406,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inspice"
+version = "1.7.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "diskcache" },
+    { name = "h5py" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "ply" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/ec/3a46d31890565fd7f1cee74137b48e037ed11e663538022836c4a2b99c7a/inspice-1.7.0.6.tar.gz", hash = "sha256:a88a78b6cccdd443f850764bbb25b740b370f41e45a4a732bef16dd219e4576b", size = 264610, upload-time = "2026-07-16T13:59:04.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/46/e560116616baf28b6bb2eb83e0719e758410c26fe5eb8b61a456a138ccaf/inspice-1.7.0.6-py3-none-any.whl", hash = "sha256:64e4bb5242703154424d9bb424068682c2d23a2e1d3445c06e32658d674dde52", size = 255224, upload-time = "2026-07-16T13:59:03.041Z" },
 ]
 
 [[package]]
@@ -2871,6 +2950,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
+]
+
+[[package]]
 name = "polars"
 version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3641,8 +3729,13 @@ dependencies = [
 
 [package.optional-dependencies]
 gdsfactoryplus = [
-    { name = "gdsfactoryplus" },
+    { name = "doroutes" },
+    { name = "elvis-lvs" },
     { name = "httpx" },
+    { name = "inspice" },
+    { name = "jaxellip" },
+    { name = "kfnetlist" },
+    { name = "sax" },
 ]
 graphics = [
     { name = "pyglet" },
@@ -3777,12 +3870,16 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "doroutes", marker = "extra == 'gdsfactoryplus'", specifier = ">=1.4.0,<2.0.0" },
+    { name = "elvis-lvs", marker = "extra == 'gdsfactoryplus'" },
     { name = "flax", marker = "extra == 'netket'" },
     { name = "gdsfactory", specifier = ">=9.46,<9.49" },
-    { name = "gdsfactoryplus", marker = "extra == 'gdsfactoryplus'" },
     { name = "gplugins", extras = ["meshwell"], marker = "extra == 'models'", specifier = "~=2.1.0" },
     { name = "httpx", marker = "extra == 'gdsfactoryplus'" },
+    { name = "inspice", marker = "extra == 'gdsfactoryplus'" },
+    { name = "jaxellip", marker = "extra == 'gdsfactoryplus'" },
     { name = "jaxellip", marker = "extra == 'models'" },
+    { name = "kfnetlist", marker = "extra == 'gdsfactoryplus'" },
     { name = "netket", marker = "extra == 'netket'", specifier = ">=3.12" },
     { name = "optax", marker = "extra == 'models'" },
     { name = "optax", marker = "extra == 'netket'" },
@@ -3796,6 +3893,7 @@ requires-dist = [
     { name = "qutip-jax", marker = "extra == 'qutip'", specifier = ">=0.1.1" },
     { name = "qutip-qip", marker = "extra == 'qutip'", specifier = ">=0.4.1" },
     { name = "ray", extras = ["default"], marker = "extra == 'ray'" },
+    { name = "sax", marker = "extra == 'gdsfactoryplus'", specifier = ">=0.18.2,<1" },
     { name = "sax", marker = "extra == 'models'", specifier = ">=0.18.2,<1" },
     { name = "scikit-rf", marker = "extra == 'models'" },
     { name = "scqubits", marker = "extra == 'scqubits'" },


### PR DESCRIPTION
Verifies qpdk against the gdsfactoryplus v2 SDK (the one bundled in the public GDSFactory+ VS Code extension) with a pytest suite marked `gfp`:

- `tests/test_gfp_server.py`: settings over RPC, cell/`pic.yml` indexing, nyanlib generation
- `tests/test_gfp_sax.py`: layout- and Mosaic-driven SAX of the resonator test chip, model coverage against the `cells_no_model_expected` exemptions, contract test that every `PDK.models` entry takes `f` in Hz
- `tests/test_gfp_lvs.py`: LVS with a negative control, connectivity, remote DRC smoke test (needs `GFP_API_KEY`)

gdsfactoryplus 2.0 is not on PyPI, so `just fetch-gfp` extracts the SDK and `gfp` binary from the Marketplace VSIX into `build/gfp-vsix/` (cp312-only, hence the Python 3.12 matrix pin). The `gdsfactoryplus` extra carries only the SDK's dependencies; the SDK itself rides on `PYTHONPATH`.

Tests skip cleanly when the SDK/binary are absent, but `GFP_REQUIRED=1` (set by `just test-gfp` and CI) turns those skips into failures, and an installed-but-broken v2 API always fails rather than skipping.

Also migrates the `pyproject.toml` settings for v2 (`sim.x` in GHz, `livewire.has_vias = false`) and gates the CI gfp jobs on the latest public extension being v2+, with a weekly `test-gfp-upstream.yml` run to pick up new releases.