### PR TITLE
Update circulax to 0.2.3 and fix the notebook against the new API

### DIFF
--- a/notebooks/circulax_transmon_optimization.ipynb
+++ b/notebooks/circulax_transmon_optimization.ipynb
@@ -152,9 +152,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from circulax.components.base_component import Signals, States, component, source\n",
-    "from circulax.components.electronic import Capacitor, Resistor\n",
-    "from circulax.solvers import setup_harmonic_balance, setup_transient"
+    "from circulax.circuit import compile_circuit\n",
+    "from circulax.components.base_component import Signals, States, component\n",
+    "from circulax.components.electronic import Capacitor, Resistor, VoltageSourceAC"
    ]
   },
   {
@@ -364,8 +364,8 @@
     "        \"instances\": {\n",
     "            \"GND\": {\"component\": \"ground\"},\n",
     "            \"Vdrive\": {\n",
-    "                \"component\": \"source_voltage\",\n",
-    "                \"settings\": {\"V\": V_drive, \"delay\": 0.0},\n",
+    "                \"component\": \"source_voltage_ac\",\n",
+    "                \"settings\": {\"V\": V_drive, \"freq\": f_drive, \"delay\": 0.0},\n",
     "            },\n",
     "            \"Rdrive\": {\n",
     "                \"component\": \"resistor\",\n",
@@ -392,18 +392,9 @@
     "    \"resistor\": Resistor,\n",
     "    \"capacitor\": Capacitor,\n",
     "    \"josephson_junction\": JosephsonJunction,\n",
-    "    \"source_voltage\": source(\n",
-    "        ports=(\"p1\", \"p2\"), states=(\"i_src\",), amplitude_param=\"V\"\n",
-    "    )(\n",
-    "        lambda signals, s, t, V=0.0, delay=0.0: (\n",
-    "            {\n",
-    "                \"p1\": s.i_src,\n",
-    "                \"p2\": -s.i_src,\n",
-    "                \"i_src\": (signals.p1 - signals.p2) - jnp.where(t >= delay, V, 0.0),\n",
-    "            },\n",
-    "            {},\n",
-    "        )\n",
-    "    ),\n",
+    "    # Sinusoidal drive: harmonic balance needs a periodic excitation, so a\n",
+    "    # step source would leave the circuit unexcited (zero AC response).\n",
+    "    \"source_voltage_ac\": VoltageSourceAC,\n",
     "    \"ground\": lambda: 0,\n",
     "}"
    ]
@@ -421,22 +412,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "`compile_circuit` turns the netlist into a callable :class:`~circulax.circuit.Circuit`.\n",
+    "Compiling **once**, outside any `jax.jit`/`jax.grad` boundary, is what makes the\n",
+    "rest of this notebook differentiable: the circuit topology (and the integer index\n",
+    "arrays derived from it) stays static, while component values are swapped in\n",
+    "functionally through the `params=` argument of each analysis."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from circulax.compiler import compile_netlist\n",
-    "from circulax.solvers import analyze_circuit\n",
+    "# Compile the netlist into a reusable, differentiable circuit\n",
+    "net_dict = build_transmon_netlist(Cs_init, Ic_init, EJ2_ratio=params[\"EJ2_ratio\"])\n",
+    "circuit = compile_circuit(net_dict, models)\n",
+    "num_vars, port_map = circuit.sys_size, circuit.port_map\n",
     "\n",
-    "# Compile the netlist\n",
-    "net_dict = build_transmon_netlist(Cs_init, Ic_init)\n",
-    "groups, num_vars, port_map = compile_netlist(net_dict, models)\n",
-    "\n",
-    "# Analyze and find DC operating point\n",
-    "solver = analyze_circuit(groups, num_vars)\n",
-    "y_dc = solver.solve_dc(groups, jnp.zeros(num_vars))\n",
+    "# DC operating point\n",
+    "y_dc = circuit.dc()\n",
     "\n",
     "print(f\"System size: {num_vars} state variables\")\n",
     "print(f\"DC operating point norm: {jnp.linalg.norm(y_dc):.2e}\")"
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "### 1.6 Harmonic-Balance Analysis\n",
@@ -464,20 +464,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": [
-    "# Set up harmonic balance at the drive frequency\n",
+    "# Solve for the periodic steady state at the drive frequency\n",
     "num_harmonics = 7  # capture up to 7th harmonic for nonlinear response\n",
-    "run_hb = setup_harmonic_balance(\n",
-    "    groups, num_vars, freq=f_drive, num_harmonics=num_harmonics\n",
-    ")\n",
-    "\n",
-    "# Solve for periodic steady state\n",
-    "y_time, y_freq = run_hb(y_dc)\n",
+    "y_time, y_freq = circuit.hb(freq=f_drive, harmonics=num_harmonics, y0=y_dc)\n",
     "\n",
     "print(f\"HB solution shape: {y_time.shape} (K time samples × {num_vars} vars)\")\n",
     "print(f\"Frequency components shape: {y_freq.shape}\")\n",
