### PR TITLE
docs: fix broken coverage badge on docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ It includes the README.md but skips SVG badges which cannot be rendered in LaTeX
 ```{only} html
 [![Docs](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/pages.yml/badge.svg)](https://gdsfactory.github.io/quantum-rf-pdk/)
 [![Tests](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml/badge.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
-[![Coverage](https://gdsfactory.github.io/quantum-rf-pdk/reports/coverage/coverage.svg)](https://gdsfactory.github.io/quantum-rf-pdk/reports/coverage/)
+[![Coverage](https://github.com/gdsfactory/quantum-rf-pdk/raw/badges/coverage.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
 [![HTML Docs](https://img.shields.io/badge/%F0%9F%93%84_HTML-Docs-blue?style=flat)](https://gdsfactory.github.io/quantum-rf-pdk/)
 [![PDF Docs](https://img.shields.io/badge/%F0%9F%93%84_PDF-Docs-blue?style=flat&logo=adobeacrobatreader)](https://gdsfactory.github.io/quantum-rf-pdk/qpdk.pdf)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gdsfactory/quantum-rf-pdk/HEAD)


### PR DESCRIPTION
Fixes #772

The **Coverage** badge on <https://gdsfactory.github.io/quantum-rf-pdk/> rendered as a broken image. `docs/index.md` pointed it at `.../reports/coverage/coverage.svg`, but that path is never published — nothing in the repo produces a `reports/` directory, and the `htmlcov/coverage.svg` that `test.yml` generates with `genbadge` is only kept as a CI artifact, never copied into the Pages artifact.

This switches the badge to the `badges` branch — the same source `README.md` already uses, kept current by `update_badges.yml` — and links it to the test workflow, matching the README entry.

```diff
-[![Coverage](https://gdsfactory.github.io/quantum-rf-pdk/reports/coverage/coverage.svg)](https://gdsfactory.github.io/quantum-rf-pdk/reports/coverage/)
+[![Coverage](https://github.com/gdsfactory/quantum-rf-pdk/raw/badges/coverage.svg)](https://github.com/gdsfactory/quantum-rf-pdk/actions/workflows/test.yml)
```

Verified the new URL resolves (302 → 200) and that it was the only broken image on the page; the other seven badges already returned 200.

Note: the `lychee` link-check hook could not run locally (the pinned binary needs a newer glibc than my container has) — CI is the first real run of that hook. Every other applicable pre-commit hook passes.

Requested by @joamatab

## Summary by Sourcery

Bug Fixes:
- Fix the broken coverage badge on the documentation homepage by using the maintained badge image and linking it to the test workflow.