@@ -492,7 +487,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -517,7 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,36 +557,38 @@
     "    Ic = jnp.exp(params_vec[0])\n",
     "    Cs = jnp.exp(params_vec[1])\n",
     "\n",
-    "    # Rebuild netlist with current parameters\n",
-    "    net = build_transmon_netlist(Cs, Ic, EJ2_ratio=params[\"EJ2_ratio\"])\n",
-    "    grps, n_vars, pmap = compile_netlist(net, models)\n",
-    "\n",
-    "    # We need a custom DC solver step here inside the JIT-able loss fn\n",
-    "    # For a simple LC circuit with no DC drive, the DC operating point is exactly zero\n",
-    "    y_dc_current = jnp.zeros(n_vars)\n",
-    "\n",
-    "    # Set up harmonic balance at the target frequency\n",
-    "    # We drive at f_target, so the response at the 1st harmonic should be maximized\n",
-    "    # if the circuit is perfectly resonant at f_target.\n",
-    "    # To formulate this as a minimization, we penalize the inverse of the response.\n",
-    "    run_hb_current = setup_harmonic_balance(\n",
-    "        grps, n_vars, freq=f_target, num_harmonics=3\n",
+    "    # Reuse the circuit compiled above and swap in the current parameter values.\n",
+    "    # Recompiling the netlist inside the traced function would turn the\n",
+    "    # topology index arrays into tracers and break the solver setup.\n",
+    "    #\n",
+    "    # We drive at f_target, so the response at the 1st harmonic should be\n",
+    "    # maximized if the circuit is perfectly resonant at f_target. To formulate\n",
+    "    # this as a minimization, we penalize the inverse of the response.\n",
+    "    # For this LC-like circuit with no DC drive, the DC operating point is zero.\n",
+    "    _, y_freq_current = circuit.hb(\n",
+    "        freq=f_target,\n",
+    "        harmonics=3,\n",
+    "        y0=jnp.zeros(circuit.sys_size),\n",
+    "        params={\"JJ1.Ic\": Ic, \"Cs1.C\": Cs},\n",
     "    )\n",
     "\n",
-    "    _, y_freq_current = run_hb_current(y_dc_current)\n",
-    "\n",
     "    # Extract the 1st harmonic voltage magnitude at the junction node\n",
-    "    jj_node_idx = pmap.get(\"JJ1,p1\", 0)\n",
+    "    jj_node_idx = port_map.get(\"JJ1,p1\", 0)\n",
     "    V_1st_harmonic = jnp.abs(y_freq_current[1, jj_node_idx])\n",
     "\n",
-    "    # Loss is inversely proportional to the resonance amplitude at the target frequency\n",
-    "    # We add a small epsilon to avoid division by zero, and a penalty for anharmonicity\n",
+    "    # Targets: transition frequency and anharmonicity, plus a weak term that\n",
+    "    # keeps the harmonic-balance response in the objective (and therefore keeps\n",
+    "    # the gradient flowing through the simulator).\n",
+    "    f01 = transmon_frequency(Ic, Cs)\n",
+    "    f_error = ((f01 - f_target) / f_target) ** 2\n",
+    "\n",
     "    alpha = transmon_anharmonicity(Ic, Cs)\n",
     "    alpha_error = ((alpha - alpha_target) / alpha_target) ** 2\n",
     "\n",
+    "    # Inversely proportional to the drive response; epsilon avoids /0\n",
     "    resonance_loss = 1.0 / (V_1st_harmonic * 1e6 + 1e-12)  # scale V to typical uV range\n",
     "\n",
-    "    return resonance_loss + 0.1 * alpha_error\n",
+    "    return f_error + 0.1 * alpha_error + 0.01 * resonance_loss\n",
     "\n",
     "\n",
     "# Initial parameters in log-space\n",
@@ -604,7 +601,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### 1.8 Running the Optimization Loop\n",
@@ -617,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +662,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "### 1.9 Optimization Convergence"
@@ -674,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,7 +697,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### 1.10 Updated Layout Visualization\n",
@@ -711,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Part 2 — Transient Pulse Analysis and Crosstalk Minimization\n",
@@ -762,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,7 +788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "### 2.2 Two-Qubit Coupled Circuit\n",
@@ -804,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,10 +855,11 @@
     "    \"ground\": lambda: 0,\n",
     "}\n",
     "\n",
-    "# Compile the coupled circuit\n",
-    "groups_c, num_vars_c, port_map_c = compile_netlist(coupled_netlist, models_coupled)\n",
-    "solver_c = analyze_circuit(groups_c, num_vars_c)\n",
-    "y_dc_c = solver_c.solve_dc(groups_c, jnp.zeros(num_vars_c))\n",
+    "# Compile the coupled circuit once — as in Part 1, the compiled circuit is\n",
+    "# reused for both the nominal run and the differentiable crosstalk metric.\n",
+    "circuit_c = compile_circuit(coupled_netlist, models_coupled, backend=\"dense\")\n",
+    "num_vars_c, port_map_c = circuit_c.sys_size, circuit_c.port_map\n",
+    "y_dc_c = circuit_c.dc()\n",
     "\n",
     "print(f\"Coupled system size: {num_vars_c} variables\")\n",
     "print(f\"Port map keys: {list(port_map_c.keys())}\")"
@@ -869,7 +867,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "### 2.3 Transient Simulation\n",
@@ -883,14 +881,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
     "import diffrax\n",
-    "\n",
-    "# Set up transient simulation\n",
-    "sim = setup_transient(groups=groups_c, linear_strategy=solver_c)\n",
     "\n",
     "# Time parameters\n",
     "t_end = 2.0e-9  # 2 ns simulation\n",
@@ -899,7 +894,7 @@
     "\n",
     "# Run transient simulation\n",
     "t_save = jnp.linspace(0, t_end, n_save)\n",
-    "sol = sim(\n",
+    "sol = circuit_c.transient(\n",
     "    t0=0.0,\n",
     "    t1=t_end,\n",
     "    dt0=dt0,\n",
@@ -930,7 +925,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "### 2.4 Time-Domain Waveforms"
@@ -939,7 +934,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -966,7 +961,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### 2.5 Crosstalk Optimization via Gradient Descent\n",
@@ -984,7 +979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,46 +998,19 @@
     "    \"\"\"\n",
     "    Cm_val = jnp.exp(log_Cm)\n",
     "\n",
-    "    # Rebuild netlist with updated Cm\n",
-    "    net = {\n",
-    "        \"instances\": {\n",
-    "            \"GND\": {\"component\": \"ground\"},\n",
-    "            \"Vpulse\": {\n",
-    "                \"component\": \"smooth_pulse\",\n",
-    "                \"settings\": {\"V\": V_pulse, \"delay\": pulse_delay, \"tr\": pulse_rise},\n",
-    "            },\n",
-    "            \"Rdrive\": {\"component\": \"resistor\", \"settings\": {\"R\": 50.0}},\n",
-    "            \"JJ1\": {\"component\": \"josephson_junction\", \"settings\": {\"Ic\": Ic_q1}},\n",
-    "            \"Cs1\": {\"component\": \"capacitor\", \"settings\": {\"C\": Cs_q1}},\n",
-    "            \"JJ2\": {\"component\": \"josephson_junction\", \"settings\": {\"Ic\": Ic_q2}},\n",
-    "            \"Cs2\": {\"component\": \"capacitor\", \"settings\": {\"C\": Cs_q2}},\n",
-    "            \"Cm\": {\"component\": \"coupling_cap\", \"settings\": {\"Cm\": Cm_val}},\n",
-    "        },\n",
-    "        \"connections\": {\n",
-    "            \"GND,p1\": (\"Vpulse,p2\", \"JJ1,p2\", \"Cs1,p2\", \"JJ2,p2\", \"Cs2,p2\"),\n",
-    "            \"Vpulse,p1\": \"Rdrive,p1\",\n",
-    "            \"Rdrive,p2\": (\"JJ1,p1\", \"Cs1,p1\", \"Cm,p1\"),\n",
-    "            \"Cm,p2\": (\"JJ2,p1\", \"Cs2,p1\"),\n",
-    "        },\n",
-    "    }\n",
-    "\n",
-    "    grps, n_vars, pmap = compile_netlist(net, models_coupled)\n",
-    "    slvr = analyze_circuit(grps, n_vars, backend=\"dense\")\n",
-    "    y0 = slvr.solve_dc(grps, jnp.zeros(n_vars))\n",
-    "\n",
-    "    sim_fn = setup_transient(groups=grps, linear_strategy=slvr)\n",
-    "    sol_val = sim_fn(\n",
+    "    # Reuse the compiled circuit and update only the coupling capacitance.\n",
+    "    # The gradient flows through the ODE solve into `Cm`.\n",
+    "    sol_val = circuit_c.transient(\n",
     "        t0=0.0,\n",
     "        t1=t_end,\n",
     "        dt0=dt0,\n",
-    "        y0=y0,\n",
     "        saveat=diffrax.SaveAt(ts=t_save),\n",
     "        max_steps=200_000,\n",
+    "        params={\"Cm.Cm\": Cm_val},\n",
     "    )\n",
     "\n",
     "    # Get Q2 voltage\n",
-    "    q2_i = pmap.get(\"JJ2,p1\", pmap.get(\"Cs2,p1\", 1))\n",
-    "    v_victim = sol_val.ys[:, q2_i]\n",
+    "    v_victim = sol_val.ys[:, q2_idx]\n",
     "    return jnp.max(jnp.abs(v_victim))\n",
     "\n",
     "\n",
@@ -1058,7 +1026,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## Summary\n",

--- a/notebooks/src/circulax_transmon_optimization.py
+++ b/notebooks/src/circulax_transmon_optimization.py
@@ -113,9 +113,9 @@ PDK.activate()
 # (charge equations).
 
 # %%
-from circulax.components.base_component import Signals, States, component, source
-from circulax.components.electronic import Capacitor, Resistor
-from circulax.solvers import setup_harmonic_balance, setup_transient
+from circulax.circuit import compile_circuit
+from circulax.components.base_component import Signals, States, component
+from circulax.components.electronic import Capacitor, Resistor, VoltageSourceAC
 
 # %% [markdown]
 # ### 1.2 Defining the Josephson Junction Component
@@ -290,8 +290,8 @@ def build_transmon_netlist(Cs: float, Ic: float, EJ2_ratio: float = 0.0) -> dict
         "instances": {
             "GND": {"component": "ground"},
             "Vdrive": {
-                "component": "source_voltage",
-                "settings": {"V": V_drive, "delay": 0.0},
+                "component": "source_voltage_ac",
+                "settings": {"V": V_drive, "freq": f_drive, "delay": 0.0},
             },
             "Rdrive": {
                 "component": "resistor",
@@ -318,18 +318,9 @@ models = {
     "resistor": Resistor,
     "capacitor": Capacitor,
     "josephson_junction": JosephsonJunction,
-    "source_voltage": source(
-        ports=("p1", "p2"), states=("i_src",), amplitude_param="V"
-    )(
-        lambda signals, s, t, V=0.0, delay=0.0: (
-            {
-                "p1": s.i_src,
-                "p2": -s.i_src,
-                "i_src": (signals.p1 - signals.p2) - jnp.where(t >= delay, V, 0.0),
-            },
-            {},
-        )
-    ),
+    # Sinusoidal drive: harmonic balance needs a periodic excitation, so a
+    # step source would leave the circuit unexcited (zero AC response).
+    "source_voltage_ac": VoltageSourceAC,
     "ground": lambda: 0,
 }
 
@@ -340,17 +331,21 @@ models = {
 # circuit (all time derivatives zero). This serves as the initial guess for
 # the HB solver.
 
+# %% [markdown]
+# `compile_circuit` turns the netlist into a callable :class:`~circulax.circuit.Circuit`.
+# Compiling **once**, outside any `jax.jit`/`jax.grad` boundary, is what makes the
+# rest of this notebook differentiable: the circuit topology (and the integer index
+# arrays derived from it) stays static, while component values are swapped in
+# functionally through the `params=` argument of each analysis.
+
 # %%
-from circulax.compiler import compile_netlist
-from circulax.solvers import analyze_circuit
+# Compile the netlist into a reusable, differentiable circuit
+net_dict = build_transmon_netlist(Cs_init, Ic_init, EJ2_ratio=params["EJ2_ratio"])
+circuit = compile_circuit(net_dict, models)
+num_vars, port_map = circuit.sys_size, circuit.port_map
 
-# Compile the netlist
-net_dict = build_transmon_netlist(Cs_init, Ic_init)
-groups, num_vars, port_map = compile_netlist(net_dict, models)
-
-# Analyze and find DC operating point
-solver = analyze_circuit(groups, num_vars)
-y_dc = solver.solve_dc(groups, jnp.zeros(num_vars))
+# DC operating point
+y_dc = circuit.dc()
 
 print(f"System size: {num_vars} state variables")
 print(f"DC operating point norm: {jnp.linalg.norm(y_dc):.2e}")
@@ -370,14 +365,9 @@ print(f"DC operating point norm: {jnp.linalg.norm(y_dc):.2e}")
 # ```
 
 # %%
-# Set up harmonic balance at the drive frequency
+# Solve for the periodic steady state at the drive frequency
 num_harmonics = 7  # capture up to 7th harmonic for nonlinear response
-run_hb = setup_harmonic_balance(
-    groups, num_vars, freq=f_drive, num_harmonics=num_harmonics
-)
-
-# Solve for periodic steady state
-y_time, y_freq = run_hb(y_dc)
+y_time, y_freq = circuit.hb(freq=f_drive, harmonics=num_harmonics, y0=y_dc)
 
 print(f"HB solution shape: {y_time.shape} (K time samples × {num_vars} vars)")
 print(f"Frequency components shape: {y_freq.shape}")
@@ -450,36 +440,38 @@ def hb_loss_fn(params_vec: jnp.ndarray) -> float:
     Ic = jnp.exp(params_vec[0])
     Cs = jnp.exp(params_vec[1])
 
-    # Rebuild netlist with current parameters
-    net = build_transmon_netlist(Cs, Ic, EJ2_ratio=params["EJ2_ratio"])
-    grps, n_vars, pmap = compile_netlist(net, models)
-
-    # We need a custom DC solver step here inside the JIT-able loss fn
-    # For a simple LC circuit with no DC drive, the DC operating point is exactly zero
-    y_dc_current = jnp.zeros(n_vars)
-
-    # Set up harmonic balance at the target frequency
-    # We drive at f_target, so the response at the 1st harmonic should be maximized
-    # if the circuit is perfectly resonant at f_target.
-    # To formulate this as a minimization, we penalize the inverse of the response.
-    run_hb_current = setup_harmonic_balance(
-        grps, n_vars, freq=f_target, num_harmonics=3
+    # Reuse the circuit compiled above and swap in the current parameter values.
+    # Recompiling the netlist inside the traced function would turn the
+    # topology index arrays into tracers and break the solver setup.
+    #
+    # We drive at f_target, so the response at the 1st harmonic should be
+    # maximized if the circuit is perfectly resonant at f_target. To formulate
+    # this as a minimization, we penalize the inverse of the response.
+    # For this LC-like circuit with no DC drive, the DC operating point is zero.
+    _, y_freq_current = circuit.hb(
+        freq=f_target,
+        harmonics=3,
+        y0=jnp.zeros(circuit.sys_size),
+        params={"JJ1.Ic": Ic, "Cs1.C": Cs},
     )
 
-    _, y_freq_current = run_hb_current(y_dc_current)
-
     # Extract the 1st harmonic voltage magnitude at the junction node
-    jj_node_idx = pmap.get("JJ1,p1", 0)
+    jj_node_idx = port_map.get("JJ1,p1", 0)
     V_1st_harmonic = jnp.abs(y_freq_current[1, jj_node_idx])
 
-    # Loss is inversely proportional to the resonance amplitude at the target frequency
-    # We add a small epsilon to avoid division by zero, and a penalty for anharmonicity
+    # Targets: transition frequency and anharmonicity, plus a weak term that
+    # keeps the harmonic-balance response in the objective (and therefore keeps
+    # the gradient flowing through the simulator).
+    f01 = transmon_frequency(Ic, Cs)
+    f_error = ((f01 - f_target) / f_target) ** 2
+
     alpha = transmon_anharmonicity(Ic, Cs)
     alpha_error = ((alpha - alpha_target) / alpha_target) ** 2
 
+    # Inversely proportional to the drive response; epsilon avoids /0
     resonance_loss = 1.0 / (V_1st_harmonic * 1e6 + 1e-12)  # scale V to typical uV range
 
-    return resonance_loss + 0.1 * alpha_error
+    return f_error + 0.1 * alpha_error + 0.01 * resonance_loss
 
 
 # Initial parameters in log-space
@@ -687,10 +679,11 @@ models_coupled = {
     "ground": lambda: 0,
 }
 
-# Compile the coupled circuit
-groups_c, num_vars_c, port_map_c = compile_netlist(coupled_netlist, models_coupled)
-solver_c = analyze_circuit(groups_c, num_vars_c)
-y_dc_c = solver_c.solve_dc(groups_c, jnp.zeros(num_vars_c))
+# Compile the coupled circuit once — as in Part 1, the compiled circuit is
+# reused for both the nominal run and the differentiable crosstalk metric.
+circuit_c = compile_circuit(coupled_netlist, models_coupled, backend="dense")
+num_vars_c, port_map_c = circuit_c.sys_size, circuit_c.port_map
+y_dc_c = circuit_c.dc()
 
 print(f"Coupled system size: {num_vars_c} variables")
 print(f"Port map keys: {list(port_map_c.keys())}")
@@ -706,9 +699,6 @@ print(f"Port map keys: {list(port_map_c.keys())}")
 # %%
 import diffrax
 
-# Set up transient simulation
-sim = setup_transient(groups=groups_c, linear_strategy=solver_c)
-
 # Time parameters
 t_end = 2.0e-9  # 2 ns simulation
 dt0 = 1e-12  # 1 ps initial timestep
@@ -716,7 +706,7 @@ n_save = 500  # number of saved points
 
 # Run transient simulation
 t_save = jnp.linspace(0, t_end, n_save)
-sol = sim(
+sol = circuit_c.transient(
     t0=0.0,
     t1=t_end,
     dt0=dt0,
@@ -796,46 +786,19 @@ def crosstalk_metric(log_Cm: float) -> float:
     """
     Cm_val = jnp.exp(log_Cm)
 
-    # Rebuild netlist with updated Cm
-    net = {
-        "instances": {
-            "GND": {"component": "ground"},
-            "Vpulse": {
-                "component": "smooth_pulse",
-                "settings": {"V": V_pulse, "delay": pulse_delay, "tr": pulse_rise},
-            },
-            "Rdrive": {"component": "resistor", "settings": {"R": 50.0}},
-            "JJ1": {"component": "josephson_junction", "settings": {"Ic": Ic_q1}},
-            "Cs1": {"component": "capacitor", "settings": {"C": Cs_q1}},
-            "JJ2": {"component": "josephson_junction", "settings": {"Ic": Ic_q2}},
-            "Cs2": {"component": "capacitor", "settings": {"C": Cs_q2}},
-            "Cm": {"component": "coupling_cap", "settings": {"Cm": Cm_val}},
-        },
-        "connections": {
-            "GND,p1": ("Vpulse,p2", "JJ1,p2", "Cs1,p2", "JJ2,p2", "Cs2,p2"),
-            "Vpulse,p1": "Rdrive,p1",
-            "Rdrive,p2": ("JJ1,p1", "Cs1,p1", "Cm,p1"),
-            "Cm,p2": ("JJ2,p1", "Cs2,p1"),
-        },
-    }
-
-    grps, n_vars, pmap = compile_netlist(net, models_coupled)
-    slvr = analyze_circuit(grps, n_vars, backend="dense")
-    y0 = slvr.solve_dc(grps, jnp.zeros(n_vars))
-
-    sim_fn = setup_transient(groups=grps, linear_strategy=slvr)
-    sol_val = sim_fn(
+    # Reuse the compiled circuit and update only the coupling capacitance.
+    # The gradient flows through the ODE solve into `Cm`.
+    sol_val = circuit_c.transient(
         t0=0.0,
         t1=t_end,
         dt0=dt0,
-        y0=y0,
         saveat=diffrax.SaveAt(ts=t_save),
         max_steps=200_000,
+        params={"Cm.Cm": Cm_val},
     )
 
     # Get Q2 voltage
-    q2_i = pmap.get("JJ2,p1", pmap.get("Cs2,p1", 1))
-    v_victim = sol_val.ys[:, q2_i]
+    v_victim = sol_val.ys[:, q2_idx]
     return jnp.max(jnp.abs(v_victim))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ documentation = "https://gdsfactory.github.io/quantum-rf-pdk/"
 repository = "https://github.com/gdsfactory/quantum-rf-pdk/"
 
 [project.optional-dependencies]
-circulax = ["circulax>=0.1.7", "optax"]
+circulax = ["circulax>=0.2.3", "optax"]
 gdsfactoryplus = ["gdsfactoryplus", "httpx"]
 graphics = ["trimesh", "pyglet<3"]
 hfss = ["polars", "pyaedt[graphics]>=0.15.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,12 +3,12 @@ revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
-    "python_full_version < '3.13' and sys_platform == 'darwin'",
     "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
@@ -427,12 +427,14 @@ wheels = [
 
 [[package]]
 name = "circulax"
-version = "0.1.7"
+version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diffrax" },
+    { name = "equinox" },
     { name = "jax" },
     { name = "jaxlib" },
+    { name = "kfnetlist" },
     { name = "klujax" },
     { name = "lineax" },
     { name = "matplotlib" },
@@ -440,9 +442,9 @@ dependencies = [
     { name = "sax" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/41/7961958b26b2552c1d3cbca3c712c42f68926703ea4d9aace56bba425b9b/circulax-0.1.7.tar.gz", hash = "sha256:2567825ff4750d3e5555a1f02dea61c294b9eb13e9d4e55db0445f4d0d7d591c", size = 504916, upload-time = "2026-04-30T15:16:11.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d7/d4838228e30a54ab4dbc78682364a7fbeb8e9031db3180ef7cc10e269943/circulax-0.2.3.tar.gz", hash = "sha256:3ea8f6f5a0b175a034de3bdae64dc77ea121b9a758524d5c50ccfaaed22aecaa", size = 3492258, upload-time = "2026-07-31T08:16:00.09Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/bc/7dc9c9932287f6fad2948bdfff5da00a5b0651606f2c6a8dc89401f1fa11/circulax-0.1.7-py3-none-any.whl", hash = "sha256:908fa6b4ee8448c766cd6cacda5e647be4228cd8f45c27bb1ed4edf6b007118c", size = 77552, upload-time = "2026-04-30T15:16:09.849Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bf/0ad8b46152e90699af38df5c063fc999269c56c4290d626579f91a41a563/circulax-0.2.3-py3-none-any.whl", hash = "sha256:d5a99d207ce6053acb5adfc17fd35ed057ff13d6a1264de0523d9c995c4c9c15", size = 190958, upload-time = "2026-07-31T08:15:57.505Z" },
 ]
 
 [[package]]
@@ -797,7 +799,7 @@ name = "dotnetcore2"
 version = "3.1.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "distro", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "distro" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/04/ddd3fc5c374870e5e3d386b18512e8c0c7557aca9fbc1d9f286bf9f4844d/dotnetcore2-3.1.23-py3-none-manylinux1_x86_64.whl", hash = "sha256:5f076ddc39da0c685e7de20ecb91ee81185928918ec86fbeb3bffc55dd867ab5", size = 31118828, upload-time = "2022-04-28T18:06:16.738Z" },
@@ -1744,6 +1746,19 @@ ipy = [
 ]
 
 [[package]]
+name = "kfnetlist"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/80/6c1ec7ba4160c61ffaf710943fc25cc1b096ebe50233edf20f8258fd5a8d/kfnetlist-0.2.2.tar.gz", hash = "sha256:9ae38fc262867daa9d06cbda3efff3f1c00504227480d4ab92c379bf0d13b84e", size = 184421, upload-time = "2026-07-13T07:37:03.628Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c1/591bf4433eb6ed36a375c1c8322ec73cc759ab31839c83efac435876c55e/kfnetlist-0.2.2-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:df4d4d138f796b4e6957194d2598654c90cee11d931e8ad2aa220a108555ae73", size = 605038, upload-time = "2026-07-13T07:36:56.468Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0d/b89f0ebaa30d46b14e2fdfbecb7a51afadc51913822209794f938140abaf/kfnetlist-0.2.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:fbaafd1cac298fa5b05ade6d5d764d363f9d1d5314428e876eeda1afac3c5a3c", size = 572532, upload-time = "2026-07-13T07:36:58.142Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f6/da7b9274d1ce01597fc38cdaf01d152e283f99e9420877a10ca8a28c5708/kfnetlist-0.2.2-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d9f0558537d8f53dcef81395f43b32aec525a812ee29b8b5b552739d0a8e2c4", size = 588358, upload-time = "2026-07-13T07:36:59.555Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ec/668945d0c21c9eb5fa64efcf52cd98fafdda72e3edbbe3458e7cb8a96001/kfnetlist-0.2.2-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c72a1e26a72a4e3d0b57cc63f6a7c60b47b7397122147a0a5c044d8a0a15aea", size = 608655, upload-time = "2026-07-13T07:37:00.987Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/46/ef0e5a0c31dd1861ee5b8fed042ed705ae08f27aceb55cb3fd87cdf40e88/kfnetlist-0.2.2-cp312-abi3-win_amd64.whl", hash = "sha256:6788a491686aac13c59c2de3ba2721b6495fc68b13b98ddc0fa81ca1d30f8a2b", size = 496245, upload-time = "2026-07-13T07:37:02.262Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2265,7 +2280,7 @@ name = "multiprocess"
 version = "0.70.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill", marker = "sys_platform != 'darwin'" },
+    { name = "dill" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
 wheels = [
@@ -2758,10 +2773,10 @@ name = "pathos"
 version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill", marker = "sys_platform != 'darwin'" },
-    { name = "multiprocess", marker = "sys_platform != 'darwin'" },
-    { name = "pox", marker = "sys_platform != 'darwin'" },
-    { name = "ppft", marker = "sys_platform != 'darwin'" },
+    { name = "dill" },
+    { name = "multiprocess" },
+    { name = "pox" },
+    { name = "ppft" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/37/0c730979d3890f8096a86af2683fac74edd4d15cb037391098dca70dcb1d/pathos-0.3.5.tar.gz", hash = "sha256:8fe041b8545c5d3880a038f866022bdebf935e5cf68f56ed3407cb7e65193a61", size = 166975, upload-time = "2026-01-20T00:06:57.848Z" }
 wheels = [
@@ -2773,7 +2788,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3794,7 +3809,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "circulax", marker = "extra == 'circulax'", specifier = ">=0.1.7" },
+    { name = "circulax", marker = "extra == 'circulax'", specifier = ">=0.2.3" },
     { name = "doroutes", specifier = ">=0.2.0" },
     { name = "flax", marker = "extra == 'netket'" },
     { name = "gdsfactory", specifier = ">=9.39.0,<9.41.0" },
@@ -4371,16 +4386,16 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "cycler", marker = "sys_platform == 'darwin'" },
-    { name = "cython", marker = "sys_platform == 'darwin'" },
-    { name = "dill", marker = "sys_platform == 'darwin'" },
-    { name = "matplotlib", marker = "sys_platform == 'darwin'" },
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "qutip", marker = "sys_platform == 'darwin'" },
-    { name = "scipy", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "cycler" },
+    { name = "cython" },
+    { name = "dill" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "qutip" },
+    { name = "scipy" },
+    { name = "sympy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/ed/69b37d03b9794518b38528efb14884f53a1ec155b61b4b126b8c58c682bd/scqubits-4.1.0.tar.gz", hash = "sha256:806f171d4b5905af3f8d4c68fce461be91eab38466fa4fbe87b71ec7b167fc7b", size = 6457745, upload-time = "2024-05-17T01:22:20.31Z" }
 wheels = [
@@ -4393,23 +4408,23 @@ version = "4.3.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cycler", marker = "sys_platform != 'darwin'" },
-    { name = "dill", marker = "sys_platform != 'darwin'" },
-    { name = "matplotlib", marker = "sys_platform != 'darwin'" },
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pathos", marker = "sys_platform != 'darwin'" },
-    { name = "qutip", marker = "sys_platform != 'darwin'" },
-    { name = "scipy", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "tqdm", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "cycler" },
+    { name = "dill" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pathos" },
+    { name = "qutip" },
+    { name = "scipy" },
+    { name = "sympy" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/57/a552661e93e9d3ea6530112f06572f0f88d55972c7a0a98d79275b67bf3c/scqubits-4.3.1.tar.gz", hash = "sha256:a40440e7270fa559d201220524f8b95eaae24235a1d4918ad08dc7358a0c39e4", size = 6498157, upload-time = "2025-05-17T16:53:35.721Z" }
 wheels = [


### PR DESCRIPTION
Targets the `copilot/create-josephson-junction-notebook` branch, so this is a PR-on-top-of-a-PR.

Bumps `circulax` from `>=0.1.7` to `>=0.2.3` (latest release) and fixes the three problems that surfaced when actually running the example against it.

## 1. `TracerArrayConversionError` (hard failure)

Both differentiable sections called `compile_netlist` *inside* the `jax.jit`/`jax.grad` boundary. In 0.2.x the compiler's topology index arrays become tracers and `setup_harmonic_balance` → `_build_index_arrays` calls `np.array()` on them:

```
jax.errors.TracerArrayConversionError: The numpy.ndarray conversion method __array__()
was called on traced array with shape int32[1,2,2]
```

Fix: compile once outside the traced function with `compile_circuit`, then swap parameter values in functionally — `circuit.hb(params={"JJ1.Ic": Ic, "Cs1.C": Cs})` and `circuit_c.transient(params={"Cm.Cm": Cm})`. This also replaces the manual `compile_netlist` + `analyze_circuit` + `setup_harmonic_balance`/`setup_transient` plumbing with the higher-level `Circuit` API.

## 2. Harmonic balance was running with a DC step drive

The driven-transmon netlist used a hand-rolled step source, so the circuit saw no periodic excitation and every harmonic came out at numerical noise:

```
Harmonic 0: |V_0| = 4.3751e-20 V
Harmonic 1: |V_1| = 8.7230e-31 V
```

Fix: use circulax's `VoltageSourceAC` at `f_drive`. First harmonic is now `4.99e-07 V`, i.e. the 1 μV drive amplitude as expected. This also drops the custom lambda source in favour of the built-in component.

## 3. The loss did not optimize what the text said it did

Section 1.7 says the loss "penalizes deviations from the target transition frequency", but the implemented loss was `1/|V_1|` + anharmonicity only. Once the drive was fixed that term is essentially flat (loss pinned at 2.00 for all 150 steps) and f01 settled at 5.29 GHz against a 5.0 GHz target.

Fix: add the frequency-error term. The harmonic-balance response stays in the objective with a small weight, so the gradient still flows through the simulator.

```
Step   0: loss = 8.51e-02, f01 = 6.2686 GHz
Step  50: loss = 2.32e-02, f01 = 5.1470 GHz
Step 100: loss = 2.03e-02, f01 = 5.0235 GHz
Step 149: loss = 2.00e-02, f01 = 5.0021 GHz

Optimized:  Ic = 23.662 nA,  Cs = 64.81 fF
Achieved:   f01 = 5.0021 GHz,  α = -298.9 MHz
Target:     f01 = 5.0000 GHz,  α = -300.0 MHz
```

## Verification

`notebooks/src/circulax_transmon_optimization.py` runs to completion (exit 0) against circulax 0.2.3 — HB analysis, 150-step Optax optimization, layout regeneration, coupled-qubit transient (crosstalk −42.8 dB) and the crosstalk gradient (`∂(crosstalk)/∂(log Cm) = 3.60e-06`).

`prek run --all-files` passes on everything this PR touches. The only failing hook is `lychee`, on pre-existing dead links elsewhere in the repo (`flaport.github.io/sax`, and a private repo URL that 404s unauthenticated) — untouched by this change.

Fixes #770

Requested by @nikosavola

---

⚠️ This PR was created by an AI agent. The code changes still need human review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the circulax transmon optimization notebook for circulax 0.2.3 and restore correct differentiable simulation and parameter optimization.

Bug Fixes:
- Fix the transmon optimization notebook for the circulax 0.2.3 API and prevent traced topology arrays from breaking differentiable harmonic-balance and transient simulations.
- Use a periodic AC drive so harmonic-balance analysis produces the expected driven response.
- Correct the optimization objective to target transition frequency alongside anharmonicity while retaining a weighted simulator-response term.

Enhancements:
- Modernize notebook circuit simulations around the reusable high-level Circuit API for DC, harmonic-balance, and transient analyses.

Build:
- Raise the circulax optional dependency minimum to version 0.2.3 and update the lockfile.

Documentation:
- Clarify the notebook's compilation and differentiability requirements.